### PR TITLE
Unify release flow: keep FrankenPHP assets on pv releases

### DIFF
--- a/.github/workflows/build-frankenphp.yml
+++ b/.github/workflows/build-frankenphp.yml
@@ -117,18 +117,24 @@ jobs:
           done
           ls -la release/
 
-      - name: Create or update release
+      - name: Upload to latest pv release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ needs.resolve-version.outputs.version }}"
-          TAG="frankenphp-${VERSION}"
+          set -euo pipefail
 
-          if gh release view "$TAG" --repo "${{ github.repository }}" > /dev/null 2>&1; then
-            gh release upload "$TAG" release/* --repo "${{ github.repository }}" --clobber
-          else
-            gh release create "$TAG" release/* \
-              --repo "${{ github.repository }}" \
-              --title "FrankenPHP ${VERSION}" \
-              --generate-notes
+          # Find the latest pv release (v* tag).
+          LATEST_TAG=$(gh release list --repo "${{ github.repository }}" --limit 10 \
+            --json tagName --jq '[.[] | select(.tagName | startswith("v"))][0].tagName')
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "::error::No pv release found. Create a release (e.g., v0.0.1) first."
+            exit 1
           fi
+
+          echo "Uploading FrankenPHP assets to $LATEST_TAG"
+          gh release upload "$LATEST_TAG" release/* \
+            --repo "${{ github.repository }}" \
+            --clobber
+
+          echo "FrankenPHP assets uploaded to $LATEST_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,44 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Copy FrankenPHP assets from previous release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          NEW_TAG="${GITHUB_REF_NAME}"
+
+          # Find the previous release (skip the one we just created).
+          PREV_TAG=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 10 \
+            --json tagName --jq "[.[] | select(.tagName != \"$NEW_TAG\" and (.tagName | startswith(\"v\")))][0].tagName")
+
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous release found — skipping FrankenPHP asset copy"
+            exit 0
+          fi
+
+          echo "Copying FrankenPHP assets from $PREV_TAG to $NEW_TAG"
+
+          # Download frankenphp-* assets from previous release.
+          mkdir -p /tmp/fp-assets
+          gh release download "$PREV_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'frankenphp-*' \
+            --dir /tmp/fp-assets 2>/dev/null || true
+
+          ASSET_COUNT=$(find /tmp/fp-assets -type f | wc -l | tr -d ' ')
+          if [ "$ASSET_COUNT" -eq 0 ]; then
+            echo "No FrankenPHP assets found in $PREV_TAG — skipping"
+            exit 0
+          fi
+
+          echo "Found $ASSET_COUNT FrankenPHP assets"
+          ls -la /tmp/fp-assets/
+
+          # Upload to the new release.
+          gh release upload "$NEW_TAG" /tmp/fp-assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+          echo "FrankenPHP assets copied to $NEW_TAG"


### PR DESCRIPTION
## Summary

- **release.yml**: After GoReleaser creates a new `v*` release, automatically copy `frankenphp-*` assets from the previous release so every pv release ships with PHP binaries out of the box.
- **build-frankenphp.yml**: Upload rebuilt FrankenPHP binaries to the **latest** `v*` pv release (with `--clobber`) instead of creating a separate `frankenphp-*` tagged release.

This ensures `pv install` always works — `AvailableVersions()` hits `/releases/latest`, and that release will always have `frankenphp-*` assets.