### PR TITLE
Rewrite FrankenPHP build to match upstream + add Intel builds

### DIFF
--- a/.github/workflows/build-frankenphp.yml
+++ b/.github/workflows/build-frankenphp.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 0 * * 1"
 
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   resolve-version:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
             echo "ref=${INPUT_REF}" >> "$GITHUB_OUTPUT"
             echo "version=${INPUT_REF}" >> "$GITHUB_OUTPUT"
           else
-            TAG=$(gh api repos/dunglas/frankenphp/releases/latest --jq '.tag_name')
+            TAG=$(gh api repos/php/frankenphp/releases/latest --jq '.tag_name')
             echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
             echo "version=${TAG}" >> "$GITHUB_OUTPUT"
           fi
@@ -38,40 +41,56 @@ jobs:
       fail-fast: false
       matrix:
         php: ["8.2", "8.3", "8.4", "8.5"]
-    runs-on: macos-14
+        platform: ["arm64", "x86_64"]
+    name: PHP ${{ matrix.php }} / macOS ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform == 'arm64' && 'macos-15' || 'macos-15-intel' }}
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - uses: actions/checkout@v4
         with:
-          repository: dunglas/frankenphp
+          repository: php/frankenphp
           ref: ${{ needs.resolve-version.outputs.ref }}
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.26"
+          cache-dependency-path: |
+            go.sum
+            caddy/go.sum
 
       - name: Build FrankenPHP with PHP ${{ matrix.php }}
         env:
           PHP_VERSION: ${{ matrix.php }}
-          HOMEBREW_NO_AUTO_UPDATE: "1"
-          # Curated extension list for web dev. The default set includes pgsql/ldap/etc
-          # which can fail to cross-compile on macOS ARM64 runners.
-          PHP_EXTENSIONS: >-
-            bcmath,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,
-            gd,gmp,iconv,igbinary,intl,mbregex,mbstring,memcached,
-            mysqli,mysqlnd,opcache,openssl,password-argon2,pcntl,
-            pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,
-            readline,redis,session,simplexml,soap,sockets,sodium,
-            sqlite3,tokenizer,xml,xmlreader,xmlwriter,xsl,zip,zlib,zstd
+          FRANKENPHP_VERSION: ${{ needs.resolve-version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./build-static.sh
 
-      - name: List build output
-        run: ls -la dist/
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-log-php${{ matrix.php }}-${{ matrix.platform }}
+          path: dist/static-php-cli/log
+
+      - name: Run sanity checks
+        run: |
+          "${BINARY}" version
+          "${BINARY}" build-info
+          "${BINARY}" list-modules | grep frankenphp
+          "${BINARY}" php-cli -r "echo 'Sanity check passed';"
+        env:
+          BINARY: dist/frankenphp-mac-${{ matrix.platform }}
+
+      - name: Rename binary
+        run: mv dist/frankenphp-mac-${{ matrix.platform }} dist/frankenphp-mac-${{ matrix.platform }}-php${{ matrix.php }}
 
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: frankenphp-mac-arm64-php${{ matrix.php }}
-          path: dist/frankenphp-*
+          name: frankenphp-mac-${{ matrix.platform }}-php${{ matrix.php }}
+          path: dist/frankenphp-mac-${{ matrix.platform }}-php${{ matrix.php }}
+          compression-level: 0
 
   release:
     needs: [resolve-version, build]
@@ -81,17 +100,16 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
+          pattern: frankenphp-mac-*
           path: artifacts
 
       - name: Prepare release assets
         run: |
           mkdir -p release
-          for dir in artifacts/frankenphp-*; do
+          for dir in artifacts/frankenphp-mac-*; do
             name=$(basename "$dir")
-            for f in "$dir"/frankenphp-*; do
-              cp "$f" "release/${name}"
-              chmod +x "release/${name}"
-            done
+            cp "$dir"/* "release/"
+            chmod +x "release/${name}"
           done
           ls -la release/
 
@@ -102,19 +120,23 @@ jobs:
           VERSION="${{ needs.resolve-version.outputs.version }}"
           TAG="frankenphp-${VERSION}"
 
-          NOTES=$(cat <<'EOF'
-          Pre-built FrankenPHP binaries with multiple PHP versions.
+          NOTES=$(cat <<'NOTES'
+          Pre-built FrankenPHP binaries with multiple PHP versions for pv.
 
           **FrankenPHP version:** `VERSION_PLACEHOLDER`
 
           ## Binaries
-          | File | PHP Version | Platform |
-          |------|------------|----------|
-          | `frankenphp-mac-arm64-php8.2` | 8.2 | macOS ARM64 |
-          | `frankenphp-mac-arm64-php8.3` | 8.3 | macOS ARM64 |
-          | `frankenphp-mac-arm64-php8.4` | 8.4 | macOS ARM64 |
-          | `frankenphp-mac-arm64-php8.5` | 8.5 | macOS ARM64 |
-          EOF
+          | File | PHP | Platform |
+          |------|-----|----------|
+          | `frankenphp-mac-arm64-php8.2` | 8.2 | macOS ARM64 (Apple Silicon) |
+          | `frankenphp-mac-arm64-php8.3` | 8.3 | macOS ARM64 (Apple Silicon) |
+          | `frankenphp-mac-arm64-php8.4` | 8.4 | macOS ARM64 (Apple Silicon) |
+          | `frankenphp-mac-arm64-php8.5` | 8.5 | macOS ARM64 (Apple Silicon) |
+          | `frankenphp-mac-x86_64-php8.2` | 8.2 | macOS x86_64 (Intel) |
+          | `frankenphp-mac-x86_64-php8.3` | 8.3 | macOS x86_64 (Intel) |
+          | `frankenphp-mac-x86_64-php8.4` | 8.4 | macOS x86_64 (Intel) |
+          | `frankenphp-mac-x86_64-php8.5` | 8.5 | macOS x86_64 (Intel) |
+          NOTES
           )
           NOTES="${NOTES//VERSION_PLACEHOLDER/$VERSION}"
 


### PR DESCRIPTION
## Summary
- Rewrites the build workflow to closely match FrankenPHP's own [static.yaml](https://github.com/php/frankenphp/blob/main/.github/workflows/static.yaml)
- Adds **macOS x86_64 (Intel)** builds via `macos-15-intel` runner alongside ARM64 on `macos-15`
- Uses `php/frankenphp` repo, Go 1.26, `GOTOOLCHAIN=local`
- Drops the custom `PHP_EXTENSIONS` override — lets FrankenPHP's default set build as upstream intended
- Adds sanity checks after build (version, modules, php-cli)
- Uploads build logs as artifacts on failure for debugging

## Changes from previous workflow
| Before | After |
|--------|-------|
| `dunglas/frankenphp` | `php/frankenphp` |
| `macos-14` ARM only | `macos-15` ARM + `macos-15-intel` x86_64 |
| Go 1.24 | Go 1.26 |
| Custom `PHP_EXTENSIONS` | Default (upstream) |
| No sanity checks | version + build-info + module grep + php-cli |
| No failure logs | Uploads `static-php-cli/log` on failure |

## Matrix: 8 builds total
PHP 8.2, 8.3, 8.4, 8.5 × ARM64, x86_64

## Test plan
- [ ] Merge and dispatch workflow
- [ ] Verify all 8 builds pass
- [ ] Verify GitHub release is created with correct assets