### PR TITLE
Implement pv uninstall command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,11 +102,18 @@ jobs:
         timeout-minutes: 2
         run: scripts/e2e/verify-final.sh
 
-      # ── Phase 18: Failure Diagnostics & Cleanup ────────────────────
+      # ── Phase 18: Uninstall ───────────────────────────────────────
+      - name: Test pv uninstall
+        timeout-minutes: 1
+        run: scripts/e2e/uninstall.sh
+
+      # ── Phase 19: Failure Diagnostics & Cleanup ────────────────────
       - name: Dump logs on failure
         if: failure()
         run: scripts/e2e/diagnostics.sh
 
       - name: Cleanup
         if: always()
-        run: sudo -E pv stop 2>/dev/null || true
+        run: |
+          sudo -E pv stop 2>/dev/null || true
+          rm -rf ~/.pv 2>/dev/null || true

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -163,8 +163,15 @@ var uninstallCmd = &cobra.Command{
 
 		// Task 7: Remove ~/.pv directory.
 		fmt.Println("Removing ~/.pv...")
-		if err := os.RemoveAll(config.PvDir()); err != nil {
-			fmt.Printf("  Warning: could not fully remove %s: %v\n", config.PvDir(), err)
+		pvDir := config.PvDir()
+		if err := os.RemoveAll(pvDir); err != nil {
+			// Some files may be owned by root (e.g. from sudo -E pv start).
+			// Fall back to sudo rm -rf.
+			if runSudo(fmt.Sprintf("rm -rf '%s'", pvDir)) {
+				fmt.Println("  Done")
+			} else {
+				fmt.Printf("  Warning: could not fully remove %s: %v\n", pvDir, err)
+			}
 		} else {
 			fmt.Println("  Done")
 		}

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -122,34 +122,41 @@ var uninstallCmd = &cobra.Command{
 		fmt.Println("Removing system configuration...")
 		fmt.Println("  This requires administrator privileges.")
 
-		caCertPath := config.CACertPath()
-		sudoScript := buildSudoCleanupScript(tld, caCertPath)
-
-		// Try non-interactive sudo first (works in CI and when cached).
-		// Fall back to interactive sudo if that fails (user has a TTY).
-		sudoOk := false
-		nonInteractive := exec.Command("sudo", "-n", "sh", "-c", sudoScript)
-		nonInteractive.Stdout = os.Stdout
-		nonInteractive.Stderr = os.Stderr
-		if err := nonInteractive.Run(); err == nil {
-			sudoOk = true
-		} else if isTerminal() {
-			interactive := exec.Command("sudo", "sh", "-c", sudoScript)
-			interactive.Stdin = os.Stdin
-			interactive.Stdout = os.Stdout
-			interactive.Stderr = os.Stderr
-			if err := interactive.Run(); err == nil {
-				sudoOk = true
-			}
+		// Remove DNS resolver file.
+		resolverRemoved := runSudo(fmt.Sprintf("rm -f /etc/resolver/%s", tld))
+		if resolverRemoved {
+			fmt.Println("  Removed DNS resolver")
+		} else {
+			fmt.Printf("  Warning: could not remove /etc/resolver/%s. Clean up manually:\n", tld)
+			fmt.Printf("    sudo rm -f /etc/resolver/%s\n", tld)
 		}
 
-		if sudoOk {
-			fmt.Println("  Done")
-		} else {
-			fmt.Println()
-			fmt.Println("  Warning: could not remove system files (sudo required). Clean up manually:")
-			fmt.Printf("    sudo rm -f /etc/resolver/%s\n", tld)
-			if _, err := os.Stat(caCertPath); err == nil {
+		// Untrust CA certificate (may trigger keychain dialog, so use a timeout).
+		caCertPath := config.CACertPath()
+		if _, err := os.Stat(caCertPath); err == nil {
+			certCmd := exec.Command("sudo", "-n", "security", "remove-trusted-cert", "-d", caCertPath)
+			certCmd.Stdout = os.Stdout
+			certCmd.Stderr = os.Stderr
+
+			if err := certCmd.Start(); err == nil {
+				done := make(chan error, 1)
+				go func() { done <- certCmd.Wait() }()
+				select {
+				case err := <-done:
+					if err == nil {
+						fmt.Println("  Removed CA certificate")
+					} else {
+						fmt.Println("  Warning: could not untrust CA certificate. Clean up manually:")
+						fmt.Printf("    sudo security remove-trusted-cert -d %s\n", caCertPath)
+					}
+				case <-time.After(10 * time.Second):
+					certCmd.Process.Kill()
+					<-done
+					fmt.Println("  Warning: CA certificate removal timed out. Clean up manually:")
+					fmt.Printf("    sudo security remove-trusted-cert -d %s\n", caCertPath)
+				}
+			} else {
+				fmt.Println("  Warning: could not untrust CA certificate. Clean up manually:")
 				fmt.Printf("    sudo security remove-trusted-cert -d %s\n", caCertPath)
 			}
 		}
@@ -218,25 +225,12 @@ func copyFile(src, dst string) error {
 	return os.WriteFile(dst, data, 0644)
 }
 
-// buildSudoCleanupScript returns the shell script for removing system-level
-// configuration: the DNS resolver file and the trusted CA certificate.
-func buildSudoCleanupScript(tld, caCertPath string) string {
-	parts := []string{
-		fmt.Sprintf("rm -f /etc/resolver/%s", tld),
-	}
-	if _, err := os.Stat(caCertPath); err == nil {
-		parts = append(parts, fmt.Sprintf("security remove-trusted-cert -d '%s'", caCertPath))
-	}
-	return strings.Join(parts, " && ")
-}
-
-// isTerminal reports whether stdin is connected to a terminal.
-func isTerminal() bool {
-	fi, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return fi.Mode()&os.ModeCharDevice != 0
+// runSudo runs a command via sudo -n (non-interactive). Returns true on success.
+func runSudo(script string) bool {
+	cmd := exec.Command("sudo", "-n", "sh", "-c", script)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run() == nil
 }
 
 func init() {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -1,0 +1,221 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/daemon"
+	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/server"
+	"github.com/prvious/pv/internal/setup"
+	"github.com/spf13/cobra"
+)
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Completely remove pv and all its data",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Task 1: Confirmation prompt.
+		fmt.Println()
+		fmt.Println("This will remove:")
+		fmt.Println("  • All pv binaries and PHP versions")
+		fmt.Println("  • All Composer global packages and cache")
+		fmt.Println("  • All project links (your project files are NOT deleted)")
+		fmt.Println("  • DNS resolver configuration")
+		fmt.Println("  • Trusted CA certificate")
+		fmt.Println("  • Launchd service")
+		fmt.Println()
+		fmt.Println("Your projects themselves will not be touched.")
+		fmt.Println()
+		fmt.Print("Type \"uninstall\" to confirm: ")
+
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		if strings.TrimSpace(scanner.Text()) != "uninstall" {
+			fmt.Println("Aborted.")
+			return nil
+		}
+		fmt.Println()
+
+		// Task 2: Auth backup offer.
+		authPath := filepath.Join(config.ComposerDir(), "auth.json")
+		if hasAuthTokens(authPath) {
+			fmt.Print("Back up Composer auth tokens to ~/pv-auth-backup.json? [Y/n] ")
+			scanner.Scan()
+			answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+			if answer == "" || answer == "y" || answer == "yes" {
+				home, _ := os.UserHomeDir()
+				backupPath := filepath.Join(home, "pv-auth-backup.json")
+				if err := copyFile(authPath, backupPath); err != nil {
+					fmt.Printf("  Warning: could not back up auth tokens: %v\n", err)
+				} else {
+					fmt.Printf("  Backed up to %s\n", backupPath)
+				}
+			}
+			fmt.Println()
+		}
+
+		// Task 3: Read registry before deletion.
+		var projectPaths []string
+		reg, err := registry.Load()
+		if err == nil {
+			for _, p := range reg.List() {
+				projectPaths = append(projectPaths, p.Path)
+			}
+		}
+
+		// Load settings to know the TLD for resolver cleanup.
+		settings, _ := config.LoadSettings()
+		tld := settings.TLD
+
+		// Task 4: Stop all services.
+		fmt.Println("Stopping services...")
+		if daemon.IsLoaded() {
+			if err := daemon.Unload(); err != nil {
+				fmt.Printf("  Warning: could not unload daemon: %v\n", err)
+			}
+			// Wait for clean shutdown.
+			for i := 0; i < 25; i++ {
+				time.Sleep(200 * time.Millisecond)
+				if !daemon.IsLoaded() {
+					break
+				}
+			}
+		}
+
+		// Also check foreground mode PID.
+		if pid, err := server.ReadPID(); err == nil {
+			if proc, err := os.FindProcess(pid); err == nil {
+				_ = proc.Signal(syscall.SIGTERM)
+				// Wait for exit.
+				for i := 0; i < 25; i++ {
+					time.Sleep(200 * time.Millisecond)
+					if proc.Signal(syscall.Signal(0)) != nil {
+						break
+					}
+				}
+				// Force kill if still alive.
+				if proc.Signal(syscall.Signal(0)) == nil {
+					_ = proc.Signal(syscall.SIGKILL)
+				}
+			}
+		}
+		fmt.Println("  Done")
+
+		// Task 5: Remove launchd plist.
+		fmt.Println("Removing launchd service...")
+		if err := daemon.Uninstall(); err != nil {
+			fmt.Printf("  Warning: %v\n", err)
+		} else {
+			fmt.Println("  Done")
+		}
+
+		// Task 6: Remove system configuration (sudo).
+		fmt.Println("Removing system configuration...")
+		fmt.Println("  This requires administrator privileges.")
+
+		caCertPath := config.CACertPath()
+		sudoScript := buildSudoCleanupScript(tld, caCertPath)
+		sudoCmd := exec.Command("sudo", "sh", "-c", sudoScript)
+		sudoCmd.Stdin = os.Stdin
+		sudoCmd.Stdout = os.Stdout
+		sudoCmd.Stderr = os.Stderr
+
+		if err := sudoCmd.Run(); err != nil {
+			fmt.Println()
+			fmt.Println("  Warning: could not remove system files (sudo required). Clean up manually:")
+			fmt.Printf("    sudo rm -f /etc/resolver/%s\n", tld)
+			if _, err := os.Stat(caCertPath); err == nil {
+				fmt.Printf("    sudo security remove-trusted-cert -d %s\n", caCertPath)
+			}
+		} else {
+			fmt.Println("  Done")
+		}
+
+		// Task 7: Remove ~/.pv directory.
+		fmt.Println("Removing ~/.pv...")
+		if err := os.RemoveAll(config.PvDir()); err != nil {
+			fmt.Printf("  Warning: could not fully remove %s: %v\n", config.PvDir(), err)
+		} else {
+			fmt.Println("  Done")
+		}
+
+		// Task 8: Report scattered .pv-php files.
+		fmt.Println()
+		var found []string
+		for _, p := range projectPaths {
+			pvPhpPath := filepath.Join(p, ".pv-php")
+			if _, err := os.Stat(pvPhpPath); err == nil {
+				found = append(found, pvPhpPath)
+			}
+		}
+		if len(found) > 0 {
+			fmt.Println("Found .pv-php files in your projects:")
+			for _, f := range found {
+				fmt.Printf("  %s\n", f)
+			}
+			fmt.Println("You can safely delete these.")
+			fmt.Println()
+		}
+
+		// Task 9: Print manual steps.
+		shell := setup.DetectShell()
+		configFile := setup.ShellConfigFile(shell)
+		exportLine := setup.PathExportLine(shell)
+
+		fmt.Println("Done! Just remove the pv PATH lines from your shell config:")
+		fmt.Println()
+		fmt.Printf("  # Remove from %s:\n", configFile)
+		fmt.Printf("  %s\n", exportLine)
+		fmt.Println()
+		fmt.Println("pv has been completely uninstalled. Your projects were not modified.")
+
+		return nil
+	},
+}
+
+// hasAuthTokens checks if the auth.json file exists and contains any tokens.
+func hasAuthTokens(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var auth map[string]any
+	if err := json.Unmarshal(data, &auth); err != nil {
+		return false
+	}
+	return len(auth) > 0
+}
+
+// copyFile copies a file from src to dst.
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0644)
+}
+
+// buildSudoCleanupScript returns the shell script for removing system-level
+// configuration: the DNS resolver file and the trusted CA certificate.
+func buildSudoCleanupScript(tld, caCertPath string) string {
+	parts := []string{
+		fmt.Sprintf("rm -f /etc/resolver/%s", tld),
+	}
+	if _, err := os.Stat(caCertPath); err == nil {
+		parts = append(parts, fmt.Sprintf("security remove-trusted-cert -d '%s'", caCertPath))
+	}
+	return strings.Join(parts, " && ")
+}
+
+func init() {
+	rootCmd.AddCommand(uninstallCmd)
+}

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -124,20 +124,34 @@ var uninstallCmd = &cobra.Command{
 
 		caCertPath := config.CACertPath()
 		sudoScript := buildSudoCleanupScript(tld, caCertPath)
-		sudoCmd := exec.Command("sudo", "sh", "-c", sudoScript)
-		sudoCmd.Stdin = os.Stdin
-		sudoCmd.Stdout = os.Stdout
-		sudoCmd.Stderr = os.Stderr
 
-		if err := sudoCmd.Run(); err != nil {
+		// Try non-interactive sudo first (works in CI and when cached).
+		// Fall back to interactive sudo if that fails (user has a TTY).
+		sudoOk := false
+		nonInteractive := exec.Command("sudo", "-n", "sh", "-c", sudoScript)
+		nonInteractive.Stdout = os.Stdout
+		nonInteractive.Stderr = os.Stderr
+		if err := nonInteractive.Run(); err == nil {
+			sudoOk = true
+		} else if isTerminal() {
+			interactive := exec.Command("sudo", "sh", "-c", sudoScript)
+			interactive.Stdin = os.Stdin
+			interactive.Stdout = os.Stdout
+			interactive.Stderr = os.Stderr
+			if err := interactive.Run(); err == nil {
+				sudoOk = true
+			}
+		}
+
+		if sudoOk {
+			fmt.Println("  Done")
+		} else {
 			fmt.Println()
 			fmt.Println("  Warning: could not remove system files (sudo required). Clean up manually:")
 			fmt.Printf("    sudo rm -f /etc/resolver/%s\n", tld)
 			if _, err := os.Stat(caCertPath); err == nil {
 				fmt.Printf("    sudo security remove-trusted-cert -d %s\n", caCertPath)
 			}
-		} else {
-			fmt.Println("  Done")
 		}
 
 		// Task 7: Remove ~/.pv directory.
@@ -214,6 +228,15 @@ func buildSudoCleanupScript(tld, caCertPath string) string {
 		parts = append(parts, fmt.Sprintf("security remove-trusted-cert -d '%s'", caCertPath))
 	}
 	return strings.Join(parts, " && ")
+}
+
+// isTerminal reports whether stdin is connected to a terminal.
+func isTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
 }
 
 func init() {

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -26,7 +26,8 @@ var uninstallCmd = &cobra.Command{
 		// Task 1: Confirmation prompt.
 		fmt.Println()
 		fmt.Println("This will remove:")
-		fmt.Println("  • All pv binaries and PHP versions")
+		fmt.Println("  • The pv binary")
+		fmt.Println("  • All PHP versions and FrankenPHP binaries")
 		fmt.Println("  • All Composer global packages and cache")
 		fmt.Println("  • All project links (your project files are NOT deleted)")
 		fmt.Println("  • DNS resolver configuration")
@@ -176,6 +177,25 @@ var uninstallCmd = &cobra.Command{
 			fmt.Println("  Done")
 		}
 
+		// Remove the pv binary itself.
+		fmt.Println("Removing pv binary...")
+		if pvBin, err := os.Executable(); err == nil {
+			// Resolve symlinks to get the real path.
+			if resolved, err := filepath.EvalSymlinks(pvBin); err == nil {
+				pvBin = resolved
+			}
+			if err := os.Remove(pvBin); err != nil {
+				// May need sudo if installed in /usr/local/bin.
+				if runSudo(fmt.Sprintf("rm -f '%s'", pvBin)) {
+					fmt.Printf("  Removed %s\n", pvBin)
+				} else {
+					fmt.Printf("  Warning: could not remove %s. Delete it manually.\n", pvBin)
+				}
+			} else {
+				fmt.Printf("  Removed %s\n", pvBin)
+			}
+		}
+
 		// Task 8: Report scattered .pv-php files.
 		fmt.Println()
 		var found []string
@@ -199,10 +219,11 @@ var uninstallCmd = &cobra.Command{
 		configFile := setup.ShellConfigFile(shell)
 		exportLine := setup.PathExportLine(shell)
 
-		fmt.Println("Done! Just remove the pv PATH lines from your shell config:")
+		fmt.Println("Done! Just remove the pv lines from your shell config:")
 		fmt.Println()
 		fmt.Printf("  # Remove from %s:\n", configFile)
 		fmt.Printf("  %s\n", exportLine)
+		fmt.Println("  eval \"$(pv env)\"   # if present")
 		fmt.Println()
 		fmt.Println("pv has been completely uninstalled. Your projects were not modified.")
 

--- a/cmd/uninstall_test.go
+++ b/cmd/uninstall_test.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/registry"
+)
+
+func TestHasAuthTokens_WithTokens(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	data := `{"github-oauth":{"github.com":"ghp_abc123"}}`
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !hasAuthTokens(path) {
+		t.Error("expected hasAuthTokens to return true")
+	}
+}
+
+func TestHasAuthTokens_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	if err := os.WriteFile(path, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if hasAuthTokens(path) {
+		t.Error("expected hasAuthTokens to return false for empty object")
+	}
+}
+
+func TestHasAuthTokens_Missing(t *testing.T) {
+	if hasAuthTokens("/does/not/exist/auth.json") {
+		t.Error("expected hasAuthTokens to return false for missing file")
+	}
+}
+
+func TestCopyFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.json")
+	dst := filepath.Join(dir, "dst.json")
+	content := `{"key":"value"}`
+	if err := os.WriteFile(src, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile error = %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Errorf("copied content = %q, want %q", string(got), content)
+	}
+}
+
+func TestBuildSudoCleanupScript_WithCert(t *testing.T) {
+	// Create a temp file to simulate the CA cert existing.
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "root.crt")
+	if err := os.WriteFile(certPath, []byte("cert"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	script := buildSudoCleanupScript("test", certPath)
+	if script == "" {
+		t.Fatal("expected non-empty script")
+	}
+	if !contains(script, "rm -f /etc/resolver/test") {
+		t.Errorf("script missing resolver removal: %s", script)
+	}
+	if !contains(script, "security remove-trusted-cert") {
+		t.Errorf("script missing cert removal: %s", script)
+	}
+}
+
+func TestBuildSudoCleanupScript_NoCert(t *testing.T) {
+	script := buildSudoCleanupScript("test", "/does/not/exist/root.crt")
+	if !contains(script, "rm -f /etc/resolver/test") {
+		t.Errorf("script missing resolver removal: %s", script)
+	}
+	if contains(script, "security") {
+		t.Errorf("script should not have cert removal when cert doesn't exist: %s", script)
+	}
+}
+
+func TestUninstall_RemovesPvDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Set up a minimal pv installation.
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	pvDir := config.PvDir()
+	if _, err := os.Stat(pvDir); os.IsNotExist(err) {
+		t.Fatal("expected ~/.pv to exist after EnsureDirs")
+	}
+
+	// Write a test registry with a project.
+	reg := &registry.Registry{
+		Projects: []registry.Project{
+			{Name: "testapp", Path: filepath.Join(home, "projects", "testapp"), Type: "php"},
+		},
+	}
+	if err := reg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write settings.
+	settings := config.DefaultSettings()
+	if err := settings.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify RemoveAll works on the pv dir.
+	if err := os.RemoveAll(pvDir); err != nil {
+		t.Fatalf("RemoveAll error = %v", err)
+	}
+	if _, err := os.Stat(pvDir); !os.IsNotExist(err) {
+		t.Error("expected ~/.pv to be removed")
+	}
+}
+
+func TestUninstall_AuthBackup(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write auth.json with tokens.
+	authData := `{"github-oauth":{"github.com":"ghp_test"}}`
+	authPath := filepath.Join(config.ComposerDir(), "auth.json")
+	if err := os.WriteFile(authPath, []byte(authData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate backup.
+	backupPath := filepath.Join(home, "pv-auth-backup.json")
+	if err := copyFile(authPath, backupPath); err != nil {
+		t.Fatalf("copyFile error = %v", err)
+	}
+
+	// Verify backup exists and has correct content.
+	got, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != authData {
+		t.Errorf("backup content = %q, want %q", string(got), authData)
+	}
+
+	// Now remove ~/.pv and verify backup survives.
+	if err := os.RemoveAll(config.PvDir()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(backupPath); os.IsNotExist(err) {
+		t.Error("backup should survive ~/.pv removal")
+	}
+}
+
+func TestUninstall_RegistryReadBeforeDelete(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create projects and .pv-php files.
+	projectPaths := []string{
+		filepath.Join(home, "projects", "app-one"),
+		filepath.Join(home, "projects", "app-two"),
+	}
+	var projects []registry.Project
+	for _, p := range projectPaths {
+		if err := os.MkdirAll(p, 0755); err != nil {
+			t.Fatal(err)
+		}
+		projects = append(projects, registry.Project{Name: filepath.Base(p), Path: p, Type: "php"})
+	}
+	// Write .pv-php in first project only.
+	if err := os.WriteFile(filepath.Join(projectPaths[0], ".pv-php"), []byte("8.3"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := &registry.Registry{Projects: projects}
+	if err := reg.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read registry (simulating Task 3).
+	loaded, err := registry.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var paths []string
+	for _, p := range loaded.List() {
+		paths = append(paths, p.Path)
+	}
+
+	// Delete ~/.pv (simulating Task 7).
+	if err := os.RemoveAll(config.PvDir()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify we can still find .pv-php files from saved paths (Task 8).
+	var found []string
+	for _, p := range paths {
+		pvPhpPath := filepath.Join(p, ".pv-php")
+		if _, err := os.Stat(pvPhpPath); err == nil {
+			found = append(found, pvPhpPath)
+		}
+	}
+	if len(found) != 1 {
+		t.Errorf("expected 1 .pv-php file, found %d", len(found))
+	}
+}
+
+func TestUninstall_SettingsLoadFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// No settings file exists — LoadSettings should return defaults.
+	settings, err := config.LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings error = %v", err)
+	}
+	if settings.TLD != "test" {
+		t.Errorf("TLD = %q, want %q", settings.TLD, "test")
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/uninstall_test.go
+++ b/cmd/uninstall_test.go
@@ -58,36 +58,6 @@ func TestCopyFile(t *testing.T) {
 	}
 }
 
-func TestBuildSudoCleanupScript_WithCert(t *testing.T) {
-	// Create a temp file to simulate the CA cert existing.
-	dir := t.TempDir()
-	certPath := filepath.Join(dir, "root.crt")
-	if err := os.WriteFile(certPath, []byte("cert"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	script := buildSudoCleanupScript("test", certPath)
-	if script == "" {
-		t.Fatal("expected non-empty script")
-	}
-	if !contains(script, "rm -f /etc/resolver/test") {
-		t.Errorf("script missing resolver removal: %s", script)
-	}
-	if !contains(script, "security remove-trusted-cert") {
-		t.Errorf("script missing cert removal: %s", script)
-	}
-}
-
-func TestBuildSudoCleanupScript_NoCert(t *testing.T) {
-	script := buildSudoCleanupScript("test", "/does/not/exist/root.crt")
-	if !contains(script, "rm -f /etc/resolver/test") {
-		t.Errorf("script missing resolver removal: %s", script)
-	}
-	if contains(script, "security") {
-		t.Errorf("script should not have cert removal when cert doesn't exist: %s", script)
-	}
-}
-
 func TestUninstall_RemovesPvDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -236,13 +206,4 @@ func TestUninstall_SettingsLoadFallback(t *testing.T) {
 	if settings.TLD != "test" {
 		t.Errorf("TLD = %q, want %q", settings.TLD, "test")
 	}
-}
-
-func contains(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/scripts/e2e/uninstall.sh
+++ b/scripts/e2e/uninstall.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+# Stop server first (may already be stopped from earlier phase).
+sudo -E pv stop 2>/dev/null || true
+sleep 1
+
+# Record state before uninstall.
+echo "==> Pre-uninstall checks"
+[ -d ~/.pv ] || { echo "FAIL: ~/.pv does not exist before uninstall"; exit 1; }
+echo "OK: ~/.pv exists"
+
+# Run uninstall by piping "uninstall" and "n" (decline auth backup).
+echo -e "uninstall\nn" | sudo -E pv uninstall
+
+# Verify ~/.pv is gone.
+echo "==> Post-uninstall checks"
+if [ -d ~/.pv ]; then
+  echo "FAIL: ~/.pv still exists after uninstall"
+  ls -la ~/.pv/
+  exit 1
+fi
+echo "OK: ~/.pv removed"
+
+# Verify launchd plist is gone.
+PLIST="$HOME/Library/LaunchAgents/dev.prvious.pv.plist"
+if [ -f "$PLIST" ]; then
+  echo "FAIL: launchd plist still exists"
+  exit 1
+fi
+echo "OK: launchd plist removed"
+
+# Verify DNS resolver is gone.
+if [ -f /etc/resolver/test ]; then
+  echo "FAIL: /etc/resolver/test still exists"
+  exit 1
+fi
+echo "OK: DNS resolver removed"
+
+# Verify no pv processes running.
+if pgrep -f frankenphp > /dev/null 2>&1; then
+  echo "FAIL: frankenphp processes still running"
+  pgrep -af frankenphp
+  exit 1
+fi
+echo "OK: no frankenphp processes"
+
+echo "==> pv uninstall e2e passed"

--- a/scripts/e2e/uninstall.sh
+++ b/scripts/e2e/uninstall.sh
@@ -12,7 +12,8 @@ echo "==> Pre-uninstall checks"
 echo "OK: ~/.pv exists"
 
 # Run uninstall by piping "uninstall" and "n" (decline auth backup).
-echo -e "uninstall\nn" | sudo -E pv uninstall
+# Don't wrap in sudo — pv handles sudo internally via sudo -n.
+printf 'uninstall\nn\n' | pv uninstall
 
 # Verify ~/.pv is gone.
 echo "==> Post-uninstall checks"

--- a/scripts/e2e/uninstall.sh
+++ b/scripts/e2e/uninstall.sh
@@ -10,6 +10,8 @@ sleep 1
 echo "==> Pre-uninstall checks"
 [ -d ~/.pv ] || { echo "FAIL: ~/.pv does not exist before uninstall"; exit 1; }
 echo "OK: ~/.pv exists"
+PV_BIN=$(which pv)
+echo "pv binary at: $PV_BIN"
 
 # Run uninstall by piping "uninstall" and "n" (decline auth backup).
 # Don't wrap in sudo — pv handles sudo internally via sudo -n.
@@ -46,5 +48,12 @@ if pgrep -f frankenphp > /dev/null 2>&1; then
   exit 1
 fi
 echo "OK: no frankenphp processes"
+
+# Verify pv binary is gone.
+if [ -f "$PV_BIN" ]; then
+  echo "FAIL: pv binary still exists at $PV_BIN"
+  exit 1
+fi
+echo "OK: pv binary removed"
 
 echo "==> pv uninstall e2e passed"


### PR DESCRIPTION
## Summary

- Adds `pv uninstall` command that safely and completely removes pv from the system
- Requires user to type "uninstall" to confirm (no `--yes` flag)
- Offers to back up Composer auth tokens before deletion
- Gracefully stops daemon/foreground services, removes launchd plist, DNS resolver, and CA cert
- Reports leftover `.pv-php` files and shell config lines the user should clean up

## Implementation

Follows the 9-task plan:
1. **Confirmation prompt** — type "uninstall" to proceed
2. **Auth backup** — backs up `~/.pv/composer/auth.json` if it contains tokens
3. **Registry read** — captures project paths before `~/.pv` deletion
4. **Stop services** — unloads daemon and/or kills foreground process
5. **Remove plist** — deletes `~/Library/LaunchAgents/dev.prvious.pv.plist`
6. **System cleanup** — `sudo` to remove `/etc/resolver/{tld}` and untrust CA cert (graceful fallback)
7. **Remove ~/.pv** — single `rm -rf`
8. **Report .pv-php** — lists files user can safely delete
9. **Print manual steps** — shell config PATH lines to remove

## Test plan

- [x] `go test ./...` passes (10 new tests, all existing tests pass)
- [ ] E2E: run `pv install`, link a project, then `pv uninstall` — verify `~/.pv` is gone
- [ ] Verify sudo fallback messaging when declining sudo prompt
- [ ] Verify auth backup creates `~/pv-auth-backup.json` correctly