### PR TITLE
Specify curated PHP extensions for FrankenPHP builds

### DIFF
--- a/.github/workflows/build-frankenphp.yml
+++ b/.github/workflows/build-frankenphp.yml
@@ -53,6 +53,15 @@ jobs:
         env:
           PHP_VERSION: ${{ matrix.php }}
           HOMEBREW_NO_AUTO_UPDATE: "1"
+          # Curated extension list for web dev. The default set includes pgsql/ldap/etc
+          # which can fail to cross-compile on macOS ARM64 runners.
+          PHP_EXTENSIONS: >-
+            bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,
+            gd,gmp,iconv,igbinary,intl,mbregex,mbstring,memcached,
+            mysqli,mysqlnd,opcache,openssl,password-argon2,pcntl,
+            pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,
+            readline,redis,session,simplexml,soap,sockets,sodium,
+            sqlite3,tokenizer,xml,xmlreader,xmlwriter,xsl,zip,zlib,zstd
         run: ./build-static.sh
 
       - name: List build output


### PR DESCRIPTION
## Summary
- Adds an explicit `PHP_EXTENSIONS` env var to the FrankenPHP build workflow
- The default set includes ~60 extensions (ldap, ssh2, imagick, tidy, parallel, etc.) which bloats binaries and caused the PHP 8.4 build to fail — PostgreSQL's `make install` errored linking against LDAP on macOS ARM64
- The curated list covers common web-dev needs (MySQL, PostgreSQL, Redis, Memcached, GD, Intl, etc.) while dropping rarely-needed extensions

## Context
Follow-up to #3. PHP 8.4 build failed: https://github.com/prvious/pv/actions/runs/22509524914

## Test plan
- [ ] Re-dispatch the workflow after merge and verify all 4 PHP versions build