### PR TITLE
Add install script for one-command setup

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -25,14 +25,15 @@ Or run it directly to configure your current session.`,
 			return fmt.Errorf("cannot determine home directory: %w", err)
 		}
 
+		localBinDir := filepath.Join(home, ".local", "bin")
 		binDir := filepath.Join(home, ".pv", "bin")
 		composerBinDir := filepath.Join(home, ".pv", "composer", "vendor", "bin")
 
 		switch shell {
 		case "fish":
-			fmt.Fprintf(cmd.OutOrStdout(), "fish_add_path -g %q %q;\n", binDir, composerBinDir)
+			fmt.Fprintf(cmd.OutOrStdout(), "fish_add_path -g %q %q %q;\n", localBinDir, binDir, composerBinDir)
 		default:
-			fmt.Fprintf(cmd.OutOrStdout(), "export PATH=%q:%q:\"$PATH\";\n", binDir, composerBinDir)
+			fmt.Fprintf(cmd.OutOrStdout(), "export PATH=%q:%q:%q:\"$PATH\";\n", localBinDir, binDir, composerBinDir)
 		}
 
 		return nil

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -36,6 +36,10 @@ func TestEnv_Zsh(t *testing.T) {
 	if !strings.HasPrefix(out, "export PATH=") {
 		t.Errorf("expected 'export PATH=' prefix, got:\n%s", out)
 	}
+	localBinDir := filepath.Join(home, ".local", "bin")
+	if !strings.Contains(out, localBinDir) {
+		t.Errorf("expected %q in output, got:\n%s", localBinDir, out)
+	}
 	binDir := filepath.Join(home, ".pv", "bin")
 	if !strings.Contains(out, binDir) {
 		t.Errorf("expected %q in output, got:\n%s", binDir, out)
@@ -84,6 +88,10 @@ func TestEnv_Fish(t *testing.T) {
 	out := buf.String()
 	if !strings.HasPrefix(out, "fish_add_path") {
 		t.Errorf("expected 'fish_add_path' prefix, got:\n%s", out)
+	}
+	localBinDir := filepath.Join(home, ".local", "bin")
+	if !strings.Contains(out, localBinDir) {
+		t.Errorf("expected %q in output, got:\n%s", localBinDir, out)
 	}
 	binDir := filepath.Join(home, ".pv", "bin")
 	if !strings.Contains(out, binDir) {

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ Usage: install.sh [options]
 Options:
     -h, --help              Display this help message
     -v, --version <version> Install a specific pv version (e.g., 0.1.0)
+    --install-dir <path>    Where to install the pv binary (default: ~/.local/bin)
     --php <version>         PHP version to install (e.g., 8.4). Auto-detects if omitted.
     --tld <tld>             Top-level domain for local sites (default: test)
     --no-modify-path        Don't modify shell config files (.zshrc, .bashrc, etc.)
@@ -29,6 +30,7 @@ Examples:
     curl -fsSL https://pv.prvious.dev/install | bash
     curl -fsSL https://pv.prvious.dev/install | bash -s -- --php 8.4
     curl -fsSL https://pv.prvious.dev/install | bash -s -- --version 0.2.0
+    curl -fsSL https://pv.prvious.dev/install | bash -s -- --install-dir /usr/local/bin
 EOF
 }
 
@@ -38,6 +40,7 @@ requested_version=""
 no_modify_path=false
 php_version=""
 tld=""
+install_dir=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -69,6 +72,15 @@ while [[ $# -gt 0 ]]; do
                 shift 2
             else
                 echo -e "${RED}Error: --tld requires a value${NC}"
+                exit 1
+            fi
+            ;;
+        --install-dir)
+            if [[ -n "${2:-}" ]]; then
+                install_dir="$2"
+                shift 2
+            else
+                echo -e "${RED}Error: --install-dir requires a path${NC}"
                 exit 1
             fi
             ;;
@@ -373,12 +385,15 @@ main() {
     echo -e "  ${MUTED}Detected:${NC} macOS ${platform#darwin-}"
     echo ""
 
-    # Acquire sudo credentials upfront (single prompt for the entire install).
-    # pv needs sudo to install the binary to /usr/local/bin and to set up
-    # the DNS resolver in /etc/resolver/ and trust the CA certificate.
+    # Resolve install directory: flag → default (~/.local/bin)
+    local dest_dir="${install_dir:-$HOME/.local/bin}"
+    mkdir -p "$dest_dir"
+
+    # Acquire sudo credentials upfront if pv install needs it
+    # (DNS resolver in /etc/resolver/ and CA trust require sudo).
     # Skip in CI where passwordless sudo is available.
     if [[ -z "${GITHUB_ACTIONS-}" ]]; then
-        echo -e "  ${MUTED}pv requires sudo for installation. You may be prompted for your password.${NC}"
+        echo -e "  ${MUTED}pv needs sudo for DNS and certificate setup. You may be prompted for your password.${NC}"
         sudo -v
         echo ""
     fi
@@ -410,19 +425,14 @@ main() {
 
     chmod 755 "$tmp_dir/pv"
 
-    # Install to /usr/local/bin
-    echo -e "  ${MUTED}Installing to /usr/local/bin/pv...${NC}"
-
-    if [[ -w "/usr/local/bin" ]]; then
-        mv "$tmp_dir/pv" /usr/local/bin/pv
-    else
-        sudo mv "$tmp_dir/pv" /usr/local/bin/pv
-    fi
+    # Install to destination directory
+    echo -e "  ${MUTED}Installing to ${dest_dir}/pv...${NC}"
+    mv "$tmp_dir/pv" "$dest_dir/pv"
 
     echo -e "  ${GREEN}✓${NC} pv v${version} installed"
     echo ""
 
-    # Run pv install (full bootstrap)
+    # Run pv install (full bootstrap — this calls sudo internally for DNS/CA)
     echo -e "  ${PURPLE}Setting up environment...${NC}"
     echo ""
 
@@ -434,7 +444,7 @@ main() {
         install_args+=(--tld "$tld")
     fi
 
-    /usr/local/bin/pv "${install_args[@]}"
+    "$dest_dir/pv" "${install_args[@]}"
 
     # Set up PATH
     echo ""
@@ -444,6 +454,7 @@ main() {
 
     # GitHub Actions support
     if [[ -n "${GITHUB_ACTIONS-}" ]] && [[ "${GITHUB_ACTIONS}" == "true" ]]; then
+        echo "$dest_dir" >> "$GITHUB_PATH"
         echo "$HOME/.pv/bin" >> "$GITHUB_PATH"
         echo "$HOME/.pv/composer/vendor/bin" >> "$GITHUB_PATH"
         echo -e "  ${GREEN}✓${NC} Added to \$GITHUB_PATH"

--- a/install.sh
+++ b/install.sh
@@ -299,12 +299,12 @@ setup_path() {
     current_shell=$(basename "${SHELL:-/bin/sh}")
 
     local config_file=""
-    local export_line=""
+    local eval_line=""
 
     case "$current_shell" in
         zsh)
             config_file="${ZDOTDIR:-$HOME}/.zshrc"
-            export_line='export PATH="$HOME/.pv/bin:$HOME/.pv/composer/vendor/bin:$PATH"'
+            eval_line='eval "$(pv env)"'
             ;;
         bash)
             # Prefer .bashrc, fall back to .bash_profile
@@ -313,15 +313,15 @@ setup_path() {
             else
                 config_file="$HOME/.bash_profile"
             fi
-            export_line='export PATH="$HOME/.pv/bin:$HOME/.pv/composer/vendor/bin:$PATH"'
+            eval_line='eval "$(pv env)"'
             ;;
         fish)
             config_file="$HOME/.config/fish/config.fish"
-            export_line='fish_add_path "$HOME/.pv/bin" "$HOME/.pv/composer/vendor/bin"'
+            eval_line='pv env | source'
             ;;
         *)
             config_file="$HOME/.profile"
-            export_line='export PATH="$HOME/.pv/bin:$HOME/.pv/composer/vendor/bin:$PATH"'
+            eval_line='eval "$(pv env)"'
             ;;
     esac
 
@@ -329,7 +329,7 @@ setup_path() {
         touch "$config_file"
     fi
 
-    add_to_path "$config_file" "$export_line"
+    add_to_path "$config_file" "$eval_line"
 }
 
 # ── Header ───────────────────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -373,6 +373,16 @@ main() {
     echo -e "  ${MUTED}Detected:${NC} macOS ${platform#darwin-}"
     echo ""
 
+    # Acquire sudo credentials upfront (single prompt for the entire install).
+    # pv needs sudo to install the binary to /usr/local/bin and to set up
+    # the DNS resolver in /etc/resolver/ and trust the CA certificate.
+    # Skip in CI where passwordless sudo is available.
+    if [[ -z "${GITHUB_ACTIONS-}" ]]; then
+        echo -e "  ${MUTED}pv requires sudo for installation. You may be prompted for your password.${NC}"
+        sudo -v
+        echo ""
+    fi
+
     # Check for existing installation
     check_existing
 
@@ -400,13 +410,12 @@ main() {
 
     chmod 755 "$tmp_dir/pv"
 
-    # Install to /usr/local/bin (requires sudo)
+    # Install to /usr/local/bin
     echo -e "  ${MUTED}Installing to /usr/local/bin/pv...${NC}"
 
     if [[ -w "/usr/local/bin" ]]; then
         mv "$tmp_dir/pv" /usr/local/bin/pv
     else
-        echo -e "  ${MUTED}sudo required to install to /usr/local/bin${NC}"
         sudo mv "$tmp_dir/pv" /usr/local/bin/pv
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Colors ───────────────────────────────────────────────────────────────────
+
+PURPLE='\033[38;5;141m'
+MUTED='\033[0;2m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# ── Usage ────────────────────────────────────────────────────────────────────
+
+usage() {
+    cat <<EOF
+pv installer
+
+Usage: install.sh [options]
+
+Options:
+    -h, --help              Display this help message
+    -v, --version <version> Install a specific pv version (e.g., 0.1.0)
+    --php <version>         PHP version to install (e.g., 8.4). Auto-detects if omitted.
+    --tld <tld>             Top-level domain for local sites (default: test)
+    --no-modify-path        Don't modify shell config files (.zshrc, .bashrc, etc.)
+
+Examples:
+    curl -fsSL https://pv.prvious.dev/install | bash
+    curl -fsSL https://pv.prvious.dev/install | bash -s -- --php 8.4
+    curl -fsSL https://pv.prvious.dev/install | bash -s -- --version 0.2.0
+EOF
+}
+
+# ── Parse args ───────────────────────────────────────────────────────────────
+
+requested_version=""
+no_modify_path=false
+php_version=""
+tld=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -v|--version)
+            if [[ -n "${2:-}" ]]; then
+                requested_version="$2"
+                shift 2
+            else
+                echo -e "${RED}Error: --version requires a version argument${NC}"
+                exit 1
+            fi
+            ;;
+        --php)
+            if [[ -n "${2:-}" ]]; then
+                php_version="$2"
+                shift 2
+            else
+                echo -e "${RED}Error: --php requires a version argument${NC}"
+                exit 1
+            fi
+            ;;
+        --tld)
+            if [[ -n "${2:-}" ]]; then
+                tld="$2"
+                shift 2
+            else
+                echo -e "${RED}Error: --tld requires a value${NC}"
+                exit 1
+            fi
+            ;;
+        --no-modify-path)
+            no_modify_path=true
+            shift
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ── Platform detection ───────────────────────────────────────────────────────
+
+detect_platform() {
+    local os
+    os=$(uname -s)
+
+    if [[ "$os" != "Darwin" ]]; then
+        echo ""
+        echo -e "${RED}  pv currently only supports macOS.${NC}"
+        echo -e "${MUTED}  Linux support is planned. Follow https://github.com/prvious/pv for updates.${NC}"
+        echo ""
+        exit 1
+    fi
+
+    local arch
+    arch=$(uname -m)
+
+    # Rosetta detection: catch x86 shells running on ARM Macs
+    if [[ "$arch" == "x86_64" ]]; then
+        local rosetta
+        rosetta=$(sysctl -n sysctl.proc_translated 2>/dev/null || echo 0)
+        if [[ "$rosetta" == "1" ]]; then
+            arch="arm64"
+        fi
+    fi
+
+    case "$arch" in
+        arm64)  echo "darwin-arm64" ;;
+        x86_64) echo "darwin-amd64" ;;
+        *)
+            echo -e "${RED}  Unsupported architecture: $arch${NC}"
+            exit 1
+            ;;
+    esac
+}
+
+# ── Progress bar ─────────────────────────────────────────────────────────────
+
+unbuffered_sed() {
+    if echo | sed -u -e "" >/dev/null 2>&1; then
+        sed -nu "$@"
+    elif echo | sed -l -e "" >/dev/null 2>&1; then
+        sed -nl "$@"
+    else
+        local pad
+        pad="$(printf "\n%512s" "")"
+        sed -ne "s/$/\\${pad}/" "$@"
+    fi
+}
+
+print_progress() {
+    local bytes="$1"
+    local length="$2"
+    [[ "$length" -gt 0 ]] || return 0
+
+    local width=40
+    local percent=$(( bytes * 100 / length ))
+    [[ "$percent" -gt 100 ]] && percent=100
+    local on=$(( percent * width / 100 ))
+    local off=$(( width - on ))
+
+    local filled
+    filled=$(printf "%*s" "$on" "")
+    filled=${filled// /■}
+    local empty
+    empty=$(printf "%*s" "$off" "")
+    empty=${empty// /･}
+
+    printf "\r  ${PURPLE}%s%s %3d%%${NC}" "$filled" "$empty" "$percent" >&4
+}
+
+download_with_progress() {
+    local url="$1"
+    local output="$2"
+
+    if [[ -t 2 ]]; then
+        exec 4>&2
+    else
+        exec 4>/dev/null
+    fi
+
+    local tmp_dir="${TMPDIR:-/tmp}"
+    local basename="${tmp_dir}/pv_install_$$"
+    local tracefile="${basename}.trace"
+
+    rm -f "$tracefile"
+    mkfifo "$tracefile"
+
+    # Hide cursor
+    printf "\033[?25l" >&4
+
+    trap "trap - RETURN; rm -f \"$tracefile\"; printf '\033[?25h' >&4; exec 4>&-" RETURN
+
+    (
+        curl --trace-ascii "$tracefile" -s -L -o "$output" "$url"
+    ) &
+    local curl_pid=$!
+
+    unbuffered_sed \
+        -e 'y/ACDEGHLNORTV/acdeghlnortv/' \
+        -e '/^0000: content-length:/p' \
+        -e '/^<= recv data/p' \
+        "$tracefile" | \
+    {
+        local length=0
+        local bytes=0
+
+        while IFS=" " read -r -a line; do
+            [[ "${#line[@]}" -lt 2 ]] && continue
+            local tag="${line[0]} ${line[1]}"
+
+            if [[ "$tag" == "0000: content-length:" ]]; then
+                length="${line[2]}"
+                length=$(echo "$length" | tr -d '\r')
+                bytes=0
+            elif [[ "$tag" == "<= recv" ]]; then
+                local size="${line[3]}"
+                bytes=$(( bytes + size ))
+                if [[ "$length" -gt 0 ]]; then
+                    print_progress "$bytes" "$length"
+                fi
+            fi
+        done
+    }
+
+    wait "$curl_pid"
+    local ret=$?
+    echo "" >&4
+    return "$ret"
+}
+
+# ── Resolve version ──────────────────────────────────────────────────────────
+
+resolve_version() {
+    if [[ -n "$requested_version" ]]; then
+        # Strip leading 'v' if present
+        requested_version="${requested_version#v}"
+
+        # Verify the release exists
+        local http_status
+        http_status=$(curl -sI -o /dev/null -w "%{http_code}" \
+            "https://github.com/prvious/pv/releases/tag/v${requested_version}")
+
+        if [[ "$http_status" == "404" ]]; then
+            echo -e "${RED}  Release v${requested_version} not found${NC}"
+            echo -e "${MUTED}  Available releases: https://github.com/prvious/pv/releases${NC}"
+            exit 1
+        fi
+
+        echo "$requested_version"
+    else
+        local version
+        version=$(curl -s https://api.github.com/repos/prvious/pv/releases/latest \
+            | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+
+        if [[ -z "$version" ]]; then
+            echo -e "${RED}  Failed to fetch latest version${NC}"
+            echo -e "${MUTED}  Check your internet connection and try again.${NC}"
+            echo -e "${MUTED}  Manual download: https://github.com/prvious/pv/releases${NC}"
+            exit 1
+        fi
+
+        echo "$version"
+    fi
+}
+
+# ── Check existing installation ──────────────────────────────────────────────
+
+check_existing() {
+    if command -v pv >/dev/null 2>&1; then
+        local existing
+        existing=$(which pv)
+
+        # Check if it's our pv (not the pipe viewer utility)
+        if "$existing" --help 2>&1 | grep -q "FrankenPHP\|prvious\|pv install"; then
+            local installed_version
+            installed_version=$("$existing" version 2>/dev/null || echo "unknown")
+            echo -e "${MUTED}  Existing installation detected: ${NC}$installed_version"
+            echo -e "${MUTED}  Upgrading...${NC}"
+        fi
+    fi
+}
+
+# ── Shell PATH setup ─────────────────────────────────────────────────────────
+
+add_to_path() {
+    local config_file="$1"
+    local command="$2"
+
+    if grep -Fq "$command" "$config_file" 2>/dev/null; then
+        return 0  # Already there
+    fi
+
+    if [[ -w "$config_file" ]]; then
+        echo "" >> "$config_file"
+        echo "# pv" >> "$config_file"
+        echo "$command" >> "$config_file"
+        echo -e "  ${GREEN}✓${NC} Added to PATH in ${MUTED}$config_file${NC}"
+    else
+        echo -e "  ${MUTED}Manually add to $config_file:${NC}"
+        echo -e "    $command"
+    fi
+}
+
+setup_path() {
+    local current_shell
+    current_shell=$(basename "${SHELL:-/bin/sh}")
+
+    local config_file=""
+    local export_line=""
+
+    case "$current_shell" in
+        zsh)
+            config_file="${ZDOTDIR:-$HOME}/.zshrc"
+            export_line='export PATH="$HOME/.pv/bin:$HOME/.pv/composer/vendor/bin:$PATH"'
+            ;;
+        bash)
+            # Prefer .bashrc, fall back to .bash_profile
+            if [[ -f "$HOME/.bashrc" ]]; then
+                config_file="$HOME/.bashrc"
+            else
+                config_file="$HOME/.bash_profile"
+            fi
+            export_line='export PATH="$HOME/.pv/bin:$HOME/.pv/composer/vendor/bin:$PATH"'
+            ;;
+        fish)
+            config_file="$HOME/.config/fish/config.fish"
+            export_line='set -gx PATH "$HOME/.pv/bin" "$HOME/.pv/composer/vendor/bin" $PATH'
+            ;;
+        *)
+            config_file="$HOME/.profile"
+            export_line='export PATH="$HOME/.pv/bin:$HOME/.pv/composer/vendor/bin:$PATH"'
+            ;;
+    esac
+
+    if [[ ! -f "$config_file" ]]; then
+        touch "$config_file"
+    fi
+
+    add_to_path "$config_file" "$export_line"
+}
+
+# ── Header ───────────────────────────────────────────────────────────────────
+
+print_header() {
+    local version="$1"
+    echo ""
+    echo -e "  ${PURPLE}${BOLD}pv${NC} ${MUTED}v${version}${NC}"
+    echo -e "  ${MUTED}Local PHP development, zero config${NC}"
+    echo ""
+}
+
+# ── Outro ────────────────────────────────────────────────────────────────────
+
+print_outro() {
+    echo ""
+    echo -e "  ${PURPLE}${BOLD}Ready!${NC} Get started:"
+    echo ""
+    echo -e "  ${BOLD}cd${NC} your-project  ${MUTED}# Go to a PHP project${NC}"
+    echo -e "  ${BOLD}pv link${NC}           ${MUTED}# Link it as project.test${NC}"
+    echo -e "  ${BOLD}pv start${NC}          ${MUTED}# Start the server${NC}"
+    echo ""
+    echo -e "  ${MUTED}Docs: https://github.com/prvious/pv${NC}"
+    echo ""
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+    # Detect platform
+    local platform
+    platform=$(detect_platform)
+
+    # Resolve version
+    local version
+    version=$(resolve_version)
+
+    # Print header
+    print_header "$version"
+
+    echo -e "  ${MUTED}Detected:${NC} macOS ${platform#darwin-}"
+    echo ""
+
+    # Check for existing installation
+    check_existing
+
+    # Download pv binary
+    local url="https://github.com/prvious/pv/releases/download/v${version}/pv-${platform}"
+    local tmp_dir="${TMPDIR:-/tmp}/pv_install_$$"
+    mkdir -p "$tmp_dir"
+    trap "rm -rf '$tmp_dir'" EXIT
+
+    echo -e "  ${MUTED}Downloading pv...${NC}"
+
+    if [[ -t 2 ]] && download_with_progress "$url" "$tmp_dir/pv" 2>&1; then
+        : # progress bar showed
+    else
+        # Fallback: no TTY or progress bar failed
+        if ! curl -fsSL -o "$tmp_dir/pv" "$url"; then
+            echo ""
+            echo -e "  ${RED}Failed to download pv${NC}"
+            echo -e "  ${MUTED}Check your internet connection and try again.${NC}"
+            echo -e "  ${MUTED}Manual download: https://github.com/prvious/pv/releases${NC}"
+            echo ""
+            exit 1
+        fi
+    fi
+
+    chmod 755 "$tmp_dir/pv"
+
+    # Install to /usr/local/bin (requires sudo)
+    echo -e "  ${MUTED}Installing to /usr/local/bin/pv...${NC}"
+
+    if [[ -w "/usr/local/bin" ]]; then
+        mv "$tmp_dir/pv" /usr/local/bin/pv
+    else
+        echo -e "  ${MUTED}sudo required to install to /usr/local/bin${NC}"
+        sudo mv "$tmp_dir/pv" /usr/local/bin/pv
+    fi
+
+    echo -e "  ${GREEN}✓${NC} pv v${version} installed"
+    echo ""
+
+    # Run pv install (full bootstrap)
+    echo -e "  ${PURPLE}Setting up environment...${NC}"
+    echo ""
+
+    local install_args=(install --force)
+    if [[ -n "$php_version" ]]; then
+        install_args+=(--php "$php_version")
+    fi
+    if [[ -n "$tld" ]]; then
+        install_args+=(--tld "$tld")
+    fi
+
+    /usr/local/bin/pv "${install_args[@]}"
+
+    # Set up PATH
+    echo ""
+    if [[ "$no_modify_path" != "true" ]]; then
+        setup_path
+    fi
+
+    # GitHub Actions support
+    if [[ -n "${GITHUB_ACTIONS-}" ]] && [[ "${GITHUB_ACTIONS}" == "true" ]]; then
+        echo "$HOME/.pv/bin" >> "$GITHUB_PATH"
+        echo "$HOME/.pv/composer/vendor/bin" >> "$GITHUB_PATH"
+        echo -e "  ${GREEN}✓${NC} Added to \$GITHUB_PATH"
+    fi
+
+    # Outro
+    print_outro
+}
+
+main

--- a/install.sh
+++ b/install.sh
@@ -177,9 +177,12 @@ download_with_progress() {
     trap "trap - RETURN; rm -f \"$tracefile\"; printf '\033[?25h' >&4; exec 4>&-" RETURN
 
     (
-        curl --trace-ascii "$tracefile" -s -L -o "$output" "$url"
+        curl --trace-ascii "$tracefile" -fsL -o "$output" "$url"
     ) &
     local curl_pid=$!
+
+    # Kill background curl on script exit (Ctrl+C, set -e, etc.)
+    trap "kill $curl_pid 2>/dev/null; rm -f \"$tracefile\"; printf '\033[?25h' >&4" EXIT
 
     unbuffered_sed \
         -e 'y/ACDEGHLNORTV/acdeghlnortv/' \
@@ -211,6 +214,10 @@ download_with_progress() {
     wait "$curl_pid"
     local ret=$?
     echo "" >&4
+
+    # Restore default EXIT trap now that curl is done
+    trap - EXIT
+
     return "$ret"
 }
 
@@ -252,10 +259,10 @@ resolve_version() {
 # ── Check existing installation ──────────────────────────────────────────────
 
 check_existing() {
-    if command -v pv >/dev/null 2>&1; then
-        local existing
-        existing=$(which pv)
+    local existing
+    existing=$(command -v pv 2>/dev/null || true)
 
+    if [[ -n "$existing" ]]; then
         # Check if it's our pv (not the pipe viewer utility)
         if "$existing" --help 2>&1 | grep -q "FrankenPHP\|prvious\|pv install"; then
             local installed_version
@@ -310,7 +317,7 @@ setup_path() {
             ;;
         fish)
             config_file="$HOME/.config/fish/config.fish"
-            export_line='set -gx PATH "$HOME/.pv/bin" "$HOME/.pv/composer/vendor/bin" $PATH'
+            export_line='fish_add_path "$HOME/.pv/bin" "$HOME/.pv/composer/vendor/bin"'
             ;;
         *)
             config_file="$HOME/.profile"


### PR DESCRIPTION
## Summary

- Adds `install.sh` — a curl-pipe installer so users can set up pv with a single command:
  ```
  curl -fsSL https://pv.prvious.dev/install | bash
  ```
- Downloads the `pv` binary to `/usr/local/bin`, then runs `pv install` to bootstrap the full environment (PHP, FrankenPHP, Composer, Mago, DNS, HTTPS certs)

## Features

- **Progress bar** with `■`/`･` characters in purple
- **Rosetta detection** — catches x86 shells running on ARM Macs
- **Version pinning** — `--version 0.2.0` to install a specific release
- **PHP version passthrough** — `--php 8.4` forwarded to `pv install`
- **Auto PATH setup** — detects zsh/bash/fish, writes to the correct config file, deduplicates
- **Idempotent** — safe to run twice, detects existing installations
- **`--no-modify-path`** — for CI environments
- **GitHub Actions support** — writes to `$GITHUB_PATH`
- **Clean error messages** on download failure (not raw curl output)

## What it delegates

The script does NOT duplicate any PHP/FrankenPHP/Composer/Mago/DNS/cert logic. It only gets the `pv` binary in place and runs `pv install --force`, which already handles all of that with its own step-by-step output.

## Prerequisites

This script expects release assets named `pv-darwin-arm64` and `pv-darwin-amd64` on GitHub releases. A release workflow for the Go binary is needed before this script is functional.