### PR TITLE
Generate Valet-compatible TLS certs for Vite HTTPS auto-detection

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/prvious/pv/internal/caddy"
+	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/detection"
 	"github.com/prvious/pv/internal/phpenv"
@@ -91,6 +92,15 @@ pv link --name=myapp ~/Code/myapp`,
 		}
 		if err := caddy.GenerateCaddyfile(); err != nil {
 			return fmt.Errorf("cannot generate Caddyfile: %w", err)
+		}
+
+		// Generate TLS certificate for Vite dev server auto-detection.
+		hostname := name + "." + settings.TLD
+		if err := certs.EnsureValetConfig(settings.TLD); err != nil {
+			ui.Subtle(fmt.Sprintf("Vite TLS config: %v", err))
+		}
+		if err := certs.GenerateSiteTLS(hostname); err != nil {
+			ui.Subtle(fmt.Sprintf("Vite TLS: %v", err))
 		}
 
 		typeLabel := projectType

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -97,10 +97,9 @@ pv link --name=myapp ~/Code/myapp`,
 		// Generate TLS certificate for Vite dev server auto-detection.
 		hostname := name + "." + settings.TLD
 		if err := certs.EnsureValetConfig(settings.TLD); err != nil {
-			ui.Subtle(fmt.Sprintf("Vite TLS config: %v", err))
-		}
-		if err := certs.GenerateSiteTLS(hostname); err != nil {
-			ui.Subtle(fmt.Sprintf("Vite TLS: %v", err))
+			ui.Subtle(fmt.Sprintf("Skipped Vite TLS setup: %v", err))
+		} else if err := certs.GenerateSiteTLS(hostname); err != nil {
+			ui.Subtle(fmt.Sprintf("Vite TLS cert not generated (HTTPS HMR may need manual config): %v", err))
 		}
 
 		typeLabel := projectType

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/prvious/pv/internal/binaries"
+	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/commands/composer"
 	"github.com/prvious/pv/internal/commands/mago"
 	"github.com/prvious/pv/internal/commands/service"
@@ -130,6 +131,11 @@ var setupCmd = &cobra.Command{
 		}
 		if err := s.Save(); err != nil {
 			return fmt.Errorf("cannot save settings: %w", err)
+		}
+
+		// Write Valet-compatible config for Vite TLS auto-detection.
+		if err := certs.EnsureValetConfig(tld); err != nil {
+			ui.Subtle(fmt.Sprintf("Vite TLS config: %v", err))
 		}
 
 		// Install PHP versions.

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -203,9 +203,18 @@ var uninstallCmd = &cobra.Command{
 			}
 		}
 
-		// Remove Valet-compatible config (Vite TLS certs).
-		if err := certs.RemoveAll(); err != nil {
-			ui.Subtle(fmt.Sprintf("Could not remove ~/.config/valet: %v", err))
+		// Remove Vite TLS certs for linked projects only.
+		if reg != nil {
+			var hostnames []string
+			for _, p := range reg.List() {
+				hostnames = append(hostnames, p.Name+"."+tld)
+			}
+			if err := certs.RemoveLinkedCerts(hostnames); err != nil {
+				ui.Subtle(fmt.Sprintf("Could not remove some Vite TLS certs: %v", err))
+			}
+		}
+		if err := certs.RemoveConfig(); err != nil {
+			ui.Subtle(fmt.Sprintf("Could not remove Valet config: %v", err))
 		}
 
 		// Remove ~/.pv directory.

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"charm.land/huh/v2"
+	"github.com/prvious/pv/internal/certs"
 	colimacmd "github.com/prvious/pv/internal/commands/colima"
 	"github.com/prvious/pv/internal/commands/composer"
 	"github.com/prvious/pv/internal/commands/mago"
@@ -200,6 +201,11 @@ var uninstallCmd = &cobra.Command{
 			}); err != nil {
 				// Error already displayed by ui.Step
 			}
+		}
+
+		// Remove Valet-compatible config (Vite TLS certs).
+		if err := certs.RemoveAll(); err != nil {
+			ui.Subtle(fmt.Sprintf("Could not remove ~/.config/valet: %v", err))
 		}
 
 		// Remove ~/.pv directory.

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -73,7 +73,9 @@ pv unlink`,
 		}
 
 		// Remove TLS certificate for Vite dev server.
-		certs.RemoveSiteTLS(name + "." + tld)
+		if err := certs.RemoveSiteTLS(name + "." + tld); err != nil {
+			ui.Subtle(fmt.Sprintf("Could not remove Vite TLS certs: %v", err))
+		}
 
 		domain := "https://" + name + "." + tld
 

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/prvious/pv/internal/caddy"
+	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/registry"
 	"github.com/prvious/pv/internal/server"
@@ -70,6 +71,10 @@ pv unlink`,
 		if settings != nil {
 			tld = settings.TLD
 		}
+
+		// Remove TLS certificate for Vite dev server.
+		certs.RemoveSiteTLS(name + "." + tld)
+
 		domain := "https://" + name + "." + tld
 
 		fmt.Fprintln(os.Stderr)

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -1,0 +1,114 @@
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+)
+
+// GenerateSiteCert creates a TLS certificate for the given hostname, signed by
+// the CA at caKeyPath/caCertPath, and writes the cert/key to certPath/keyPath.
+func GenerateSiteCert(hostname, caCertPath, caKeyPath, certPath, keyPath string) error {
+	caCert, caKey, err := loadCA(caCertPath, caKeyPath)
+	if err != nil {
+		return fmt.Errorf("cannot load CA: %w", err)
+	}
+
+	// Generate a new ECDSA key for the site.
+	siteKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("cannot generate site key: %w", err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return fmt.Errorf("cannot generate serial number: %w", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject:      pkix.Name{CommonName: hostname},
+		DNSNames:     []string{hostname},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(825 * 24 * time.Hour), // ~2 years (within macOS limit)
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, caCert, &siteKey.PublicKey, caKey)
+	if err != nil {
+		return fmt.Errorf("cannot create certificate: %w", err)
+	}
+
+	// Write cert file.
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+		return fmt.Errorf("cannot write certificate: %w", err)
+	}
+
+	// Write key file.
+	keyDER, err := x509.MarshalECPrivateKey(siteKey)
+	if err != nil {
+		return fmt.Errorf("cannot marshal key: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		return fmt.Errorf("cannot write key: %w", err)
+	}
+
+	return nil
+}
+
+func loadCA(certPath, keyPath string) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, nil, fmt.Errorf("no PEM block in CA certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return nil, nil, fmt.Errorf("no PEM block in CA key")
+	}
+
+	key, err := parsePrivateKey(keyBlock.Bytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, key, nil
+}
+
+func parsePrivateKey(der []byte) (*ecdsa.PrivateKey, error) {
+	if key, err := x509.ParseECPrivateKey(der); err == nil {
+		return key, nil
+	}
+	// Caddy may store the key in PKCS8 format.
+	parsed, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, fmt.Errorf("unsupported CA key format")
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("CA key is not ECDSA")
+	}
+	return key, nil
+}

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -14,14 +14,13 @@ import (
 )
 
 // GenerateSiteCert creates a TLS certificate for the given hostname, signed by
-// the CA at caKeyPath/caCertPath, and writes the cert/key to certPath/keyPath.
+// the CA at caCertPath/caKeyPath, and writes the cert/key to certPath/keyPath.
 func GenerateSiteCert(hostname, caCertPath, caKeyPath, certPath, keyPath string) error {
 	caCert, caKey, err := loadCA(caCertPath, caKeyPath)
 	if err != nil {
 		return fmt.Errorf("cannot load CA: %w", err)
 	}
 
-	// Generate a new ECDSA key for the site.
 	siteKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return fmt.Errorf("cannot generate site key: %w", err)
@@ -37,7 +36,7 @@ func GenerateSiteCert(hostname, caCertPath, caKeyPath, certPath, keyPath string)
 		Subject:      pkix.Name{CommonName: hostname},
 		DNSNames:     []string{hostname},
 		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(825 * 24 * time.Hour), // ~2 years (within macOS limit)
+		NotAfter:     time.Now().Add(825 * 24 * time.Hour), // 825 days (macOS max for trusted TLS certs)
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 	}
@@ -47,19 +46,18 @@ func GenerateSiteCert(hostname, caCertPath, caKeyPath, certPath, keyPath string)
 		return fmt.Errorf("cannot create certificate: %w", err)
 	}
 
-	// Write cert file.
 	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
 		return fmt.Errorf("cannot write certificate: %w", err)
 	}
 
-	// Write key file.
 	keyDER, err := x509.MarshalECPrivateKey(siteKey)
 	if err != nil {
 		return fmt.Errorf("cannot marshal key: %w", err)
 	}
 	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
 	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		os.Remove(certPath) // clean up orphaned cert
 		return fmt.Errorf("cannot write key: %w", err)
 	}
 
@@ -101,14 +99,14 @@ func parsePrivateKey(der []byte) (*ecdsa.PrivateKey, error) {
 	if key, err := x509.ParseECPrivateKey(der); err == nil {
 		return key, nil
 	}
-	// Caddy may store the key in PKCS8 format.
+	// Caddy's PKI (via smallstep) may store CA keys in PKCS#8 format.
 	parsed, err := x509.ParsePKCS8PrivateKey(der)
 	if err != nil {
-		return nil, fmt.Errorf("unsupported CA key format")
+		return nil, fmt.Errorf("unsupported CA key format: %w", err)
 	}
 	key, ok := parsed.(*ecdsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("CA key is not ECDSA")
+		return nil, fmt.Errorf("CA key is %T, expected *ecdsa.PrivateKey", parsed)
 	}
 	return key, nil
 }

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -1,0 +1,142 @@
+package certs
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func createTestCA(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+
+	certPath = filepath.Join(dir, "root.crt")
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	if err := os.WriteFile(certPath, certPEM, 0644); err != nil {
+		t.Fatalf("write CA cert: %v", err)
+	}
+
+	keyPath = filepath.Join(dir, "root.key")
+	keyDER, err := x509.MarshalECPrivateKey(caKey)
+	if err != nil {
+		t.Fatalf("marshal CA key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	if err := os.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		t.Fatalf("write CA key: %v", err)
+	}
+
+	return certPath, keyPath
+}
+
+func TestGenerateSiteCert(t *testing.T) {
+	dir := t.TempDir()
+	caCertPath, caKeyPath := createTestCA(t, dir)
+
+	certPath := filepath.Join(dir, "myapp.test.crt")
+	keyPath := filepath.Join(dir, "myapp.test.key")
+
+	if err := GenerateSiteCert("myapp.test", caCertPath, caKeyPath, certPath, keyPath); err != nil {
+		t.Fatalf("GenerateSiteCert() error = %v", err)
+	}
+
+	// Verify cert file exists and is valid.
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		t.Fatal("no PEM block in cert")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+
+	if cert.Subject.CommonName != "myapp.test" {
+		t.Errorf("CommonName = %q, want %q", cert.Subject.CommonName, "myapp.test")
+	}
+	if len(cert.DNSNames) != 1 || cert.DNSNames[0] != "myapp.test" {
+		t.Errorf("DNSNames = %v, want [myapp.test]", cert.DNSNames)
+	}
+	if cert.NotAfter.Before(time.Now().Add(800 * 24 * time.Hour)) {
+		t.Error("cert expires too soon")
+	}
+
+	// Verify key file exists and is valid.
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		t.Fatal("no PEM block in key")
+	}
+
+	// Verify key permissions.
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("stat key: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("key permissions = %o, want 0600", info.Mode().Perm())
+	}
+
+	// Verify the cert is signed by the CA.
+	caCertPEM, _ := os.ReadFile(caCertPath)
+	caBlock, _ := pem.Decode(caCertPEM)
+	caCert, _ := x509.ParseCertificate(caBlock.Bytes)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:     pool,
+		DNSName:   "myapp.test",
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}); err != nil {
+		t.Errorf("cert verification failed: %v", err)
+	}
+}
+
+func TestGenerateSiteCert_MissingCA(t *testing.T) {
+	dir := t.TempDir()
+
+	err := GenerateSiteCert("myapp.test",
+		filepath.Join(dir, "nonexistent.crt"),
+		filepath.Join(dir, "nonexistent.key"),
+		filepath.Join(dir, "out.crt"),
+		filepath.Join(dir, "out.key"),
+	)
+	if err == nil {
+		t.Fatal("expected error for missing CA")
+	}
+}

--- a/internal/certs/valet.go
+++ b/internal/certs/valet.go
@@ -1,0 +1,85 @@
+package certs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+// valetConfig mirrors the config.json structure the laravel-vite-plugin reads.
+type valetConfig struct {
+	TLD string `json:"tld"`
+}
+
+// ValetConfigDir returns ~/.config/valet (where laravel-vite-plugin looks for
+// Valet on macOS). pv populates this so Vite auto-detects TLS certificates.
+func ValetConfigDir() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "valet")
+}
+
+// ValetCertsDir returns ~/.config/valet/Certificates.
+func ValetCertsDir() string {
+	return filepath.Join(ValetConfigDir(), "Certificates")
+}
+
+// EnsureValetConfig writes ~/.config/valet/config.json with the current TLD.
+// Creates the directory tree if needed.
+func EnsureValetConfig(tld string) error {
+	dir := ValetConfigDir()
+	if err := os.MkdirAll(filepath.Join(dir, "Certificates"), 0755); err != nil {
+		return fmt.Errorf("cannot create valet config dir: %w", err)
+	}
+
+	cfg := valetConfig{TLD: tld}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "config.json"), data, 0644)
+}
+
+// GenerateSiteTLS generates a TLS cert/key pair for hostname and places them
+// in the Valet Certificates directory where laravel-vite-plugin expects them.
+// Uses Caddy's local CA to sign the certificate.
+func GenerateSiteTLS(hostname string) error {
+	caCertPath := config.CACertPath()
+	caKeyPath := caKeyPath()
+
+	if _, err := os.Stat(caCertPath); err != nil {
+		return fmt.Errorf("Caddy CA not found at %s (run pv start first to generate it)", caCertPath)
+	}
+	if _, err := os.Stat(caKeyPath); err != nil {
+		return fmt.Errorf("Caddy CA key not found at %s", caKeyPath)
+	}
+
+	certsDir := ValetCertsDir()
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		return fmt.Errorf("cannot create certificates dir: %w", err)
+	}
+
+	certPath := filepath.Join(certsDir, hostname+".crt")
+	keyPath := filepath.Join(certsDir, hostname+".key")
+
+	return GenerateSiteCert(hostname, caCertPath, caKeyPath, certPath, keyPath)
+}
+
+// RemoveSiteTLS removes the TLS cert/key pair for hostname from the Valet
+// Certificates directory.
+func RemoveSiteTLS(hostname string) {
+	certsDir := ValetCertsDir()
+	os.Remove(filepath.Join(certsDir, hostname+".crt"))
+	os.Remove(filepath.Join(certsDir, hostname+".key"))
+}
+
+// RemoveAll removes the entire ~/.config/valet directory created by pv.
+func RemoveAll() error {
+	return os.RemoveAll(ValetConfigDir())
+}
+
+func caKeyPath() string {
+	return filepath.Join(config.PvDir(), "caddy", "pki", "authorities", "local", "root.key")
+}

--- a/internal/certs/valet.go
+++ b/internal/certs/valet.go
@@ -2,6 +2,7 @@ package certs
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,37 +10,55 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-// valetConfig mirrors the config.json structure the laravel-vite-plugin reads.
-type valetConfig struct {
-	TLD string `json:"tld"`
-}
-
 // ValetConfigDir returns ~/.config/valet (where laravel-vite-plugin looks for
 // Valet on macOS). pv populates this so Vite auto-detects TLS certificates.
-func ValetConfigDir() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".config", "valet")
+func ValetConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "valet"), nil
 }
 
 // ValetCertsDir returns ~/.config/valet/Certificates.
-func ValetCertsDir() string {
-	return filepath.Join(ValetConfigDir(), "Certificates")
+func ValetCertsDir() (string, error) {
+	dir, err := ValetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "Certificates"), nil
 }
 
-// EnsureValetConfig writes ~/.config/valet/config.json with the current TLD.
-// Creates the directory tree if needed.
+// EnsureValetConfig writes the TLD to ~/.config/valet/config.json for
+// laravel-vite-plugin's TLS certificate discovery. Merges with any existing
+// config.json to avoid destroying real Valet settings.
 func EnsureValetConfig(tld string) error {
-	dir := ValetConfigDir()
+	dir, err := ValetConfigDir()
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Join(dir, "Certificates"), 0755); err != nil {
 		return fmt.Errorf("cannot create valet config dir: %w", err)
 	}
 
-	cfg := valetConfig{TLD: tld}
+	configPath := filepath.Join(dir, "config.json")
+
+	// Read existing config to preserve other fields (e.g., real Valet settings).
+	cfg := make(map[string]any)
+	if data, err := os.ReadFile(configPath); err == nil {
+		_ = json.Unmarshal(data, &cfg) // ignore parse errors, overwrite corrupt file
+	}
+
+	cfg["tld"] = tld
+
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot marshal valet config: %w", err)
 	}
-	return os.WriteFile(filepath.Join(dir, "config.json"), data, 0644)
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		return fmt.Errorf("cannot write valet config: %w", err)
+	}
+	return nil
 }
 
 // GenerateSiteTLS generates a TLS cert/key pair for hostname and places them
@@ -47,7 +66,7 @@ func EnsureValetConfig(tld string) error {
 // Uses Caddy's local CA to sign the certificate.
 func GenerateSiteTLS(hostname string) error {
 	caCertPath := config.CACertPath()
-	caKeyPath := caKeyPath()
+	caKeyPath := config.CAKeyPath()
 
 	if _, err := os.Stat(caCertPath); err != nil {
 		return fmt.Errorf("Caddy CA not found at %s (run pv start first to generate it)", caCertPath)
@@ -56,7 +75,10 @@ func GenerateSiteTLS(hostname string) error {
 		return fmt.Errorf("Caddy CA key not found at %s", caKeyPath)
 	}
 
-	certsDir := ValetCertsDir()
+	certsDir, err := ValetCertsDir()
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(certsDir, 0755); err != nil {
 		return fmt.Errorf("cannot create certificates dir: %w", err)
 	}
@@ -68,18 +90,50 @@ func GenerateSiteTLS(hostname string) error {
 }
 
 // RemoveSiteTLS removes the TLS cert/key pair for hostname from the Valet
-// Certificates directory.
-func RemoveSiteTLS(hostname string) {
-	certsDir := ValetCertsDir()
-	os.Remove(filepath.Join(certsDir, hostname+".crt"))
-	os.Remove(filepath.Join(certsDir, hostname+".key"))
+// Certificates directory. Returns nil if the files do not exist.
+func RemoveSiteTLS(hostname string) error {
+	certsDir, err := ValetCertsDir()
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, ext := range []string{".crt", ".key"} {
+		if err := os.Remove(filepath.Join(certsDir, hostname+ext)); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
-// RemoveAll removes the entire ~/.config/valet directory created by pv.
-func RemoveAll() error {
-	return os.RemoveAll(ValetConfigDir())
+// RemoveLinkedCerts removes TLS cert/key pairs for the given hostnames only.
+// Does not touch any other files in ~/.config/valet.
+func RemoveLinkedCerts(hostnames []string) error {
+	certsDir, err := ValetCertsDir()
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	for _, h := range hostnames {
+		for _, ext := range []string{".crt", ".key"} {
+			if err := os.Remove(filepath.Join(certsDir, h+ext)); err != nil && !os.IsNotExist(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
 }
 
-func caKeyPath() string {
-	return filepath.Join(config.PvDir(), "caddy", "pki", "authorities", "local", "root.key")
+// RemoveConfig removes the config.json file from ~/.config/valet.
+// Does not remove the directory itself or any other files.
+func RemoveConfig() error {
+	dir, err := ValetConfigDir()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(filepath.Join(dir, "config.json")); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }

--- a/internal/certs/valet_test.go
+++ b/internal/certs/valet_test.go
@@ -1,0 +1,112 @@
+package certs
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureValetConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := EnsureValetConfig("test"); err != nil {
+		t.Fatalf("EnsureValetConfig() error = %v", err)
+	}
+
+	// Verify config.json.
+	configPath := filepath.Join(home, ".config", "valet", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.json: %v", err)
+	}
+
+	var cfg valetConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse config.json: %v", err)
+	}
+	if cfg.TLD != "test" {
+		t.Errorf("TLD = %q, want %q", cfg.TLD, "test")
+	}
+
+	// Verify Certificates directory exists.
+	certsDir := filepath.Join(home, ".config", "valet", "Certificates")
+	info, err := os.Stat(certsDir)
+	if err != nil {
+		t.Fatalf("Certificates dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("Certificates is not a directory")
+	}
+}
+
+func TestEnsureValetConfig_UpdatesTLD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := EnsureValetConfig("test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsureValetConfig("dev"); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := filepath.Join(home, ".config", "valet", "config.json")
+	data, _ := os.ReadFile(configPath)
+	var cfg valetConfig
+	json.Unmarshal(data, &cfg)
+
+	if cfg.TLD != "dev" {
+		t.Errorf("TLD = %q, want %q after update", cfg.TLD, "dev")
+	}
+}
+
+func TestRemoveSiteTLS(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	certsDir := filepath.Join(home, ".config", "valet", "Certificates")
+	os.MkdirAll(certsDir, 0755)
+
+	// Create dummy cert files.
+	certPath := filepath.Join(certsDir, "myapp.test.crt")
+	keyPath := filepath.Join(certsDir, "myapp.test.key")
+	os.WriteFile(certPath, []byte("cert"), 0644)
+	os.WriteFile(keyPath, []byte("key"), 0600)
+
+	RemoveSiteTLS("myapp.test")
+
+	if _, err := os.Stat(certPath); !os.IsNotExist(err) {
+		t.Error("cert file should be removed")
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Error("key file should be removed")
+	}
+}
+
+func TestRemoveSiteTLS_NonExistent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Should not panic on non-existent files.
+	RemoveSiteTLS("nonexistent.test")
+}
+
+func TestRemoveAll(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := EnsureValetConfig("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := RemoveAll(); err != nil {
+		t.Fatalf("RemoveAll() error = %v", err)
+	}
+
+	valetDir := filepath.Join(home, ".config", "valet")
+	if _, err := os.Stat(valetDir); !os.IsNotExist(err) {
+		t.Error("valet dir should be removed")
+	}
+}

--- a/internal/certs/valet_test.go
+++ b/internal/certs/valet_test.go
@@ -22,12 +22,12 @@ func TestEnsureValetConfig(t *testing.T) {
 		t.Fatalf("read config.json: %v", err)
 	}
 
-	var cfg valetConfig
+	var cfg map[string]any
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		t.Fatalf("parse config.json: %v", err)
 	}
-	if cfg.TLD != "test" {
-		t.Errorf("TLD = %q, want %q", cfg.TLD, "test")
+	if cfg["tld"] != "test" {
+		t.Errorf("TLD = %q, want %q", cfg["tld"], "test")
 	}
 
 	// Verify Certificates directory exists.
@@ -54,11 +54,45 @@ func TestEnsureValetConfig_UpdatesTLD(t *testing.T) {
 
 	configPath := filepath.Join(home, ".config", "valet", "config.json")
 	data, _ := os.ReadFile(configPath)
-	var cfg valetConfig
+	var cfg map[string]any
 	json.Unmarshal(data, &cfg)
 
-	if cfg.TLD != "dev" {
-		t.Errorf("TLD = %q, want %q after update", cfg.TLD, "dev")
+	if cfg["tld"] != "dev" {
+		t.Errorf("TLD = %q, want %q after update", cfg["tld"], "dev")
+	}
+}
+
+func TestEnsureValetConfig_PreservesExistingFields(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Write a pre-existing config with extra fields (e.g., real Valet config).
+	configDir := filepath.Join(home, ".config", "valet")
+	os.MkdirAll(configDir, 0755)
+	existing := map[string]any{
+		"tld":      "local",
+		"loopback": "127.0.0.1",
+		"paths":    []string{"/home/user/Sites"},
+	}
+	data, _ := json.Marshal(existing)
+	os.WriteFile(filepath.Join(configDir, "config.json"), data, 0644)
+
+	if err := EnsureValetConfig("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	result, _ := os.ReadFile(filepath.Join(configDir, "config.json"))
+	var cfg map[string]any
+	json.Unmarshal(result, &cfg)
+
+	if cfg["tld"] != "test" {
+		t.Errorf("TLD = %q, want %q", cfg["tld"], "test")
+	}
+	if cfg["loopback"] != "127.0.0.1" {
+		t.Error("existing loopback field was lost")
+	}
+	if cfg["paths"] == nil {
+		t.Error("existing paths field was lost")
 	}
 }
 
@@ -75,7 +109,9 @@ func TestRemoveSiteTLS(t *testing.T) {
 	os.WriteFile(certPath, []byte("cert"), 0644)
 	os.WriteFile(keyPath, []byte("key"), 0600)
 
-	RemoveSiteTLS("myapp.test")
+	if err := RemoveSiteTLS("myapp.test"); err != nil {
+		t.Fatalf("RemoveSiteTLS() error = %v", err)
+	}
 
 	if _, err := os.Stat(certPath); !os.IsNotExist(err) {
 		t.Error("cert file should be removed")
@@ -89,11 +125,50 @@ func TestRemoveSiteTLS_NonExistent(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// Should not panic on non-existent files.
-	RemoveSiteTLS("nonexistent.test")
+	// Should not error on non-existent files.
+	if err := RemoveSiteTLS("nonexistent.test"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
-func TestRemoveAll(t *testing.T) {
+func TestRemoveLinkedCerts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	certsDir := filepath.Join(home, ".config", "valet", "Certificates")
+	os.MkdirAll(certsDir, 0755)
+
+	// Create certs for two "linked" apps and one "other" app.
+	for _, name := range []string{"app1.test", "app2.test", "other.test"} {
+		os.WriteFile(filepath.Join(certsDir, name+".crt"), []byte("cert"), 0644)
+		os.WriteFile(filepath.Join(certsDir, name+".key"), []byte("key"), 0600)
+	}
+
+	// Only remove linked apps.
+	if err := RemoveLinkedCerts([]string{"app1.test", "app2.test"}); err != nil {
+		t.Fatalf("RemoveLinkedCerts() error = %v", err)
+	}
+
+	// Linked certs should be gone.
+	for _, name := range []string{"app1.test", "app2.test"} {
+		if _, err := os.Stat(filepath.Join(certsDir, name+".crt")); !os.IsNotExist(err) {
+			t.Errorf("%s.crt should be removed", name)
+		}
+		if _, err := os.Stat(filepath.Join(certsDir, name+".key")); !os.IsNotExist(err) {
+			t.Errorf("%s.key should be removed", name)
+		}
+	}
+
+	// Other cert should still exist.
+	if _, err := os.Stat(filepath.Join(certsDir, "other.test.crt")); err != nil {
+		t.Error("other.test.crt should NOT be removed")
+	}
+	if _, err := os.Stat(filepath.Join(certsDir, "other.test.key")); err != nil {
+		t.Error("other.test.key should NOT be removed")
+	}
+}
+
+func TestRemoveConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -101,12 +176,41 @@ func TestRemoveAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := RemoveAll(); err != nil {
-		t.Fatalf("RemoveAll() error = %v", err)
+	if err := RemoveConfig(); err != nil {
+		t.Fatalf("RemoveConfig() error = %v", err)
 	}
 
-	valetDir := filepath.Join(home, ".config", "valet")
-	if _, err := os.Stat(valetDir); !os.IsNotExist(err) {
-		t.Error("valet dir should be removed")
+	configPath := filepath.Join(home, ".config", "valet", "config.json")
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Error("config.json should be removed")
+	}
+
+	// Certificates directory should still exist.
+	certsDir := filepath.Join(home, ".config", "valet", "Certificates")
+	if _, err := os.Stat(certsDir); err != nil {
+		t.Error("Certificates dir should NOT be removed")
+	}
+}
+
+func TestRemoveConfig_NonExistent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Should not error when config doesn't exist.
+	if err := RemoveConfig(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValetConfigDir_ReturnsAbsolutePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir, err := ValetConfigDir()
+	if err != nil {
+		t.Fatalf("ValetConfigDir() error = %v", err)
+	}
+	if !filepath.IsAbs(dir) {
+		t.Errorf("ValetConfigDir() = %q, want absolute path", dir)
 	}
 }

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -139,6 +139,11 @@ func CACertPath() string {
 	return filepath.Join(PvDir(), "caddy", "pki", "authorities", "local", "root.crt")
 }
 
+// CAKeyPath returns the path to Caddy's local CA private key.
+func CAKeyPath() string {
+	return filepath.Join(PvDir(), "caddy", "pki", "authorities", "local", "root.key")
+}
+
 func ServicesDir() string {
 	return filepath.Join(PvDir(), "services")
 }


### PR DESCRIPTION
## Summary

- Fixes mixed content errors when using Vite dev server with pv's HTTPS sites
- `pv link` now generates per-site TLS certificates signed by Caddy's local CA and places them at `~/.config/valet/Certificates/` where `laravel-vite-plugin` auto-detects them
- `npm run dev` just works — zero configuration needed

## How it works

`laravel-vite-plugin` has built-in detection for Valet/Herd TLS certificates. It checks `~/.config/valet/` for:
- `config.json` with the TLD (e.g., `{"tld": "test"}`)
- `Certificates/{hostname}.key` and `.crt`

When found, Vite's dev server automatically serves HTTPS on the `.test` domain, and the hot file URL uses HTTPS — so `@vite` generates correct `<script>` tags with no mixed content.

pv now populates this structure:
- **`pv link`**: generates cert + writes `config.json`
- **`pv unlink`**: removes the site's cert files
- **`pv setup`**: writes `config.json` when TLD is configured
- **`pv uninstall`**: cleans up `~/.config/valet/`

## Test plan

- [x] Unit tests for cert generation (CA signing, SAN, key permissions)
- [x] Unit tests for Valet config management (config.json, cert cleanup)
- [x] All existing tests pass
- [ ] Manual: `pv link myapp` → verify `~/.config/valet/Certificates/myapp.test.{crt,key}` exist
- [ ] Manual: `cd myapp && npm run dev` → verify Vite console shows "Using Valet certificate to secure Vite"
- [ ] Manual: visit `https://myapp.test` → verify no mixed content errors, HMR works
- [ ] Manual: `pv unlink myapp` → verify cert files removed