### PR TITLE
Revert custom PHP_EXTENSIONS, use upstream defaults

### DIFF
--- a/.github/workflows/build-frankenphp.yml
+++ b/.github/workflows/build-frankenphp.yml
@@ -67,8 +67,6 @@ jobs:
           PHP_VERSION: ${{ matrix.php }}
           FRANKENPHP_VERSION: ${{ needs.resolve-version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Upstream default minus gmp (gmplib.org is frequently unreachable from GH runners)
-          PHP_EXTENSIONS: "amqp,apcu,ast,bcmath,brotli,bz2,calendar,ctype,curl,dba,dom,exif,fileinfo,filter,ftp,gd,gettext,iconv,igbinary,imagick,intl,ldap,lz4,mbregex,mbstring,memcached,mysqli,mysqlnd,opcache,openssl,password-argon2,parallel,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,pgsql,phar,posix,protobuf,readline,redis,session,shmop,simplexml,soap,sockets,sodium,sqlite3,ssh2,sysvmsg,sysvsem,sysvshm,tidy,tokenizer,xlswriter,xml,xmlreader,xmlwriter,xsl,xz,zip,zlib,yaml,zstd"
         run: ./build-static.sh
 
       - name: Upload logs on failure


### PR DESCRIPTION
The gmplib.org timeout was transient. Upstream builds with gmp fine. Let build-static.sh use its own defaults.