### PR TITLE
Use macos-14/13 runners for FrankenPHP builds

### DIFF
--- a/.github/workflows/build-frankenphp.yml
+++ b/.github/workflows/build-frankenphp.yml
@@ -43,7 +43,7 @@ jobs:
         php: ["8.2", "8.3", "8.4", "8.5"]
         platform: ["arm64", "x86_64"]
     name: PHP ${{ matrix.php }} / macOS ${{ matrix.platform }}
-    runs-on: ${{ matrix.platform == 'arm64' && 'macos-15' || 'macos-15-intel' }}
+    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-13' }}
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:


### PR DESCRIPTION
## Summary
- Switch from `macos-15` / `macos-15-intel` to `macos-14` / `macos-13`
- The newer runners have long queue wait times; older ones have better availability

ARM64 → `macos-14`, Intel x86_64 → `macos-13`

## Test plan
- [ ] Dispatch and verify jobs pick up runners quickly