### PR TITLE
Add pv env command for shell PATH configuration

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,70 +39,75 @@ jobs:
         timeout-minutes: 1
         run: scripts/e2e/verify-install.sh
 
-      # ── Phase 4: Create Fixtures ───────────────────────────────────
+      # ── Phase 4: Test pv env ─────────────────────────────────────────
+      - name: Test pv env PATH setup
+        timeout-minutes: 1
+        run: scripts/e2e/env.sh
+
+      # ── Phase 5: Create Fixtures ───────────────────────────────────
       - name: Create test fixtures
         run: scripts/e2e/fixtures.sh
 
-      # ── Phase 5: Link & Verify ─────────────────────────────────────
+      # ── Phase 6: Link & Verify ─────────────────────────────────────
       - name: Link projects and verify config
         run: scripts/e2e/link-verify.sh
 
-      # ── Phase 6: Start & Curl All Sites ────────────────────────────
+      # ── Phase 7: Start & Curl All Sites ────────────────────────────
       - name: Start server and curl all sites
         timeout-minutes: 2
         run: scripts/e2e/start-curl.sh
 
-      # ── Phase 7: Dynamic Link While Running ────────────────────────
+      # ── Phase 8: Dynamic Link While Running ────────────────────────
       - name: Dynamic link while server running
         timeout-minutes: 1
         run: scripts/e2e/dynamic-link.sh
 
-      # ── Phase 8: Dynamic Unlink While Running ──────────────────────
+      # ── Phase 9: Dynamic Unlink While Running ──────────────────────
       - name: Dynamic unlink while server running
         timeout-minutes: 1
         run: scripts/e2e/dynamic-unlink.sh
 
-      # ── Phase 9: Test pv log ───────────────────────────────────────
+      # ── Phase 10: Test pv log ──────────────────────────────────────
       - name: Test pv log
         run: scripts/e2e/log.sh
 
-      # ── Phase 10: Test pv restart ──────────────────────────────────
+      # ── Phase 11: Test pv restart ──────────────────────────────────
       - name: Test pv restart
         timeout-minutes: 1
         run: scripts/e2e/restart.sh
 
-      # ── Phase 11: PHP Shim Resolution ──────────────────────────────
+      # ── Phase 12: PHP Shim Resolution ──────────────────────────────
       - name: Test PHP shim per-project resolution
         run: scripts/e2e/shim.sh
 
-      # ── Phase 12: Composer Containment ──────────────────────────────
+      # ── Phase 13: Composer Containment ─────────────────────────────
       - name: Test Composer isolation and global install
         timeout-minutes: 3
         run: scripts/e2e/composer.sh
 
-      # ── Phase 13: Error Handling ───────────────────────────────────
+      # ── Phase 14: Error Handling ───────────────────────────────────
       - name: Test error handling
         run: scripts/e2e/errors.sh
 
-      # ── Phase 14: Stop Server ──────────────────────────────────────
+      # ── Phase 15: Stop Server ──────────────────────────────────────
       - name: Stop server
         run: scripts/e2e/stop.sh
 
-      # ── Phase 15: PHP Version Lifecycle ────────────────────────────
+      # ── Phase 16: PHP Version Lifecycle ────────────────────────────
       - name: Test PHP version lifecycle
         run: scripts/e2e/lifecycle.sh
 
-      # ── Phase 16: Test pv update ───────────────────────────────────
+      # ── Phase 17: Test pv update ───────────────────────────────────
       - name: Test pv update
         timeout-minutes: 3
         run: scripts/e2e/update.sh
 
-      # ── Phase 17: Verify Server After PHP Changes ──────────────────
+      # ── Phase 18: Verify Server After PHP Changes ──────────────────
       - name: Verify server with remaining projects
         timeout-minutes: 2
         run: scripts/e2e/verify-final.sh
 
-      # ── Phase 18: Failure Diagnostics & Cleanup ────────────────────
+      # ── Phase 19: Failure Diagnostics & Cleanup ────────────────────
       - name: Dump logs on failure
         if: failure()
         run: scripts/e2e/diagnostics.sh

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+var envCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Print shell configuration for pv",
+	Long: `Print shell commands to configure PATH for pv.
+
+Add this to your shell config (.zshrc, .bashrc, config.fish):
+
+  eval "$(pv env)"
+
+Or run it directly to configure your current session.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		shell := detectShell()
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("cannot determine home directory: %w", err)
+		}
+
+		binDir := filepath.Join(home, ".pv", "bin")
+		composerBinDir := filepath.Join(home, ".pv", "composer", "vendor", "bin")
+
+		switch shell {
+		case "fish":
+			fmt.Fprintf(cmd.OutOrStdout(), "fish_add_path -g %q %q;\n", binDir, composerBinDir)
+		default:
+			fmt.Fprintf(cmd.OutOrStdout(), "export PATH=%q:%q:\"$PATH\";\n", binDir, composerBinDir)
+		}
+
+		return nil
+	},
+}
+
+// detectShell returns the name of the user's login shell.
+func detectShell() string {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		return "sh"
+	}
+	return filepath.Base(shell)
+}
+
+func init() {
+	rootCmd.AddCommand(envCmd)
+}

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newEnvCmd() *cobra.Command {
+	root := &cobra.Command{Use: "pv", SilenceErrors: true, SilenceUsage: true}
+	env := &cobra.Command{
+		Use:  "env",
+		RunE: envCmd.RunE,
+	}
+	root.AddCommand(env)
+	return root
+}
+
+func TestEnv_Zsh(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/bin/zsh")
+
+	var buf bytes.Buffer
+	cmd := newEnvCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"env"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("env command error = %v", err)
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "export PATH=") {
+		t.Errorf("expected 'export PATH=' prefix, got:\n%s", out)
+	}
+	binDir := filepath.Join(home, ".pv", "bin")
+	if !strings.Contains(out, binDir) {
+		t.Errorf("expected %q in output, got:\n%s", binDir, out)
+	}
+	composerDir := filepath.Join(home, ".pv", "composer", "vendor", "bin")
+	if !strings.Contains(out, composerDir) {
+		t.Errorf("expected %q in output, got:\n%s", composerDir, out)
+	}
+	if !strings.Contains(out, "$PATH") {
+		t.Errorf("expected $PATH in output, got:\n%s", out)
+	}
+}
+
+func TestEnv_Bash(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/bin/bash")
+
+	var buf bytes.Buffer
+	cmd := newEnvCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"env"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("env command error = %v", err)
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "export PATH=") {
+		t.Errorf("expected 'export PATH=' prefix, got:\n%s", out)
+	}
+}
+
+func TestEnv_Fish(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "/usr/local/bin/fish")
+
+	var buf bytes.Buffer
+	cmd := newEnvCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"env"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("env command error = %v", err)
+	}
+
+	out := buf.String()
+	if !strings.HasPrefix(out, "fish_add_path") {
+		t.Errorf("expected 'fish_add_path' prefix, got:\n%s", out)
+	}
+	binDir := filepath.Join(home, ".pv", "bin")
+	if !strings.Contains(out, binDir) {
+		t.Errorf("expected %q in output, got:\n%s", binDir, out)
+	}
+}
+
+func TestEnv_NoShellEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("SHELL", "")
+
+	var buf bytes.Buffer
+	cmd := newEnvCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"env"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("env command error = %v", err)
+	}
+
+	out := buf.String()
+	// Falls back to sh-compatible export
+	if !strings.HasPrefix(out, "export PATH=") {
+		t.Errorf("expected 'export PATH=' prefix for fallback, got:\n%s", out)
+	}
+}

--- a/internal/setup/shell.go
+++ b/internal/setup/shell.go
@@ -41,14 +41,17 @@ func PathExportLine(shell string) string {
 	}
 }
 
-// PrintPathInstructions prints the instructions for adding ~/.pv/bin to the user's PATH.
+// PrintPathInstructions prints the instructions for adding pv to the user's PATH.
 func PrintPathInstructions() {
 	shell := DetectShell()
 	configFile := ShellConfigFile(shell)
-	exportLine := PathExportLine(shell)
 
-	fmt.Println("Add ~/.pv/bin to your PATH by running:")
+	fmt.Println("Add pv to your PATH:")
 	fmt.Println()
-	fmt.Printf("  echo '%s' >> %s\n", exportLine, configFile)
+	fmt.Printf("  echo 'eval \"$(pv env)\"' >> %s\n", configFile)
 	fmt.Printf("  source %s\n", configFile)
+	fmt.Println()
+	fmt.Println("Or configure your current session:")
+	fmt.Println()
+	fmt.Println("  eval \"$(pv env)\"")
 }

--- a/internal/setup/shell.go
+++ b/internal/setup/shell.go
@@ -48,10 +48,20 @@ func PrintPathInstructions() {
 
 	fmt.Println("Add pv to your PATH:")
 	fmt.Println()
-	fmt.Printf("  echo 'eval \"$(pv env)\"' >> %s\n", configFile)
+	switch shell {
+	case "fish":
+		fmt.Printf("  echo 'pv env | source' >> %s\n", configFile)
+	default:
+		fmt.Printf("  echo 'eval \"$(pv env)\"' >> %s\n", configFile)
+	}
 	fmt.Printf("  source %s\n", configFile)
 	fmt.Println()
 	fmt.Println("Or configure your current session:")
 	fmt.Println()
-	fmt.Println("  eval \"$(pv env)\"")
+	switch shell {
+	case "fish":
+		fmt.Println("  pv env | source")
+	default:
+		fmt.Println("  eval \"$(pv env)\"")
+	}
 }

--- a/scripts/e2e/composer.sh
+++ b/scripts/e2e/composer.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 source "$(dirname "$0")/helpers.sh"
 
+# Set up PATH via pv env so we can use bare `composer` and `php` commands
+eval "$(pv env)"
+
 # ── 1. Verify composer shim exists and is executable ───────────────────
 echo "==> Verify composer shim exists"
 ls -la ~/.pv/bin/composer
@@ -13,13 +16,13 @@ test -f ~/.pv/data/composer.phar || { echo "FAIL: composer.phar not found"; exit
 
 # ── 2. Verify COMPOSER_HOME isolation ──────────────────────────────────
 echo "==> Verify COMPOSER_HOME points to ~/.pv/composer"
-COMPOSER_HOME_OUTPUT=$(~/.pv/bin/composer config --global home 2>/dev/null)
+COMPOSER_HOME_OUTPUT=$(composer config --global home 2>/dev/null)
 echo "  COMPOSER_HOME = $COMPOSER_HOME_OUTPUT"
 assert_contains "$COMPOSER_HOME_OUTPUT" ".pv/composer" "COMPOSER_HOME not isolated under ~/.pv/composer"
 
 # ── 3. Verify COMPOSER_CACHE_DIR isolation ─────────────────────────────
 echo "==> Verify COMPOSER_CACHE_DIR points to ~/.pv/composer/cache"
-COMPOSER_CACHE_OUTPUT=$(~/.pv/bin/composer config --global cache-dir 2>/dev/null)
+COMPOSER_CACHE_OUTPUT=$(composer config --global cache-dir 2>/dev/null)
 echo "  COMPOSER_CACHE_DIR = $COMPOSER_CACHE_OUTPUT"
 assert_contains "$COMPOSER_CACHE_OUTPUT" ".pv/composer/cache" "COMPOSER_CACHE_DIR not isolated under ~/.pv/composer/cache"
 
@@ -34,7 +37,7 @@ echo "  OK: ~/.composer does not exist"
 
 # ── 5. Composer global require — real install to disk ──────────────────
 echo "==> composer global require laravel/installer"
-~/.pv/bin/composer global require laravel/installer --no-interaction 2>&1 | tail -5
+composer global require laravel/installer --no-interaction 2>&1 | tail -5
 
 echo "==> Verify laravel/installer landed in ~/.pv/composer/vendor"
 test -d ~/.pv/composer/vendor/laravel/installer || { echo "FAIL: laravel/installer not in ~/.pv/composer/vendor"; exit 1; }
@@ -44,9 +47,9 @@ echo "==> Verify laravel binary in ~/.pv/composer/vendor/bin"
 test -f ~/.pv/composer/vendor/bin/laravel || { echo "FAIL: laravel binary not in ~/.pv/composer/vendor/bin"; exit 1; }
 echo "  OK: ~/.pv/composer/vendor/bin/laravel exists"
 
-# ── 6. Verify the binary is actually executable ───────────────────────
-echo "==> Run laravel --version through the vendor bin"
-LARAVEL_OUT=$(~/.pv/bin/php ~/.pv/composer/vendor/bin/laravel --version 2>&1 || true)
+# ── 6. Verify the binary is actually executable via PATH ──────────────
+echo "==> Run laravel --version via PATH (composer/vendor/bin is in PATH)"
+LARAVEL_OUT=$(laravel --version 2>&1 || true)
 echo "  $LARAVEL_OUT"
 assert_contains "$LARAVEL_OUT" "Laravel Installer" "laravel binary did not produce expected output"
 
@@ -66,7 +69,7 @@ fi
 
 # ── 9. Composer global remove — cleanup works in isolation ─────────────
 echo "==> composer global remove laravel/installer"
-~/.pv/bin/composer global remove laravel/installer --no-interaction 2>&1 | tail -3
+composer global remove laravel/installer --no-interaction 2>&1 | tail -3
 
 echo "==> Verify laravel/installer removed from vendor"
 if [ -d ~/.pv/composer/vendor/laravel/installer ]; then
@@ -80,14 +83,14 @@ echo "==> Verify composer uses correct PHP per project"
 
 # In 8.3 project dir, composer should use PHP 8.3.
 if [ -d /tmp/e2e-php83 ]; then
-  PHP_VER=$(cd /tmp/e2e-php83 && ~/.pv/bin/composer --version 2>&1 | head -1)
+  PHP_VER=$(cd /tmp/e2e-php83 && composer --version 2>&1 | head -1)
   echo "  e2e-php83 dir: $PHP_VER"
   # Composer itself runs — that's proof the PHP resolution worked.
   assert_contains "$PHP_VER" "Composer" "composer did not run in e2e-php83 project"
 fi
 
 # In global context, should use PHP 8.4.
-PHP_VER=$(cd /tmp && ~/.pv/bin/composer --version 2>&1 | head -1)
+PHP_VER=$(cd /tmp && composer --version 2>&1 | head -1)
 echo "  /tmp (global): $PHP_VER"
 assert_contains "$PHP_VER" "Composer" "composer did not run in global context"
 

--- a/scripts/e2e/env.sh
+++ b/scripts/e2e/env.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+# ── 1. pv env produces output ─────────────────────────────────────────
+echo "==> pv env produces output"
+ENV_OUT=$(pv env)
+echo "$ENV_OUT"
+[ -n "$ENV_OUT" ] || { echo "FAIL: pv env produced empty output"; exit 1; }
+
+# ── 2. Output contains ~/.pv/bin ───────────────────────────────────────
+echo "==> Output contains ~/.pv/bin"
+assert_contains "$ENV_OUT" ".pv/bin" "pv env output missing .pv/bin"
+
+# ── 3. Output contains ~/.pv/composer/vendor/bin ───────────────────────
+echo "==> Output contains ~/.pv/composer/vendor/bin"
+assert_contains "$ENV_OUT" ".pv/composer/vendor/bin" "pv env output missing .pv/composer/vendor/bin"
+
+# ── 4. Output is valid shell syntax ───────────────────────────────────
+echo "==> Output is valid shell syntax (can be eval'd)"
+eval "$ENV_OUT"
+
+# ── 5. After eval, php resolves to ~/.pv/bin/php ──────────────────────
+echo "==> php resolves via PATH after eval"
+PHP_PATH=$(command -v php)
+echo "  php -> $PHP_PATH"
+assert_contains "$PHP_PATH" ".pv/bin/php" "php did not resolve to ~/.pv/bin/php"
+
+# ── 6. After eval, composer resolves to ~/.pv/bin/composer ─────────────
+echo "==> composer resolves via PATH after eval"
+COMPOSER_PATH=$(command -v composer)
+echo "  composer -> $COMPOSER_PATH"
+assert_contains "$COMPOSER_PATH" ".pv/bin/composer" "composer did not resolve to ~/.pv/bin/composer"
+
+# ── 7. PATH-resolved php actually works ───────────────────────────────
+echo "==> php --version works via PATH"
+PHP_VER=$(php --version | head -1)
+echo "  $PHP_VER"
+assert_contains "$PHP_VER" "PHP 8" "php --version did not return expected output"
+
+# ── 8. PATH-resolved composer actually works ──────────────────────────
+echo "==> composer --version works via PATH"
+COMPOSER_VER=$(composer --version 2>&1 | head -1)
+echo "  $COMPOSER_VER"
+assert_contains "$COMPOSER_VER" "Composer" "composer --version did not return expected output"
+
+# ── 9. pv env with SHELL=fish produces fish syntax ────────────────────
+echo "==> pv env with SHELL=/usr/bin/fish produces fish syntax"
+FISH_OUT=$(SHELL=/usr/bin/fish pv env)
+echo "$FISH_OUT"
+assert_contains "$FISH_OUT" "fish_add_path" "fish output missing fish_add_path"
+
+# ── 10. pv env with SHELL=bash produces export syntax ─────────────────
+echo "==> pv env with SHELL=/bin/bash produces export syntax"
+BASH_OUT=$(SHELL=/bin/bash pv env)
+echo "$BASH_OUT"
+assert_contains "$BASH_OUT" "export PATH=" "bash output missing export PATH="
+
+# ── 11. pv env with SHELL=zsh produces export syntax ──────────────────
+echo "==> pv env with SHELL=/bin/zsh produces export syntax"
+ZSH_OUT=$(SHELL=/bin/zsh pv env)
+echo "$ZSH_OUT"
+assert_contains "$ZSH_OUT" "export PATH=" "zsh output missing export PATH="
+
+echo ""
+echo "OK: pv env verified"

--- a/scripts/e2e/lifecycle.sh
+++ b/scripts/e2e/lifecycle.sh
@@ -2,12 +2,15 @@
 set -euo pipefail
 source "$(dirname "$0")/helpers.sh"
 
+# Set up PATH via pv env so we can use bare `php` command
+eval "$(pv env)"
+
 # Switch global to 8.3
 pv use php:8.3
 echo "==> Verify settings after switching to 8.3"
 grep -q '"global_php": "8.3"' ~/.pv/config/settings.json || { echo "FAIL: settings not updated"; exit 1; }
 readlink ~/.pv/bin/frankenphp | grep -q "8.3" || { echo "FAIL: symlink not pointing to 8.3"; exit 1; }
-OUT=$(cd /tmp && ~/.pv/bin/php --version)
+OUT=$(cd /tmp && php --version)
 echo "$OUT"
 echo "$OUT" | grep -qi "8\.3" || { echo "FAIL: shim not resolving to 8.3"; exit 1; }
 echo "OK: pv use php:8.3 works"

--- a/scripts/e2e/shim.sh
+++ b/scripts/e2e/shim.sh
@@ -2,18 +2,21 @@
 set -euo pipefail
 source "$(dirname "$0")/helpers.sh"
 
+# Set up PATH via pv env so we can use bare `php` command
+eval "$(pv env)"
+
 echo "==> Shim in e2e-php83 dir (.pv-php -> 8.3)"
-OUT=$(cd /tmp/e2e-php83 && ~/.pv/bin/php --version)
+OUT=$(cd /tmp/e2e-php83 && php --version)
 echo "$OUT"
 echo "$OUT" | grep -qi "8\.3" || { echo "FAIL: shim did not resolve to 8.3"; exit 1; }
 
 echo "==> Shim in e2e-php dir (composer.json -> 8.4)"
-OUT=$(cd /tmp/e2e-php && ~/.pv/bin/php --version)
+OUT=$(cd /tmp/e2e-php && php --version)
 echo "$OUT"
 echo "$OUT" | grep -qi "8\.4" || { echo "FAIL: shim did not resolve to 8.4"; exit 1; }
 
 echo "==> Shim in /tmp (global fallback -> 8.4)"
-OUT=$(cd /tmp && ~/.pv/bin/php --version)
+OUT=$(cd /tmp && php --version)
 echo "$OUT"
 echo "$OUT" | grep -qi "8\.4" || { echo "FAIL: shim did not resolve to global 8.4"; exit 1; }
 


### PR DESCRIPTION
## Summary

- Adds `pv env` command that outputs shell-specific PATH configuration
- Users add one line to their shell config instead of hardcoded export statements:
  ```
  eval "$(pv env)"
  ```
- Updates `pv install` PATH instructions to reference `pv env`

## How it works

`pv env` detects the shell via `$SHELL` and outputs the appropriate syntax:

**zsh/bash:**
```
$ pv env
export PATH="/Users/you/.pv/bin":"/Users/you/.pv/composer/vendor/bin":"$PATH";
```

**fish:**
```
$ pv env
fish_add_path -g "/Users/you/.pv/bin" "/Users/you/.pv/composer/vendor/bin";
```

## Why

Future-proof PATH management. If pv adds more directories to PATH later (new tools, new shim locations), `pv env` picks them up automatically -- users don't need to re-edit their shell config.

## Changes

- `cmd/env.go` — new command
- `cmd/env_test.go` — tests for zsh, bash, fish, and empty SHELL fallback
- `internal/setup/shell.go` — `PrintPathInstructions` now references `eval "$(pv env)"` instead of hardcoded export lines