### PR TITLE
Add GoReleaser config and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+version: 2
+
+project_name: pv
+
+builds:
+  - main: .
+    binary: pv
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/prvious/pv/cmd.version={{ .Version }}
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+release:
+  github:
+    owner: prvious
+    name: pv
+  draft: false
+  prerelease: auto
+  name_template: "v{{ .Version }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,8 +17,8 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - format: binary
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
 
 checksum:
   name_template: "checksums.txt"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,6 @@ builds:
       - -X github.com/prvious/pv/cmd.version={{ .Version }}
     goos:
       - darwin
-      - linux
     goarch:
       - amd64
       - arm64

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "0.1.0"
+// version is set at build time via ldflags:
+//
+//	go build -ldflags "-X github.com/prvious/pv/cmd.version=1.0.0"
+var version = "dev"
 
 var rootCmd = &cobra.Command{
 	Use:     "pv",


### PR DESCRIPTION
## Summary

- Add GoReleaser configuration and GitHub Actions release workflow to automate binary builds and GitHub Releases when a version tag is pushed.

## Changes

- **`cmd/root.go`** -- Change hardcoded version `"0.1.0"` to `"dev"` default, with ldflags injection support (`-X github.com/prvious/pv/cmd.version=...`)
- **`.goreleaser.yaml`** -- Cross-compile for darwin on amd64/arm64, static binaries (CGO_ENABLED=0), checksums, auto-changelog. Release assets are bare binaries named `pv-darwin-arm64` and `pv-darwin-amd64`.
- **`.github/workflows/release.yml`** -- Triggers on `v*` tags, runs tests, then GoReleaser to build and publish to GitHub Releases

## Usage

```bash
git tag v0.2.0
git push origin v0.2.0
```