### PR TITLE
Implement daemon mode with launchd integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,11 @@ internal/
 - **Port scheme**: `8000 + major*100 + minor*10` (e.g., PHP 8.3 → 8830).
 - FrankenPHP binaries come from `prvious/pv` GitHub releases (format: `frankenphp-{platform}-php{version}`).
 
+## Testing strategy
+
+- **Unit tests** (`go test ./...`): Run locally. Use `t.Setenv("HOME", t.TempDir())` for filesystem isolation. Fake binaries (bash scripts) can stand in for real PHP when testing shims.
+- **E2E tests** (`.github/workflows/e2e.yml` + `scripts/e2e/`): Run on GitHub Actions (macOS runner) to simulate real end-user flows. These tests use real PHP, real Composer, real FrankenPHP — things we can't easily run locally. **When your feature involves real binary execution, network calls, DNS, HTTPS, or anything that needs a full `pv install` environment, add an e2e script in `scripts/e2e/` and wire it into the workflow.** Each script sources `scripts/e2e/helpers.sh` for `assert_contains`, `assert_fails`, `curl_site`, etc. The workflow phases run sequentially: install → verify → fixtures → link → start → curl → shim → composer → errors → stop → lifecycle → update → verify-final.
+
 ## Key patterns
 
 - **Test isolation**: Tests use `t.Setenv("HOME", t.TempDir())` so filesystem ops go to a temp dir.

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prvious/pv/internal/config"
-	"github.com/prvious/pv/internal/daemon"
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +16,7 @@ var (
 	logFollow bool
 	logLines  int
 	logError  bool
-	logAccess bool
+	logDaemon bool
 )
 
 var logCmd = &cobra.Command{
@@ -25,19 +24,11 @@ var logCmd = &cobra.Command{
 	Short: "Tail the FrankenPHP log",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Explicit flags take priority, otherwise auto-detect.
-		var logPath string
-		switch {
-		case logError:
+		logPath := config.CaddyLogPath()
+		if logError {
 			logPath = config.DaemonErrLogPath()
-		case logAccess:
-			logPath = config.CaddyLogPath()
-		default:
-			if daemon.IsLoaded() {
-				logPath = config.DaemonLogPath()
-			} else {
-				logPath = config.CaddyLogPath()
-			}
+		} else if logDaemon {
+			logPath = config.DaemonLogPath()
 		}
 		f, err := os.Open(logPath)
 		if err != nil {
@@ -112,6 +103,6 @@ func init() {
 	logCmd.Flags().BoolVarP(&logFollow, "follow", "f", false, "Follow log output")
 	logCmd.Flags().IntVarP(&logLines, "lines", "n", 50, "Number of lines to show")
 	logCmd.Flags().BoolVar(&logError, "error", false, "Show daemon stderr log")
-	logCmd.Flags().BoolVar(&logAccess, "access", false, "Show FrankenPHP access log")
+	logCmd.Flags().BoolVar(&logDaemon, "daemon", false, "Show daemon stdout log")
 	rootCmd.AddCommand(logCmd)
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -15,6 +15,8 @@ import (
 var (
 	logFollow bool
 	logLines  int
+	logError  bool
+	logDaemon bool
 )
 
 var logCmd = &cobra.Command{
@@ -23,6 +25,11 @@ var logCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logPath := config.CaddyLogPath()
+		if logError {
+			logPath = config.DaemonErrLogPath()
+		} else if logDaemon {
+			logPath = config.DaemonLogPath()
+		}
 		f, err := os.Open(logPath)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -95,5 +102,7 @@ func tailLines(f *os.File, n int, filter string) ([]string, error) {
 func init() {
 	logCmd.Flags().BoolVarP(&logFollow, "follow", "f", false, "Follow log output")
 	logCmd.Flags().IntVarP(&logLines, "lines", "n", 50, "Number of lines to show")
+	logCmd.Flags().BoolVar(&logError, "error", false, "Show daemon stderr log")
+	logCmd.Flags().BoolVar(&logDaemon, "daemon", false, "Show daemon stdout log")
 	rootCmd.AddCommand(logCmd)
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/daemon"
 	"github.com/spf13/cobra"
 )
 
@@ -16,7 +17,7 @@ var (
 	logFollow bool
 	logLines  int
 	logError  bool
-	logDaemon bool
+	logAccess bool
 )
 
 var logCmd = &cobra.Command{
@@ -24,11 +25,19 @@ var logCmd = &cobra.Command{
 	Short: "Tail the FrankenPHP log",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		logPath := config.CaddyLogPath()
-		if logError {
+		// Explicit flags take priority, otherwise auto-detect.
+		var logPath string
+		switch {
+		case logError:
 			logPath = config.DaemonErrLogPath()
-		} else if logDaemon {
-			logPath = config.DaemonLogPath()
+		case logAccess:
+			logPath = config.CaddyLogPath()
+		default:
+			if daemon.IsLoaded() {
+				logPath = config.DaemonLogPath()
+			} else {
+				logPath = config.CaddyLogPath()
+			}
 		}
 		f, err := os.Open(logPath)
 		if err != nil {
@@ -103,6 +112,6 @@ func init() {
 	logCmd.Flags().BoolVarP(&logFollow, "follow", "f", false, "Follow log output")
 	logCmd.Flags().IntVarP(&logLines, "lines", "n", 50, "Number of lines to show")
 	logCmd.Flags().BoolVar(&logError, "error", false, "Show daemon stderr log")
-	logCmd.Flags().BoolVar(&logDaemon, "daemon", false, "Show daemon stdout log")
+	logCmd.Flags().BoolVar(&logAccess, "access", false, "Show FrankenPHP access log")
 	rootCmd.AddCommand(logCmd)
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -3,14 +3,25 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/server"
 	"github.com/spf13/cobra"
 )
 
 var restartCmd = &cobra.Command{
 	Use:   "restart",
-	Short: "Reload FrankenPHP configuration",
+	Short: "Restart or reload the pv server",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Daemon mode — use launchctl kickstart for atomic restart.
+		if daemon.IsLoaded() {
+			if err := daemon.Restart(); err != nil {
+				return fmt.Errorf("cannot restart daemon: %w", err)
+			}
+			fmt.Println("pv restarted")
+			return nil
+		}
+
+		// Foreground mode — reload config via admin API.
 		if !server.IsRunning() {
 			return fmt.Errorf("pv is not running")
 		}

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/prvious/pv/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+var serviceCmd = &cobra.Command{
+	Use:   "service",
+	Short: "Manage the pv background service",
+}
+
+var serviceInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install pv as a login service (starts on boot)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg := daemon.DefaultPlistConfig()
+		cfg.RunAtLoad = true
+
+		if err := daemon.Install(cfg); err != nil {
+			return fmt.Errorf("cannot install service: %w", err)
+		}
+
+		// Load the service so it starts immediately.
+		if err := daemon.Load(); err != nil {
+			return fmt.Errorf("cannot start service: %w", err)
+		}
+
+		fmt.Println("pv service installed (will start automatically on login)")
+		return nil
+	},
+}
+
+var serviceUninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Uninstall the pv login service",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Unload if loaded.
+		if daemon.IsLoaded() {
+			if err := daemon.Unload(); err != nil {
+				return fmt.Errorf("cannot stop service: %w", err)
+			}
+		}
+
+		if err := daemon.Uninstall(); err != nil {
+			return fmt.Errorf("cannot uninstall service: %w", err)
+		}
+
+		fmt.Println("pv service uninstalled")
+		return nil
+	},
+}
+
+func init() {
+	serviceCmd.AddCommand(serviceInstallCmd)
+	serviceCmd.AddCommand(serviceUninstallCmd)
+	rootCmd.AddCommand(serviceCmd)
+}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -83,7 +83,7 @@ func startDaemon() error {
 	} else {
 		fmt.Println("pv daemon started (waiting for process...)")
 	}
-	fmt.Println("Run `pv log --daemon` to view logs")
+	fmt.Println("Run `pv log` to view logs")
 	return nil
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,29 +2,93 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/server"
 	"github.com/spf13/cobra"
+)
+
+var (
+	startBackground bool
+	startForeground bool
 )
 
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the pv server (DNS + FrankenPHP)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if server.IsRunning() {
-			return fmt.Errorf("pv is already running (PID file exists and process is alive)")
+		if startBackground {
+			return startDaemon()
 		}
-
-		settings, err := config.LoadSettings()
-		if err != nil {
-			return fmt.Errorf("cannot load settings: %w", err)
-		}
-
-		return server.Start(settings.TLD)
+		return startFG()
 	},
 }
 
+func startFG() error {
+	if server.IsRunning() {
+		return fmt.Errorf("pv is already running (PID file exists and process is alive)")
+	}
+
+	settings, err := config.LoadSettings()
+	if err != nil {
+		return fmt.Errorf("cannot load settings: %w", err)
+	}
+
+	return server.Start(settings.TLD)
+}
+
+func startDaemon() error {
+	// Check if already running via launchd.
+	if daemon.IsLoaded() {
+		pid, err := daemon.GetPID()
+		if err == nil && pid > 0 {
+			fmt.Printf("pv is already running (PID %d)\n", pid)
+			return nil
+		}
+	}
+
+	// Also check foreground PID file.
+	if server.IsRunning() {
+		pid, _ := server.ReadPID()
+		fmt.Printf("pv is already running in foreground (PID %d)\n", pid)
+		return nil
+	}
+
+	// Generate and write plist.
+	cfg := daemon.DefaultPlistConfig()
+	if err := daemon.Install(cfg); err != nil {
+		return fmt.Errorf("cannot install plist: %w", err)
+	}
+
+	// Load the service.
+	if err := daemon.Load(); err != nil {
+		return fmt.Errorf("cannot start daemon: %w", err)
+	}
+
+	// Wait for the process to appear.
+	var pid int
+	for i := 0; i < 15; i++ {
+		time.Sleep(200 * time.Millisecond)
+		p, err := daemon.GetPID()
+		if err == nil && p > 0 {
+			pid = p
+			break
+		}
+	}
+
+	if pid > 0 {
+		fmt.Printf("pv is running in the background (PID %d)\n", pid)
+	} else {
+		fmt.Println("pv daemon started (waiting for process...)")
+	}
+	fmt.Println("Run `pv log --daemon` to view logs")
+	return nil
+}
+
 func init() {
+	startCmd.Flags().BoolVar(&startBackground, "background", false, "Run as a background daemon via launchd")
+	startCmd.Flags().BoolVar(&startForeground, "foreground", false, "Run in the foreground (default)")
 	rootCmd.AddCommand(startCmd)
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/phpenv"
 	"github.com/prvious/pv/internal/registry"
 	"github.com/prvious/pv/internal/server"
@@ -20,10 +21,23 @@ var statusCmd = &cobra.Command{
 			return fmt.Errorf("cannot load settings: %w", err)
 		}
 
-		running := server.IsRunning()
+		// Determine running state and mode.
+		var running bool
+		var mode string
+		var pid int
+
+		if daemon.IsLoaded() {
+			running = true
+			mode = "daemon"
+			pid, _ = daemon.GetPID()
+		} else if server.IsRunning() {
+			running = true
+			mode = "foreground"
+			pid, _ = server.ReadPID()
+		}
+
 		if running {
-			pid, _ := server.ReadPID()
-			fmt.Printf("Status:  running (PID %d)\n", pid)
+			fmt.Printf("Status:  running (PID %d, %s mode)\n", pid, mode)
 		} else {
 			fmt.Println("Status:  stopped")
 		}

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+	"time"
 
+	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/server"
 	"github.com/spf13/cobra"
 )
@@ -13,9 +15,29 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the pv server",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Check daemon mode first.
+		if daemon.IsLoaded() {
+			if err := daemon.Unload(); err != nil {
+				return fmt.Errorf("cannot stop daemon: %w", err)
+			}
+
+			// Wait for process to exit.
+			for i := 0; i < 25; i++ {
+				time.Sleep(200 * time.Millisecond)
+				if !daemon.IsLoaded() {
+					break
+				}
+			}
+
+			fmt.Println("pv stopped")
+			return nil
+		}
+
+		// Foreground mode — use PID file.
 		pid, err := server.ReadPID()
 		if err != nil {
-			return fmt.Errorf("pv does not appear to be running (no PID file)")
+			fmt.Println("pv is not running")
+			return nil
 		}
 
 		proc, err := os.FindProcess(pid)
@@ -27,7 +49,15 @@ var stopCmd = &cobra.Command{
 			return fmt.Errorf("cannot send signal to process %d: %w", pid, err)
 		}
 
-		fmt.Printf("Sent stop signal to pv (PID %d)\n", pid)
+		// Wait for process to exit.
+		for i := 0; i < 25; i++ {
+			time.Sleep(200 * time.Millisecond)
+			if proc.Signal(syscall.Signal(0)) != nil {
+				break
+			}
+		}
+
+		fmt.Println("pv stopped")
 		return nil
 	},
 }

--- a/cmd/use.go
+++ b/cmd/use.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
+	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/phpenv"
 	"github.com/prvious/pv/internal/server"
 	"github.com/spf13/cobra"
@@ -37,9 +37,17 @@ var useCmd = &cobra.Command{
 
 		fmt.Printf("Global PHP switched to %s\n", version)
 
-		if oldV != version && server.IsRunning() {
+		// If daemon is running, sync the plist and restart.
+		if oldV != version && daemon.IsLoaded() {
+			cfg := daemon.DefaultPlistConfig()
+			if err := daemon.SyncIfNeeded(cfg); err != nil {
+				fmt.Printf("Warning: cannot sync daemon plist: %v\n", err)
+			} else {
+				fmt.Println("Daemon restarted with new PHP version")
+			}
+		} else if oldV != version && server.IsRunning() {
 			fmt.Println("Server is running — restart required for changes to take effect.")
-			fmt.Fprintln(os.Stderr, "Run: pv stop && pv start")
+			fmt.Println("Run: pv restart")
 		}
 
 		return nil

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -43,6 +43,14 @@ func CaddyLogPath() string {
 	return filepath.Join(LogsDir(), "caddy.log")
 }
 
+func DaemonLogPath() string {
+	return filepath.Join(LogsDir(), "pv.log")
+}
+
+func DaemonErrLogPath() string {
+	return filepath.Join(LogsDir(), "pv.err.log")
+}
+
 func CaddyLogPathForVersion(version string) string {
 	return filepath.Join(LogsDir(), "caddy-"+version+".log")
 }

--- a/internal/daemon/launchctl.go
+++ b/internal/daemon/launchctl.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// domainTarget returns the launchd domain target for the current user (e.g. "gui/501").
+func domainTarget() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+// serviceTarget returns the full service target (e.g. "gui/501/dev.prvious.pv").
+func serviceTarget() string {
+	return domainTarget() + "/" + Label
+}
+
+// Install writes the plist to ~/Library/LaunchAgents/.
+func Install(cfg PlistConfig) error {
+	return WritePlist(cfg)
+}
+
+// Uninstall removes the plist file from ~/Library/LaunchAgents/.
+func Uninstall() error {
+	return RemovePlist()
+}
+
+// Load tells launchd to load the pv service.
+func Load() error {
+	out, err := exec.Command("launchctl", "load", PlistPath()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cannot start pv service: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// Unload tells launchd to unload the pv service.
+func Unload() error {
+	out, err := exec.Command("launchctl", "unload", PlistPath()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cannot stop pv service: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// Restart asks launchd to kill and restart the pv service in one atomic operation.
+func Restart() error {
+	out, err := exec.Command("launchctl", "kickstart", "-k", serviceTarget()).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cannot restart pv service: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// IsLoaded returns true if the pv service is registered with launchd.
+func IsLoaded() bool {
+	err := exec.Command("launchctl", "list", Label).Run()
+	return err == nil
+}
+
+// GetPID returns the PID of the running pv service, or 0 if not running.
+func GetPID() (int, error) {
+	out, err := exec.Command("launchctl", "list", Label).Output()
+	if err != nil {
+		return 0, fmt.Errorf("pv service is not running")
+	}
+
+	// launchctl list <label> outputs a header line then a data line:
+	//   "PID" "Status" "Label"
+	//   12345 0        dev.prvious.pv
+	// If not running, PID column shows "-".
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return 0, fmt.Errorf("pv service is not running")
+	}
+
+	fields := strings.Fields(lines[1])
+	if len(fields) < 1 || fields[0] == "-" {
+		return 0, fmt.Errorf("pv service is loaded but not running")
+	}
+
+	pid, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse PID from launchctl output: %w", err)
+	}
+
+	return pid, nil
+}

--- a/internal/daemon/launchctl_test.go
+++ b/internal/daemon/launchctl_test.go
@@ -1,0 +1,82 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDomainTarget(t *testing.T) {
+	target := domainTarget()
+	expected := fmt.Sprintf("gui/%d", os.Getuid())
+	if target != expected {
+		t.Errorf("domainTarget() = %q, want %q", target, expected)
+	}
+}
+
+func TestServiceTarget(t *testing.T) {
+	target := serviceTarget()
+	expected := fmt.Sprintf("gui/%d/%s", os.Getuid(), Label)
+	if target != expected {
+		t.Errorf("serviceTarget() = %q, want %q", target, expected)
+	}
+}
+
+func TestInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := PlistConfig{
+		Label:        Label,
+		PvBinaryPath: filepath.Join(home, ".pv", "bin", "pv"),
+		LogDir:       filepath.Join(home, ".pv", "logs"),
+		HomeDir:      filepath.Join(home, ".pv"),
+		EnvVars:      map[string]string{"PATH": "/usr/bin"},
+	}
+
+	if err := Install(cfg); err != nil {
+		t.Fatalf("Install error: %v", err)
+	}
+
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", Label+".plist")
+	if _, err := os.Stat(plistPath); err != nil {
+		t.Fatalf("plist file not created: %v", err)
+	}
+}
+
+func TestUninstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Install first.
+	cfg := PlistConfig{
+		Label:        Label,
+		PvBinaryPath: "/usr/local/bin/pv",
+		LogDir:       "/tmp/logs",
+		HomeDir:      "/tmp",
+		EnvVars:      map[string]string{},
+	}
+	if err := Install(cfg); err != nil {
+		t.Fatalf("Install error: %v", err)
+	}
+
+	// Uninstall.
+	if err := Uninstall(); err != nil {
+		t.Fatalf("Uninstall error: %v", err)
+	}
+
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", Label+".plist")
+	if _, err := os.Stat(plistPath); !os.IsNotExist(err) {
+		t.Error("plist file should not exist after Uninstall")
+	}
+}
+
+func TestUninstall_NoFileIsOk(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := Uninstall(); err != nil {
+		t.Fatalf("Uninstall on missing file should not error: %v", err)
+	}
+}

--- a/internal/daemon/sync.go
+++ b/internal/daemon/sync.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+)
+
+// NeedsSync returns true if the plist on disk differs from what would be generated.
+func NeedsSync(cfg PlistConfig) (bool, error) {
+	expected, err := RenderPlist(cfg)
+	if err != nil {
+		return false, fmt.Errorf("cannot render plist for comparison: %w", err)
+	}
+
+	current, err := os.ReadFile(PlistPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil // No plist on disk, needs sync.
+		}
+		return false, fmt.Errorf("cannot read current plist: %w", err)
+	}
+
+	return !bytes.Equal(current, expected), nil
+}
+
+// SyncIfNeeded checks if the plist needs updating and reloads the daemon if so.
+func SyncIfNeeded(cfg PlistConfig) error {
+	needsSync, err := NeedsSync(cfg)
+	if err != nil {
+		return err
+	}
+	if !needsSync {
+		return nil
+	}
+
+	if err := WritePlist(cfg); err != nil {
+		return fmt.Errorf("cannot update plist: %w", err)
+	}
+
+	// If daemon is loaded, restart it to pick up changes.
+	if IsLoaded() {
+		if err := Restart(); err != nil {
+			return fmt.Errorf("cannot restart daemon after plist update: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/daemon/sync_test.go
+++ b/internal/daemon/sync_test.go
@@ -1,0 +1,137 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNeedsSync_NoPlistOnDisk(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := PlistConfig{
+		Label:        Label,
+		PvBinaryPath: filepath.Join(home, ".pv", "bin", "pv"),
+		LogDir:       filepath.Join(home, ".pv", "logs"),
+		HomeDir:      filepath.Join(home, ".pv"),
+		EnvVars:      map[string]string{"PATH": "/usr/bin"},
+	}
+
+	needs, err := NeedsSync(cfg)
+	if err != nil {
+		t.Fatalf("NeedsSync error: %v", err)
+	}
+	if !needs {
+		t.Error("expected NeedsSync=true when no plist on disk")
+	}
+}
+
+func TestNeedsSync_Identical(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := PlistConfig{
+		Label:        Label,
+		PvBinaryPath: filepath.Join(home, ".pv", "bin", "pv"),
+		LogDir:       filepath.Join(home, ".pv", "logs"),
+		HomeDir:      filepath.Join(home, ".pv"),
+		EnvVars:      map[string]string{"PATH": "/usr/bin"},
+	}
+
+	// Write the plist.
+	if err := WritePlist(cfg); err != nil {
+		t.Fatalf("WritePlist error: %v", err)
+	}
+
+	// Same config — should not need sync.
+	needs, err := NeedsSync(cfg)
+	if err != nil {
+		t.Fatalf("NeedsSync error: %v", err)
+	}
+	if needs {
+		t.Error("expected NeedsSync=false when plist matches")
+	}
+}
+
+func TestNeedsSync_Different(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := PlistConfig{
+		Label:        Label,
+		PvBinaryPath: filepath.Join(home, ".pv", "bin", "pv"),
+		LogDir:       filepath.Join(home, ".pv", "logs"),
+		HomeDir:      filepath.Join(home, ".pv"),
+		EnvVars:      map[string]string{"PATH": "/usr/bin"},
+	}
+
+	// Write plist with original config.
+	if err := WritePlist(cfg); err != nil {
+		t.Fatalf("WritePlist error: %v", err)
+	}
+
+	// Change config — should need sync.
+	cfg.PvBinaryPath = filepath.Join(home, ".pv", "php", "8.3", "frankenphp")
+	needs, err := NeedsSync(cfg)
+	if err != nil {
+		t.Fatalf("NeedsSync error: %v", err)
+	}
+	if !needs {
+		t.Error("expected NeedsSync=true when config changed")
+	}
+}
+
+func TestNeedsSync_RunAtLoadChange(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := PlistConfig{
+		Label:        Label,
+		PvBinaryPath: filepath.Join(home, ".pv", "bin", "pv"),
+		LogDir:       filepath.Join(home, ".pv", "logs"),
+		HomeDir:      filepath.Join(home, ".pv"),
+		RunAtLoad:    false,
+		EnvVars:      map[string]string{"PATH": "/usr/bin"},
+	}
+
+	if err := WritePlist(cfg); err != nil {
+		t.Fatalf("WritePlist error: %v", err)
+	}
+
+	// Toggle RunAtLoad.
+	cfg.RunAtLoad = true
+	needs, err := NeedsSync(cfg)
+	if err != nil {
+		t.Fatalf("NeedsSync error: %v", err)
+	}
+	if !needs {
+		t.Error("expected NeedsSync=true when RunAtLoad changed")
+	}
+}
+
+func TestNeedsSync_CorruptedPlist(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Write garbage to the plist location.
+	plistDir := filepath.Join(home, "Library", "LaunchAgents")
+	os.MkdirAll(plistDir, 0755)
+	os.WriteFile(filepath.Join(plistDir, Label+".plist"), []byte("garbage"), 0644)
+
+	cfg := PlistConfig{
+		Label:        Label,
+		PvBinaryPath: filepath.Join(home, ".pv", "bin", "pv"),
+		LogDir:       filepath.Join(home, ".pv", "logs"),
+		HomeDir:      filepath.Join(home, ".pv"),
+		EnvVars:      map[string]string{"PATH": "/usr/bin"},
+	}
+
+	needs, err := NeedsSync(cfg)
+	if err != nil {
+		t.Fatalf("NeedsSync error: %v", err)
+	}
+	if !needs {
+		t.Error("expected NeedsSync=true when plist is corrupted")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds launchctl wrapper (`Load`, `Unload`, `Restart`, `IsLoaded`, `GetPID`) with human-readable error messages
- Adds plist sync (`NeedsSync`, `SyncIfNeeded`) to detect and apply config drift
- `pv start --background` installs plist and loads via launchd with health check polling
- `pv stop` is daemon-aware: unloads launchd service or falls back to SIGTERM
- `pv restart` uses `launchctl kickstart` for atomic daemon restart
- `pv status` shows daemon/foreground mode with PID
- `pv service install/uninstall` for RunAtLoad auto-start on login
- `pv log --error` / `pv log --daemon` for daemon-specific log files
- `pv use` auto-syncs plist and restarts daemon on PHP version switch
- Documents testing strategy in CLAUDE.md

## Test plan
- [x] 24 daemon unit tests pass (`go test ./internal/daemon/ -v`)
- [x] All internal package tests pass (`go test ./internal/...`)
- [ ] E2E daemon scripts (Tasks 12-13) to be added once commands are validated on macOS runner