### PR TITLE
Smart automation for Laravel project bootstrapping

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -1,17 +1,21 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/prvious/pv/internal/automation"
 	"github.com/prvious/pv/internal/caddy"
 	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/detection"
+	"github.com/prvious/pv/internal/laravel"
 	"github.com/prvious/pv/internal/phpenv"
 	"github.com/prvious/pv/internal/registry"
 	"github.com/prvious/pv/internal/server"
+	"github.com/prvious/pv/internal/services"
 	"github.com/prvious/pv/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -87,6 +91,54 @@ pv link --name=myapp ~/Code/myapp`,
 			return fmt.Errorf("cannot save registry: %w", err)
 		}
 
+		// Automation context — declared here so both pre and post steps can access it.
+		var autoCtx *automation.Context
+
+		// Pre-Caddyfile automation steps for Laravel projects.
+		if projectType == "laravel" || projectType == "laravel-octane" {
+			autoCtx = &automation.Context{
+				ProjectPath: absPath,
+				ProjectName: name,
+				ProjectType: projectType,
+				PHPVersion:  phpVersion,
+				TLD:         settings.Defaults.TLD,
+				Registry:    reg,
+				Settings:    settings,
+				Env:         make(map[string]string),
+			}
+
+			// Load existing .env if present.
+			if envVars, err := services.ReadDotEnv(filepath.Join(absPath, ".env")); err == nil {
+				autoCtx.Env = envVars
+			}
+
+			preSteps := []automation.Step{
+				&laravel.CopyEnvStep{},
+				&laravel.GenerateKeyStep{},
+				&laravel.InstallOctaneStep{},
+				&laravel.ComposerInstallStep{},
+			}
+			if err := automation.RunPipeline(preSteps, autoCtx); err != nil {
+				if !errors.Is(err, ui.ErrAlreadyPrinted) {
+					return err
+				}
+			}
+
+			// Re-detect if Octane was installed.
+			if laravel.HasOctaneWorker(absPath) && projectType != "laravel-octane" {
+				projectType = "laravel-octane"
+				for i := range reg.Projects {
+					if reg.Projects[i].Name == name {
+						reg.Projects[i].Type = "laravel-octane"
+						break
+					}
+				}
+				project.Type = "laravel-octane"
+				autoCtx.ProjectType = "laravel-octane"
+				_ = reg.Save()
+			}
+		}
+
 		if err := caddy.GenerateSiteConfig(project, globalPHP); err != nil {
 			return fmt.Errorf("cannot generate site config: %w", err)
 		}
@@ -123,6 +175,21 @@ pv link --name=myapp ~/Code/myapp`,
 		// Save again in case services were bound.
 		if err := reg.Save(); err != nil {
 			return fmt.Errorf("cannot save registry: %w", err)
+		}
+
+		// Post-binding automation steps for Laravel projects.
+		if autoCtx != nil {
+			postSteps := []automation.Step{
+				&laravel.DetectServicesStep{},
+				&laravel.SetAppURLStep{},
+				&laravel.CreateDatabaseStep{},
+				&laravel.RunMigrationsStep{},
+			}
+			if err := automation.RunPipeline(postSteps, autoCtx); err != nil {
+				if !errors.Is(err, ui.ErrAlreadyPrinted) {
+					return err
+				}
+			}
 		}
 
 		if server.IsRunning() {

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -114,14 +113,12 @@ pv link --name=myapp ~/Code/myapp`,
 
 			preSteps := []automation.Step{
 				&laravel.CopyEnvStep{},
+				&laravel.ComposerInstallStep{},
 				&laravel.GenerateKeyStep{},
 				&laravel.InstallOctaneStep{},
-				&laravel.ComposerInstallStep{},
 			}
 			if err := automation.RunPipeline(preSteps, autoCtx); err != nil {
-				if !errors.Is(err, ui.ErrAlreadyPrinted) {
-					return err
-				}
+				return err
 			}
 
 			// Re-detect if Octane was installed.
@@ -135,7 +132,9 @@ pv link --name=myapp ~/Code/myapp`,
 				}
 				project.Type = "laravel-octane"
 				autoCtx.ProjectType = "laravel-octane"
-				_ = reg.Save()
+				if err := reg.Save(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not persist Octane re-detection: %v", err))
+				}
 			}
 		}
 
@@ -186,9 +185,7 @@ pv link --name=myapp ~/Code/myapp`,
 				&laravel.RunMigrationsStep{},
 			}
 			if err := automation.RunPipeline(postSteps, autoCtx); err != nil {
-				if !errors.Is(err, ui.ErrAlreadyPrinted) {
-					return err
-				}
+				return err
 			}
 		}
 

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -201,6 +201,8 @@ pv link --name=myapp ~/Code/myapp`,
 			}
 		}
 
+		server.WatchProject(name, absPath)
+
 		return nil
 	},
 }

--- a/cmd/link_test.go
+++ b/cmd/link_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/services"
 	"github.com/spf13/cobra"
 )
 
@@ -299,5 +300,177 @@ func TestLink_CreatesCaddyfile(t *testing.T) {
 	}
 	if !strings.Contains(content, "import sites/*") {
 		t.Error("expected 'import sites/*' in Caddyfile")
+	}
+}
+
+// scaffoldLaravelProject creates a minimal Laravel project directory for testing.
+// It creates composer.json, .env.example, and a vendor/ dir (to prevent
+// ComposerInstallStep from trying to run the real composer binary).
+func scaffoldLaravelProject(t *testing.T, name string) string {
+	t.Helper()
+	projDir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(projDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	composerJSON := `{"require":{"laravel/framework":"^11.0"}}`
+	if err := os.WriteFile(filepath.Join(projDir, "composer.json"), []byte(composerJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	envExample := "APP_NAME=Laravel\nAPP_KEY=\nAPP_URL=http://localhost\nDB_CONNECTION=sqlite\n"
+	if err := os.WriteFile(filepath.Join(projDir, ".env.example"), []byte(envExample), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Create vendor/ so ComposerInstallStep is skipped (no real composer in tests).
+	if err := os.MkdirAll(filepath.Join(projDir, "vendor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return projDir
+}
+
+func TestLink_AutomationCopiesEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	writeDefaultSettings(t)
+
+	projDir := scaffoldLaravelProject(t, "envtest")
+
+	cmd := newLinkCmd()
+	cmd.SetArgs([]string{"link", projDir, "--name", "envtest"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("link command error = %v", err)
+	}
+
+	// .env should have been created by CopyEnvStep.
+	envPath := filepath.Join(projDir, ".env")
+	if _, err := os.Stat(envPath); os.IsNotExist(err) {
+		t.Fatal(".env was not created by automation pipeline")
+	}
+
+	env, err := services.ReadDotEnv(envPath)
+	if err != nil {
+		t.Fatalf("failed to read .env: %v", err)
+	}
+	if env["APP_NAME"] != "Laravel" {
+		t.Errorf("APP_NAME = %q, want %q", env["APP_NAME"], "Laravel")
+	}
+}
+
+func TestLink_AutomationSetsAppURL(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	writeDefaultSettings(t)
+
+	projDir := scaffoldLaravelProject(t, "urltest")
+
+	cmd := newLinkCmd()
+	cmd.SetArgs([]string{"link", projDir, "--name", "urltest"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("link command error = %v", err)
+	}
+
+	env, err := services.ReadDotEnv(filepath.Join(projDir, ".env"))
+	if err != nil {
+		t.Fatalf("failed to read .env: %v", err)
+	}
+	want := "https://urltest.test"
+	if env["APP_URL"] != want {
+		t.Errorf("APP_URL = %q, want %q", env["APP_URL"], want)
+	}
+}
+
+func TestLink_AutomationSkippedForNonLaravel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	writeDefaultSettings(t)
+
+	projDir := filepath.Join(t.TempDir(), "plainphp")
+	if err := os.MkdirAll(projDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a .env.example but no laravel/framework in composer.json.
+	if err := os.WriteFile(filepath.Join(projDir, ".env.example"), []byte("APP_KEY=\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projDir, "index.php"), []byte("<?php echo 'hi';"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newLinkCmd()
+	cmd.SetArgs([]string{"link", projDir, "--name", "plainphp"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("link command error = %v", err)
+	}
+
+	// .env should NOT have been created — automation only runs for Laravel.
+	if _, err := os.Stat(filepath.Join(projDir, ".env")); !os.IsNotExist(err) {
+		t.Error(".env should not exist for non-Laravel project")
+	}
+}
+
+func TestLink_AutomationRedetectsOctane(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	writeDefaultSettings(t)
+
+	projDir := scaffoldLaravelProject(t, "octanetest")
+
+	// Simulate Octane: add octane to composer.json and pre-create the worker file
+	// (since artisan octane:install can't run in tests).
+	composerJSON := `{"require":{"laravel/framework":"^11.0","laravel/octane":"^2.0"}}`
+	if err := os.WriteFile(filepath.Join(projDir, "composer.json"), []byte(composerJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(projDir, "public"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projDir, "public", "frankenphp-worker.php"), []byte("<?php"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newLinkCmd()
+	cmd.SetArgs([]string{"link", projDir, "--name", "octanetest"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("link command error = %v", err)
+	}
+
+	reg, err := registry.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	p := reg.Find("octanetest")
+	if p == nil {
+		t.Fatal("project not found")
+	}
+	if p.Type != "laravel-octane" {
+		t.Errorf("Type = %q, want %q", p.Type, "laravel-octane")
+	}
+}
+
+func TestLink_AutomationLoadsExistingEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	writeDefaultSettings(t)
+
+	projDir := scaffoldLaravelProject(t, "existingenv")
+
+	// Pre-create .env so CopyEnvStep is skipped but the file is loaded into context.
+	envContent := "APP_NAME=Existing\nAPP_KEY=base64:existingkey\nAPP_URL=http://localhost\n"
+	if err := os.WriteFile(filepath.Join(projDir, ".env"), []byte(envContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newLinkCmd()
+	cmd.SetArgs([]string{"link", projDir, "--name", "existingenv"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("link command error = %v", err)
+	}
+
+	// SetAppURLStep should have updated APP_URL even with pre-existing .env.
+	env, err := services.ReadDotEnv(filepath.Join(projDir, ".env"))
+	if err != nil {
+		t.Fatalf("failed to read .env: %v", err)
+	}
+	want := "https://existingenv.test"
+	if env["APP_URL"] != want {
+		t.Errorf("APP_URL = %q, want %q", env["APP_URL"], want)
+	}
+	// APP_KEY should remain unchanged (GenerateKeyStep skipped because key is set).
+	if env["APP_KEY"] != "base64:existingkey" {
+		t.Errorf("APP_KEY = %q, want %q", env["APP_KEY"], "base64:existingkey")
 	}
 }

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -46,14 +46,18 @@ pv unlink`,
 			name = p.Name
 		}
 
-		// Check project exists before removing.
-		if reg.Find(name) == nil {
+		// Check project exists before removing and capture path for unwatching.
+		project := reg.Find(name)
+		if project == nil {
 			return fmt.Errorf("project %q is not linked", name)
 		}
+		projectPath := project.Path
 
 		if err := reg.Remove(name); err != nil {
 			return err
 		}
+
+		server.UnwatchProject(projectPath)
 
 		if err := reg.Save(); err != nil {
 			return fmt.Errorf("cannot save registry: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	charm.land/huh/v2 v2.0.0-20260226141913-a8934362ea3b
 	charm.land/lipgloss/v2 v2.0.0
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260305213658-fe36e8c10185
+	github.com/charmbracelet/x/term v0.2.2
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/miekg/dns v1.1.72
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
@@ -22,7 +24,6 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/automation/pipeline.go
+++ b/internal/automation/pipeline.go
@@ -1,6 +1,7 @@
 package automation
 
 import (
+	"fmt"
 	"os"
 
 	"charm.land/huh/v2"
@@ -37,22 +38,31 @@ var isInteractiveFunc = func() bool {
 	return term.IsTerminal(os.Stdin.Fd())
 }
 
+// IsInteractive returns whether stdin is a TTY.
+// Exported so service hooks can check before prompting.
+func IsInteractive() bool {
+	return isInteractiveFunc()
+}
+
 // ConfirmFunc prompts the user for confirmation. Exported so service hooks
-// in Tier 2 can reference it. Swappable for tests.
-var ConfirmFunc = func(label string) bool {
+// (internal/commands/service/hooks.go) can reuse the same confirmation flow.
+// Swappable for tests.
+var ConfirmFunc = func(label string) (bool, error) {
 	var confirmed bool
 	err := huh.NewConfirm().
 		Title(label + "?").
 		Value(&confirmed).
 		Run()
 	if err != nil {
-		return false
+		return false, err
 	}
-	return confirmed
+	return confirmed, nil
 }
 
 // RunPipeline executes a sequence of Steps, respecting each step's gate
-// setting from the automation config.
+// setting from the automation config. Individual step failures are displayed
+// by ui.Step (✗) but do not abort the pipeline — automation is best-effort.
+// Returns an error only if a user prompt is interrupted (Ctrl+C).
 func RunPipeline(steps []Step, ctx *Context) error {
 	for _, step := range steps {
 		if !step.ShouldRun(ctx) {
@@ -68,23 +78,26 @@ func RunPipeline(steps []Step, ctx *Context) error {
 			if !isInteractiveFunc() {
 				continue
 			}
-			if !ConfirmFunc(step.Label()) {
+			confirmed, err := ConfirmFunc(step.Label())
+			if err != nil {
+				return fmt.Errorf("aborted")
+			}
+			if !confirmed {
 				continue
 			}
 		}
 
 		// AutoOn (or AutoAsk confirmed) — run the step.
-		if err := ui.Step(step.Label(), func() (string, error) {
+		// Step failures are displayed by ui.Step (✗); continue with remaining steps.
+		_ = ui.Step(step.Label(), func() (string, error) {
 			return step.Run(ctx)
-		}); err != nil {
-			return err
-		}
+		})
 	}
 	return nil
 }
 
 // LookupGate maps a gate string to its AutoMode value in the Automation config.
-// Unknown gates default to AutoOn.
+// Unknown gates default to AutoAsk to avoid accidentally running unconfigured steps.
 func LookupGate(a *config.Automation, gate string) config.AutoMode {
 	switch gate {
 	case "composer_install":
@@ -106,6 +119,7 @@ func LookupGate(a *config.Automation, gate string) config.AutoMode {
 	case "service_fallback":
 		return a.ServiceFallback
 	default:
-		return config.AutoOn
+		fmt.Fprintf(os.Stderr, "Warning: unknown automation gate %q, defaulting to ask\n", gate)
+		return config.AutoAsk
 	}
 }

--- a/internal/automation/pipeline.go
+++ b/internal/automation/pipeline.go
@@ -1,0 +1,111 @@
+package automation
+
+import (
+	"os"
+
+	"charm.land/huh/v2"
+	"github.com/charmbracelet/x/term"
+
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/ui"
+)
+
+// Context carries state through an automation pipeline.
+type Context struct {
+	ProjectPath string
+	ProjectName string
+	ProjectType string
+	PHPVersion  string
+	TLD         string
+	Registry    *registry.Registry
+	Settings    *config.Settings
+	Env         map[string]string
+	DBCreated   bool
+}
+
+// Step is a single automation action in a pipeline.
+type Step interface {
+	Label() string
+	Gate() string
+	ShouldRun(ctx *Context) bool
+	Run(ctx *Context) (string, error)
+}
+
+// isInteractiveFunc detects whether stdin is a TTY. Swappable for tests.
+var isInteractiveFunc = func() bool {
+	return term.IsTerminal(os.Stdin.Fd())
+}
+
+// ConfirmFunc prompts the user for confirmation. Exported so service hooks
+// in Tier 2 can reference it. Swappable for tests.
+var ConfirmFunc = func(label string) bool {
+	var confirmed bool
+	err := huh.NewConfirm().
+		Title(label + "?").
+		Value(&confirmed).
+		Run()
+	if err != nil {
+		return false
+	}
+	return confirmed
+}
+
+// RunPipeline executes a sequence of Steps, respecting each step's gate
+// setting from the automation config.
+func RunPipeline(steps []Step, ctx *Context) error {
+	for _, step := range steps {
+		if !step.ShouldRun(ctx) {
+			continue
+		}
+
+		mode := LookupGate(&ctx.Settings.Automation, step.Gate())
+
+		switch mode {
+		case config.AutoOff:
+			continue
+		case config.AutoAsk:
+			if !isInteractiveFunc() {
+				continue
+			}
+			if !ConfirmFunc(step.Label()) {
+				continue
+			}
+		}
+
+		// AutoOn (or AutoAsk confirmed) — run the step.
+		if err := ui.Step(step.Label(), func() (string, error) {
+			return step.Run(ctx)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// LookupGate maps a gate string to its AutoMode value in the Automation config.
+// Unknown gates default to AutoOn.
+func LookupGate(a *config.Automation, gate string) config.AutoMode {
+	switch gate {
+	case "composer_install":
+		return a.ComposerInstall
+	case "copy_env":
+		return a.CopyEnv
+	case "generate_key":
+		return a.GenerateKey
+	case "set_app_url":
+		return a.SetAppURL
+	case "install_octane":
+		return a.InstallOctane
+	case "create_database":
+		return a.CreateDatabase
+	case "run_migrations":
+		return a.RunMigrations
+	case "update_env_on_service":
+		return a.ServiceEnvUpdate
+	case "service_fallback":
+		return a.ServiceFallback
+	default:
+		return config.AutoOn
+	}
+}

--- a/internal/automation/pipeline_test.go
+++ b/internal/automation/pipeline_test.go
@@ -130,7 +130,7 @@ func TestRunPipeline_AskRunsWhenConfirmed(t *testing.T) {
 	defer func() { isInteractiveFunc = origIsInteractive }()
 
 	origConfirm := ConfirmFunc
-	ConfirmFunc = func(label string) bool { return true }
+	ConfirmFunc = func(label string) (bool, error) { return true, nil }
 	defer func() { ConfirmFunc = origConfirm }()
 
 	if err := RunPipeline([]Step{step}, ctx); err != nil {
@@ -158,7 +158,7 @@ func TestRunPipeline_AskSkipsWhenDenied(t *testing.T) {
 	defer func() { isInteractiveFunc = origIsInteractive }()
 
 	origConfirm := ConfirmFunc
-	ConfirmFunc = func(label string) bool { return false }
+	ConfirmFunc = func(label string) (bool, error) { return false, nil }
 	defer func() { ConfirmFunc = origConfirm }()
 
 	if err := RunPipeline([]Step{step}, ctx); err != nil {
@@ -185,7 +185,7 @@ func TestLookupGate(t *testing.T) {
 		{"run_migrations", a.RunMigrations},
 		{"update_env_on_service", a.ServiceEnvUpdate},
 		{"service_fallback", a.ServiceFallback},
-		{"unknown_gate", config.AutoOn},
+		{"unknown_gate", config.AutoAsk},
 	}
 
 	for _, tt := range tests {

--- a/internal/automation/pipeline_test.go
+++ b/internal/automation/pipeline_test.go
@@ -1,0 +1,199 @@
+package automation
+
+import (
+	"testing"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+// stubStep implements Step for testing.
+type stubStep struct {
+	label     string
+	gate      string
+	shouldRun bool
+	result    string
+	err       error
+	ran       bool
+}
+
+func (s *stubStep) Label() string           { return s.label }
+func (s *stubStep) Gate() string            { return s.gate }
+func (s *stubStep) ShouldRun(_ *Context) bool { return s.shouldRun }
+func (s *stubStep) Run(_ *Context) (string, error) {
+	s.ran = true
+	return s.result, s.err
+}
+
+func defaultCtx() *Context {
+	s := config.DefaultSettings()
+	return &Context{
+		ProjectPath: "/tmp/test-project",
+		ProjectName: "test-project",
+		Settings:    s,
+		Env:         make(map[string]string),
+	}
+}
+
+func TestRunPipeline_SkipsWhenShouldRunFalse(t *testing.T) {
+	step := &stubStep{
+		label:     "skip me",
+		gate:      "composer_install",
+		shouldRun: false,
+		result:    "done",
+	}
+
+	ctx := defaultCtx()
+	if err := RunPipeline([]Step{step}, ctx); err != nil {
+		t.Fatalf("RunPipeline() error = %v", err)
+	}
+	if step.ran {
+		t.Error("step should not have run when ShouldRun returns false")
+	}
+}
+
+func TestRunPipeline_SkipsWhenGateOff(t *testing.T) {
+	step := &stubStep{
+		label:     "composer install",
+		gate:      "composer_install",
+		shouldRun: true,
+		result:    "installed",
+	}
+
+	ctx := defaultCtx()
+	ctx.Settings.Automation.ComposerInstall = config.AutoOff
+
+	if err := RunPipeline([]Step{step}, ctx); err != nil {
+		t.Fatalf("RunPipeline() error = %v", err)
+	}
+	if step.ran {
+		t.Error("step should not have run when gate is AutoOff")
+	}
+}
+
+func TestRunPipeline_RunsWhenGateOn(t *testing.T) {
+	step := &stubStep{
+		label:     "composer install",
+		gate:      "composer_install",
+		shouldRun: true,
+		result:    "installed",
+	}
+
+	ctx := defaultCtx()
+	ctx.Settings.Automation.ComposerInstall = config.AutoOn
+
+	if err := RunPipeline([]Step{step}, ctx); err != nil {
+		t.Fatalf("RunPipeline() error = %v", err)
+	}
+	if !step.ran {
+		t.Error("step should have run when gate is AutoOn")
+	}
+}
+
+func TestRunPipeline_AskTreatedAsOffWhenNonInteractive(t *testing.T) {
+	step := &stubStep{
+		label:     "run migrations",
+		gate:      "run_migrations",
+		shouldRun: true,
+		result:    "migrated",
+	}
+
+	ctx := defaultCtx()
+	ctx.Settings.Automation.RunMigrations = config.AutoAsk
+
+	// Force non-interactive
+	origIsInteractive := isInteractiveFunc
+	isInteractiveFunc = func() bool { return false }
+	defer func() { isInteractiveFunc = origIsInteractive }()
+
+	if err := RunPipeline([]Step{step}, ctx); err != nil {
+		t.Fatalf("RunPipeline() error = %v", err)
+	}
+	if step.ran {
+		t.Error("step should not have run when gate is AutoAsk and non-interactive")
+	}
+}
+
+func TestRunPipeline_AskRunsWhenConfirmed(t *testing.T) {
+	step := &stubStep{
+		label:     "run migrations",
+		gate:      "run_migrations",
+		shouldRun: true,
+		result:    "migrated",
+	}
+
+	ctx := defaultCtx()
+	ctx.Settings.Automation.RunMigrations = config.AutoAsk
+
+	// Force interactive + confirm yes
+	origIsInteractive := isInteractiveFunc
+	isInteractiveFunc = func() bool { return true }
+	defer func() { isInteractiveFunc = origIsInteractive }()
+
+	origConfirm := ConfirmFunc
+	ConfirmFunc = func(label string) bool { return true }
+	defer func() { ConfirmFunc = origConfirm }()
+
+	if err := RunPipeline([]Step{step}, ctx); err != nil {
+		t.Fatalf("RunPipeline() error = %v", err)
+	}
+	if !step.ran {
+		t.Error("step should have run when gate is AutoAsk and user confirms")
+	}
+}
+
+func TestRunPipeline_AskSkipsWhenDenied(t *testing.T) {
+	step := &stubStep{
+		label:     "run migrations",
+		gate:      "run_migrations",
+		shouldRun: true,
+		result:    "migrated",
+	}
+
+	ctx := defaultCtx()
+	ctx.Settings.Automation.RunMigrations = config.AutoAsk
+
+	// Force interactive + confirm no
+	origIsInteractive := isInteractiveFunc
+	isInteractiveFunc = func() bool { return true }
+	defer func() { isInteractiveFunc = origIsInteractive }()
+
+	origConfirm := ConfirmFunc
+	ConfirmFunc = func(label string) bool { return false }
+	defer func() { ConfirmFunc = origConfirm }()
+
+	if err := RunPipeline([]Step{step}, ctx); err != nil {
+		t.Fatalf("RunPipeline() error = %v", err)
+	}
+	if step.ran {
+		t.Error("step should not have run when gate is AutoAsk and user denies")
+	}
+}
+
+func TestLookupGate(t *testing.T) {
+	a := config.DefaultAutomation()
+
+	tests := []struct {
+		gate string
+		want config.AutoMode
+	}{
+		{"composer_install", a.ComposerInstall},
+		{"copy_env", a.CopyEnv},
+		{"generate_key", a.GenerateKey},
+		{"set_app_url", a.SetAppURL},
+		{"install_octane", a.InstallOctane},
+		{"create_database", a.CreateDatabase},
+		{"run_migrations", a.RunMigrations},
+		{"update_env_on_service", a.ServiceEnvUpdate},
+		{"service_fallback", a.ServiceFallback},
+		{"unknown_gate", config.AutoOn},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.gate, func(t *testing.T) {
+			got := LookupGate(&a, tt.gate)
+			if got != tt.want {
+				t.Errorf("LookupGate(%q) = %q, want %q", tt.gate, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/caddy/caddy.go
+++ b/internal/caddy/caddy.go
@@ -33,6 +33,7 @@ const laravelOctaneTmpl = `{{.Name}}.{{.TLD}} {
             file frankenphp-worker.php
             num 1
             watch {{.Path}}/**/*.php
+            watch {{.Path}}/vendor/autoload.php
         }
     }
 }
@@ -87,6 +88,7 @@ const versionLaravelOctaneTmpl = `http://{{.Name}}.{{.TLD}} {
             file frankenphp-worker.php
             num 1
             watch {{.Path}}/**/*.php
+            watch {{.Path}}/vendor/autoload.php
         }
     }
 }

--- a/internal/caddy/caddy_test.go
+++ b/internal/caddy/caddy_test.go
@@ -72,6 +72,40 @@ func TestGenerateSiteConfig_LaravelOctane(t *testing.T) {
 	}
 }
 
+func TestOctaneTemplate_WatchesAutoload(t *testing.T) {
+	scaffold(t)
+
+	projDir := t.TempDir()
+	p := registry.Project{Name: "octane-autoload", Path: projDir, Type: "laravel-octane"}
+
+	if err := GenerateSiteConfig(p, ""); err != nil {
+		t.Fatalf("GenerateSiteConfig() error = %v", err)
+	}
+
+	content := readSiteConfig(t, "octane-autoload")
+
+	if !strings.Contains(content, "vendor/autoload.php") {
+		t.Errorf("expected 'vendor/autoload.php' watch directive in Octane config, got:\n%s", content)
+	}
+}
+
+func TestOctaneTemplate_WatchesAutoload_VersionSpecific(t *testing.T) {
+	scaffold(t)
+
+	projDir := t.TempDir()
+	p := registry.Project{Name: "octane-ver", Path: projDir, Type: "laravel-octane", PHP: "8.3"}
+
+	if err := GenerateSiteConfig(p, "8.4"); err != nil {
+		t.Fatalf("GenerateSiteConfig() error = %v", err)
+	}
+
+	content := readVersionSiteConfig(t, "8.3", "octane-ver")
+
+	if !strings.Contains(content, "vendor/autoload.php") {
+		t.Errorf("expected 'vendor/autoload.php' watch directive in version Octane config, got:\n%s", content)
+	}
+}
+
 func TestGenerateSiteConfig_Laravel(t *testing.T) {
 	scaffold(t)
 

--- a/internal/commands/service/add.go
+++ b/internal/commands/service/add.go
@@ -123,6 +123,9 @@ pv service:add postgres 16`,
 			return fmt.Errorf("cannot save registry: %w", err)
 		}
 
+		// Update .env for linked Laravel projects.
+		updateLinkedProjectsEnv(reg, svcName, svc, version)
+
 		// Regenerate Caddy configs for service consoles (*.pv.{tld}).
 		if err := caddy.GenerateServiceSiteConfigs(reg); err != nil {
 			ui.Subtle(fmt.Sprintf("Could not generate service site config: %v", err))

--- a/internal/commands/service/hooks.go
+++ b/internal/commands/service/hooks.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/laravel"
+	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/services"
+	"github.com/prvious/pv/internal/ui"
+)
+
+func extractServiceName(key string) string {
+	if idx := strings.Index(key, ":"); idx > 0 {
+		return key[:idx]
+	}
+	return key
+}
+
+func extractVersion(key string) string {
+	if idx := strings.Index(key, ":"); idx > 0 {
+		return key[idx+1:]
+	}
+	return "latest"
+}
+
+// updateLinkedProjectsEnv updates .env for all linked Laravel projects
+// when a service is added or started.
+func updateLinkedProjectsEnv(reg *registry.Registry, svcName string, svc services.Service, version string) {
+	settings, err := config.LoadSettings()
+	if err != nil || settings.Automation.ServiceEnvUpdate == config.AutoOff {
+		return
+	}
+
+	var laravelProjects []registry.Project
+	for _, p := range reg.List() {
+		if p.Type == "laravel" || p.Type == "laravel-octane" {
+			laravelProjects = append(laravelProjects, p)
+		}
+	}
+	if len(laravelProjects) == 0 {
+		return
+	}
+
+	shouldUpdate := settings.Automation.ServiceEnvUpdate == config.AutoOn
+	if settings.Automation.ServiceEnvUpdate == config.AutoAsk {
+		shouldUpdate = automation.ConfirmFunc(
+			fmt.Sprintf("Update .env for %d linked Laravel project(s)", len(laravelProjects)),
+		)
+	}
+	if !shouldUpdate {
+		return
+	}
+
+	for _, p := range laravelProjects {
+		project := reg.Find(p.Name)
+		if project == nil || project.Services == nil {
+			continue
+		}
+		if err := laravel.UpdateProjectEnvForService(
+			p.Path, p.Name, svcName, svc, svc.Port(version), project.Services,
+		); err != nil {
+			ui.Subtle(fmt.Sprintf("Could not update .env for %s: %v", p.Name, err))
+		} else {
+			ui.Success(fmt.Sprintf("Updated .env for %s", p.Name))
+		}
+	}
+}
+
+// applyFallbacksToLinkedProjects applies safe env fallbacks when a service
+// is stopped or removed.
+func applyFallbacksToLinkedProjects(reg *registry.Registry, svcName string) {
+	settings, err := config.LoadSettings()
+	if err != nil || settings.Automation.ServiceFallback == config.AutoOff {
+		return
+	}
+
+	projectNames := reg.ProjectsUsingService(svcName)
+	if len(projectNames) == 0 {
+		return
+	}
+
+	shouldFallback := settings.Automation.ServiceFallback == config.AutoOn
+	if settings.Automation.ServiceFallback == config.AutoAsk {
+		shouldFallback = automation.ConfirmFunc(
+			fmt.Sprintf("Apply env fallbacks for %s to %d project(s)", svcName, len(projectNames)),
+		)
+	}
+	if !shouldFallback {
+		return
+	}
+
+	for _, pName := range projectNames {
+		project := reg.Find(pName)
+		if project == nil {
+			continue
+		}
+		envPath := filepath.Join(project.Path, ".env")
+		if err := laravel.ApplyFallbacks(envPath, svcName); err != nil {
+			ui.Subtle(fmt.Sprintf("Could not apply fallbacks for %s: %v", pName, err))
+		} else {
+			ui.Success(fmt.Sprintf("Applied %s fallbacks for %s", svcName, pName))
+		}
+	}
+}

--- a/internal/commands/service/hooks.go
+++ b/internal/commands/service/hooks.go
@@ -28,10 +28,14 @@ func extractVersion(key string) string {
 }
 
 // updateLinkedProjectsEnv updates .env for all linked Laravel projects
-// when a service is added or started.
+// (including Octane) when a service is added or started.
 func updateLinkedProjectsEnv(reg *registry.Registry, svcName string, svc services.Service, version string) {
 	settings, err := config.LoadSettings()
-	if err != nil || settings.Automation.ServiceEnvUpdate == config.AutoOff {
+	if err != nil {
+		ui.Subtle(fmt.Sprintf("Could not load settings for service env hooks: %v", err))
+		return
+	}
+	if settings.Automation.ServiceEnvUpdate == config.AutoOff {
 		return
 	}
 
@@ -47,9 +51,16 @@ func updateLinkedProjectsEnv(reg *registry.Registry, svcName string, svc service
 
 	shouldUpdate := settings.Automation.ServiceEnvUpdate == config.AutoOn
 	if settings.Automation.ServiceEnvUpdate == config.AutoAsk {
-		shouldUpdate = automation.ConfirmFunc(
+		if !automation.IsInteractive() {
+			return
+		}
+		confirmed, err := automation.ConfirmFunc(
 			fmt.Sprintf("Update .env for %d linked Laravel project(s)", len(laravelProjects)),
 		)
+		if err != nil {
+			return
+		}
+		shouldUpdate = confirmed
 	}
 	if !shouldUpdate {
 		return
@@ -74,7 +85,11 @@ func updateLinkedProjectsEnv(reg *registry.Registry, svcName string, svc service
 // is stopped or removed.
 func applyFallbacksToLinkedProjects(reg *registry.Registry, svcName string) {
 	settings, err := config.LoadSettings()
-	if err != nil || settings.Automation.ServiceFallback == config.AutoOff {
+	if err != nil {
+		ui.Subtle(fmt.Sprintf("Could not load settings for service fallback hooks: %v", err))
+		return
+	}
+	if settings.Automation.ServiceFallback == config.AutoOff {
 		return
 	}
 
@@ -85,9 +100,16 @@ func applyFallbacksToLinkedProjects(reg *registry.Registry, svcName string) {
 
 	shouldFallback := settings.Automation.ServiceFallback == config.AutoOn
 	if settings.Automation.ServiceFallback == config.AutoAsk {
-		shouldFallback = automation.ConfirmFunc(
+		if !automation.IsInteractive() {
+			return
+		}
+		confirmed, err := automation.ConfirmFunc(
 			fmt.Sprintf("Apply env fallbacks for %s to %d project(s)", svcName, len(projectNames)),
 		)
+		if err != nil {
+			return
+		}
+		shouldFallback = confirmed
 	}
 	if !shouldFallback {
 		return

--- a/internal/commands/service/hooks_test.go
+++ b/internal/commands/service/hooks_test.go
@@ -54,7 +54,7 @@ func TestApplyFallbacksToLinkedProjects_Integration(t *testing.T) {
 	}
 
 	origConfirm := automation.ConfirmFunc
-	automation.ConfirmFunc = func(label string) bool { return true }
+	automation.ConfirmFunc = func(label string) (bool, error) { return true, nil }
 	defer func() { automation.ConfirmFunc = origConfirm }()
 
 	applyFallbacksToLinkedProjects(reg, "redis")

--- a/internal/commands/service/hooks_test.go
+++ b/internal/commands/service/hooks_test.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/services"
+)
+
+func TestExtractServiceName(t *testing.T) {
+	tests := []struct{ key, want string }{
+		{"mysql:8.0.32", "mysql"},
+		{"redis", "redis"},
+		{"postgres:16", "postgres"},
+	}
+	for _, tt := range tests {
+		if got := extractServiceName(tt.key); got != tt.want {
+			t.Errorf("extractServiceName(%q) = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestExtractVersion(t *testing.T) {
+	tests := []struct{ key, want string }{
+		{"mysql:8.0.32", "8.0.32"},
+		{"redis", "latest"},
+		{"postgres:16", "16"},
+	}
+	for _, tt := range tests {
+		if got := extractVersion(tt.key); got != tt.want {
+			t.Errorf("extractVersion(%q) = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestApplyFallbacksToLinkedProjects_Integration(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	projectDir := t.TempDir()
+	envPath := filepath.Join(projectDir, ".env")
+	os.WriteFile(envPath, []byte("CACHE_STORE=redis\nSESSION_DRIVER=redis\n"), 0644)
+
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{
+			"redis": {Image: "redis:latest", Port: 6379},
+		},
+		Projects: []registry.Project{
+			{Name: "test-app", Path: projectDir, Type: "laravel",
+				Services: &registry.ProjectServices{Redis: true}},
+		},
+	}
+
+	origConfirm := automation.ConfirmFunc
+	automation.ConfirmFunc = func(label string) bool { return true }
+	defer func() { automation.ConfirmFunc = origConfirm }()
+
+	applyFallbacksToLinkedProjects(reg, "redis")
+
+	env, _ := services.ReadDotEnv(envPath)
+	if env["CACHE_STORE"] != "file" {
+		t.Errorf("CACHE_STORE = %q, want file", env["CACHE_STORE"])
+	}
+	if env["SESSION_DRIVER"] != "file" {
+		t.Errorf("SESSION_DRIVER = %q, want file", env["SESSION_DRIVER"])
+	}
+}

--- a/internal/commands/service/remove.go
+++ b/internal/commands/service/remove.go
@@ -48,7 +48,9 @@ var removeCmd = &cobra.Command{
 		}
 
 		// Regenerate Caddy configs for service consoles.
-		_ = caddy.GenerateServiceSiteConfigs(reg)
+		if err := caddy.GenerateServiceSiteConfigs(reg); err != nil {
+			ui.Subtle(fmt.Sprintf("Could not regenerate service site configs: %v", err))
+		}
 
 		// Determine data path for the message.
 		version := extractVersion(key)

--- a/internal/commands/service/remove.go
+++ b/internal/commands/service/remove.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/prvious/pv/internal/caddy"
 	"github.com/prvious/pv/internal/config"
@@ -36,6 +35,11 @@ var removeCmd = &cobra.Command{
 			return err
 		}
 
+		// Apply fallbacks and unbind before removing from registry.
+		svcName := extractServiceName(key)
+		applyFallbacksToLinkedProjects(reg, svcName)
+		reg.UnbindService(svcName)
+
 		if err := reg.RemoveService(key); err != nil {
 			return err
 		}
@@ -47,12 +51,7 @@ var removeCmd = &cobra.Command{
 		_ = caddy.GenerateServiceSiteConfigs(reg)
 
 		// Determine data path for the message.
-		svcName := key
-		version := "latest"
-		if idx := strings.Index(key, ":"); idx > 0 {
-			svcName = key[:idx]
-			version = key[idx+1:]
-		}
+		version := extractVersion(key)
 		dataDir := config.ServiceDataDir(svcName, version)
 
 		ui.Subtle(fmt.Sprintf("Data preserved at %s", dataDir))

--- a/internal/commands/service/start.go
+++ b/internal/commands/service/start.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prvious/pv/internal/colima"
 	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/services"
 	"github.com/prvious/pv/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -45,6 +46,11 @@ var startCmd = &cobra.Command{
 				}); err != nil {
 					return err
 				}
+				svcName := extractServiceName(key)
+				svc, lookupErr := services.Lookup(svcName)
+				if lookupErr == nil {
+					updateLinkedProjectsEnv(reg, svcName, svc, extractVersion(key))
+				}
 			}
 		} else {
 			key := args[0]
@@ -57,6 +63,11 @@ var startCmd = &cobra.Command{
 				return fmt.Sprintf("%s started", key), nil
 			}); err != nil {
 				return err
+			}
+			svcName := extractServiceName(key)
+			svc, lookupErr := services.Lookup(svcName)
+			if lookupErr == nil {
+				updateLinkedProjectsEnv(reg, svcName, svc, extractVersion(key))
 			}
 		}
 

--- a/internal/commands/service/start.go
+++ b/internal/commands/service/start.go
@@ -48,7 +48,9 @@ var startCmd = &cobra.Command{
 				}
 				svcName := extractServiceName(key)
 				svc, lookupErr := services.Lookup(svcName)
-				if lookupErr == nil {
+				if lookupErr != nil {
+					ui.Subtle(fmt.Sprintf("Could not look up %s for env update: %v", svcName, lookupErr))
+				} else {
 					updateLinkedProjectsEnv(reg, svcName, svc, extractVersion(key))
 				}
 			}
@@ -66,7 +68,9 @@ var startCmd = &cobra.Command{
 			}
 			svcName := extractServiceName(key)
 			svc, lookupErr := services.Lookup(svcName)
-			if lookupErr == nil {
+			if lookupErr != nil {
+				ui.Subtle(fmt.Sprintf("Could not look up %s for env update: %v", svcName, lookupErr))
+			} else {
 				updateLinkedProjectsEnv(reg, svcName, svc, extractVersion(key))
 			}
 		}

--- a/internal/commands/service/stop.go
+++ b/internal/commands/service/stop.go
@@ -38,6 +38,10 @@ var stopCmd = &cobra.Command{
 					return err
 				}
 			}
+			// Apply fallbacks for each stopped service.
+			for key := range reg.ListServices() {
+				applyFallbacksToLinkedProjects(reg, extractServiceName(key))
+			}
 		} else {
 			key := args[0]
 			if reg.FindService(key) == nil {
@@ -50,6 +54,8 @@ var stopCmd = &cobra.Command{
 			}); err != nil {
 				return err
 			}
+			// Apply fallbacks for the stopped service.
+			applyFallbacksToLinkedProjects(reg, extractServiceName(args[0]))
 		}
 
 		fmt.Fprintln(os.Stderr)

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -57,34 +57,39 @@ func DefaultAutomation() Automation {
 	}
 }
 
-// applyAutomationDefaults fills empty Automation fields with defaults.
+func validAutoMode(m AutoMode) bool {
+	return m == AutoOn || m == AutoOff || m == AutoAsk
+}
+
+// applyAutomationDefaults fills empty Automation fields with defaults
+// and replaces invalid values with the default.
 func applyAutomationDefaults(a *Automation) {
 	d := DefaultAutomation()
-	if a.ComposerInstall == "" {
+	if !validAutoMode(a.ComposerInstall) {
 		a.ComposerInstall = d.ComposerInstall
 	}
-	if a.CopyEnv == "" {
+	if !validAutoMode(a.CopyEnv) {
 		a.CopyEnv = d.CopyEnv
 	}
-	if a.GenerateKey == "" {
+	if !validAutoMode(a.GenerateKey) {
 		a.GenerateKey = d.GenerateKey
 	}
-	if a.SetAppURL == "" {
+	if !validAutoMode(a.SetAppURL) {
 		a.SetAppURL = d.SetAppURL
 	}
-	if a.InstallOctane == "" {
+	if !validAutoMode(a.InstallOctane) {
 		a.InstallOctane = d.InstallOctane
 	}
-	if a.CreateDatabase == "" {
+	if !validAutoMode(a.CreateDatabase) {
 		a.CreateDatabase = d.CreateDatabase
 	}
-	if a.RunMigrations == "" {
+	if !validAutoMode(a.RunMigrations) {
 		a.RunMigrations = d.RunMigrations
 	}
-	if a.ServiceEnvUpdate == "" {
+	if !validAutoMode(a.ServiceEnvUpdate) {
 		a.ServiceEnvUpdate = d.ServiceEnvUpdate
 	}
-	if a.ServiceFallback == "" {
+	if !validAutoMode(a.ServiceFallback) {
 		a.ServiceFallback = d.ServiceFallback
 	}
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -8,19 +8,92 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// AutoMode controls whether an automation step runs automatically.
+type AutoMode string
+
+const (
+	AutoOn  AutoMode = "true"
+	AutoOff AutoMode = "false"
+	AutoAsk AutoMode = "ask"
+)
+
 type Defaults struct {
 	PHP string `yaml:"php,omitempty"`
 	TLD string `yaml:"tld"`
 }
 
+// Automation controls which link-time steps run automatically.
+type Automation struct {
+	ComposerInstall AutoMode `yaml:"composer_install,omitempty"`
+	CopyEnv         AutoMode `yaml:"copy_env,omitempty"`
+	GenerateKey     AutoMode `yaml:"generate_key,omitempty"`
+	SetAppURL       AutoMode `yaml:"set_app_url,omitempty"`
+	InstallOctane   AutoMode `yaml:"install_octane,omitempty"`
+	CreateDatabase  AutoMode `yaml:"create_database,omitempty"`
+	RunMigrations   AutoMode `yaml:"run_migrations,omitempty"`
+	ServiceEnvUpdate AutoMode `yaml:"update_env_on_service,omitempty"`
+	ServiceFallback AutoMode `yaml:"service_fallback,omitempty"`
+}
+
 type Settings struct {
-	Defaults Defaults `yaml:"defaults"`
+	Defaults   Defaults   `yaml:"defaults"`
+	Automation Automation `yaml:"automation,omitempty"`
 }
 
 var validTLD = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 
+// DefaultAutomation returns the default automation settings.
+func DefaultAutomation() Automation {
+	return Automation{
+		ComposerInstall:  AutoOn,
+		CopyEnv:          AutoOn,
+		GenerateKey:      AutoOn,
+		SetAppURL:        AutoOn,
+		InstallOctane:    AutoAsk,
+		CreateDatabase:   AutoOn,
+		RunMigrations:    AutoAsk,
+		ServiceEnvUpdate: AutoOn,
+		ServiceFallback:  AutoOn,
+	}
+}
+
+// applyAutomationDefaults fills empty Automation fields with defaults.
+func applyAutomationDefaults(a *Automation) {
+	d := DefaultAutomation()
+	if a.ComposerInstall == "" {
+		a.ComposerInstall = d.ComposerInstall
+	}
+	if a.CopyEnv == "" {
+		a.CopyEnv = d.CopyEnv
+	}
+	if a.GenerateKey == "" {
+		a.GenerateKey = d.GenerateKey
+	}
+	if a.SetAppURL == "" {
+		a.SetAppURL = d.SetAppURL
+	}
+	if a.InstallOctane == "" {
+		a.InstallOctane = d.InstallOctane
+	}
+	if a.CreateDatabase == "" {
+		a.CreateDatabase = d.CreateDatabase
+	}
+	if a.RunMigrations == "" {
+		a.RunMigrations = d.RunMigrations
+	}
+	if a.ServiceEnvUpdate == "" {
+		a.ServiceEnvUpdate = d.ServiceEnvUpdate
+	}
+	if a.ServiceFallback == "" {
+		a.ServiceFallback = d.ServiceFallback
+	}
+}
+
 func DefaultSettings() *Settings {
-	return &Settings{Defaults: Defaults{TLD: "test"}}
+	return &Settings{
+		Defaults:   Defaults{TLD: "test"},
+		Automation: DefaultAutomation(),
+	}
 }
 
 func LoadSettings() (*Settings, error) {
@@ -39,6 +112,7 @@ func LoadSettings() (*Settings, error) {
 	if s.Defaults.TLD == "" {
 		s.Defaults.TLD = "test"
 	}
+	applyAutomationDefaults(&s.Automation)
 	return &s, nil
 }
 

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -297,6 +297,31 @@ func TestLoadSettings_MissingAutomationGetsDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadSettings_InvalidAutoModeResetToDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(SettingsPath(), []byte("automation:\n    composer_install: banana\n    copy_env: \"false\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings() error = %v", err)
+	}
+	// "banana" is invalid → should be reset to default ("true").
+	if loaded.Automation.ComposerInstall != AutoOn {
+		t.Errorf("ComposerInstall = %q, want %q (invalid value should reset to default)", loaded.Automation.ComposerInstall, AutoOn)
+	}
+	// "false" is valid → should be preserved.
+	if loaded.Automation.CopyEnv != AutoOff {
+		t.Errorf("CopyEnv = %q, want %q", loaded.Automation.CopyEnv, AutoOff)
+	}
+}
+
 func TestValidateTLD(t *testing.T) {
 	tests := []struct {
 		tld     string

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -186,6 +186,117 @@ func TestSettings_SaveWithPHPOnlyDefaultsTLD(t *testing.T) {
 	}
 }
 
+func TestDefaultSettings_HasAutomationDefaults(t *testing.T) {
+	s := DefaultSettings()
+
+	a := s.Automation
+	if a.ComposerInstall != AutoOn {
+		t.Errorf("ComposerInstall = %q, want %q", a.ComposerInstall, AutoOn)
+	}
+	if a.CopyEnv != AutoOn {
+		t.Errorf("CopyEnv = %q, want %q", a.CopyEnv, AutoOn)
+	}
+	if a.GenerateKey != AutoOn {
+		t.Errorf("GenerateKey = %q, want %q", a.GenerateKey, AutoOn)
+	}
+	if a.SetAppURL != AutoOn {
+		t.Errorf("SetAppURL = %q, want %q", a.SetAppURL, AutoOn)
+	}
+	if a.InstallOctane != AutoAsk {
+		t.Errorf("InstallOctane = %q, want %q", a.InstallOctane, AutoAsk)
+	}
+	if a.CreateDatabase != AutoOn {
+		t.Errorf("CreateDatabase = %q, want %q", a.CreateDatabase, AutoOn)
+	}
+	if a.RunMigrations != AutoAsk {
+		t.Errorf("RunMigrations = %q, want %q", a.RunMigrations, AutoAsk)
+	}
+	if a.ServiceEnvUpdate != AutoOn {
+		t.Errorf("ServiceEnvUpdate = %q, want %q", a.ServiceEnvUpdate, AutoOn)
+	}
+	if a.ServiceFallback != AutoOn {
+		t.Errorf("ServiceFallback = %q, want %q", a.ServiceFallback, AutoOn)
+	}
+}
+
+func TestSettings_AutomationRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	s := DefaultSettings()
+	s.Automation.ComposerInstall = AutoOff
+	s.Automation.InstallOctane = AutoOn
+	s.Automation.RunMigrations = AutoOff
+
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings() error = %v", err)
+	}
+
+	if loaded.Automation.ComposerInstall != AutoOff {
+		t.Errorf("ComposerInstall = %q, want %q", loaded.Automation.ComposerInstall, AutoOff)
+	}
+	if loaded.Automation.InstallOctane != AutoOn {
+		t.Errorf("InstallOctane = %q, want %q", loaded.Automation.InstallOctane, AutoOn)
+	}
+	if loaded.Automation.RunMigrations != AutoOff {
+		t.Errorf("RunMigrations = %q, want %q", loaded.Automation.RunMigrations, AutoOff)
+	}
+	// Verify unmodified fields kept their defaults
+	if loaded.Automation.CopyEnv != AutoOn {
+		t.Errorf("CopyEnv = %q, want %q", loaded.Automation.CopyEnv, AutoOn)
+	}
+}
+
+func TestLoadSettings_MissingAutomationGetsDefaults(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	// Write YAML with only defaults section, no automation
+	if err := os.WriteFile(SettingsPath(), []byte("defaults:\n    tld: test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadSettings()
+	if err != nil {
+		t.Fatalf("LoadSettings() error = %v", err)
+	}
+
+	a := loaded.Automation
+	if a.ComposerInstall != AutoOn {
+		t.Errorf("ComposerInstall = %q, want %q", a.ComposerInstall, AutoOn)
+	}
+	if a.CopyEnv != AutoOn {
+		t.Errorf("CopyEnv = %q, want %q", a.CopyEnv, AutoOn)
+	}
+	if a.GenerateKey != AutoOn {
+		t.Errorf("GenerateKey = %q, want %q", a.GenerateKey, AutoOn)
+	}
+	if a.SetAppURL != AutoOn {
+		t.Errorf("SetAppURL = %q, want %q", a.SetAppURL, AutoOn)
+	}
+	if a.InstallOctane != AutoAsk {
+		t.Errorf("InstallOctane = %q, want %q", a.InstallOctane, AutoAsk)
+	}
+	if a.CreateDatabase != AutoOn {
+		t.Errorf("CreateDatabase = %q, want %q", a.CreateDatabase, AutoOn)
+	}
+	if a.RunMigrations != AutoAsk {
+		t.Errorf("RunMigrations = %q, want %q", a.RunMigrations, AutoAsk)
+	}
+	if a.ServiceEnvUpdate != AutoOn {
+		t.Errorf("ServiceEnvUpdate = %q, want %q", a.ServiceEnvUpdate, AutoOn)
+	}
+	if a.ServiceFallback != AutoOn {
+		t.Errorf("ServiceFallback = %q, want %q", a.ServiceFallback, AutoOn)
+	}
+}
+
 func TestValidateTLD(t *testing.T) {
 	tests := []struct {
 		tld     string

--- a/internal/laravel/artisan.go
+++ b/internal/laravel/artisan.go
@@ -1,0 +1,93 @@
+package laravel
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/prvious/pv/internal/services"
+)
+
+// HasComposerJSON checks whether composer.json exists in the project.
+func HasComposerJSON(projectPath string) bool {
+	_, err := os.Stat(filepath.Join(projectPath, "composer.json"))
+	return err == nil
+}
+
+// HasVendorDir checks whether the vendor/ directory exists in the project.
+func HasVendorDir(projectPath string) bool {
+	info, err := os.Stat(filepath.Join(projectPath, "vendor"))
+	return err == nil && info.IsDir()
+}
+
+// HasEnvExample checks whether .env.example exists in the project.
+func HasEnvExample(projectPath string) bool {
+	_, err := os.Stat(filepath.Join(projectPath, ".env.example"))
+	return err == nil
+}
+
+// HasEnvFile checks whether .env exists in the project.
+func HasEnvFile(projectPath string) bool {
+	_, err := os.Stat(filepath.Join(projectPath, ".env"))
+	return err == nil
+}
+
+// HasOctaneWorker checks whether public/frankenphp-worker.php exists.
+func HasOctaneWorker(projectPath string) bool {
+	_, err := os.Stat(filepath.Join(projectPath, "public", "frankenphp-worker.php"))
+	return err == nil
+}
+
+// HasOctanePackage checks whether laravel/octane is in composer.json require.
+func HasOctanePackage(projectPath string) bool {
+	data, err := os.ReadFile(filepath.Join(projectPath, "composer.json"))
+	if err != nil {
+		return false
+	}
+	var c struct {
+		Require map[string]string `json:"require"`
+	}
+	if json.Unmarshal(data, &c) != nil {
+		return false
+	}
+	_, ok := c.Require["laravel/octane"]
+	return ok
+}
+
+// ReadAppKey reads APP_KEY from the project's .env file.
+// Returns empty string if .env is missing or APP_KEY is not set.
+func ReadAppKey(projectPath string) string {
+	env, err := services.ReadDotEnv(filepath.Join(projectPath, ".env"))
+	if err != nil {
+		return ""
+	}
+	return env["APP_KEY"]
+}
+
+// RunArtisan executes an artisan command in the project directory.
+func RunArtisan(projectPath, phpBin string, args ...string) (string, error) {
+	cmdArgs := append([]string{filepath.Join(projectPath, "artisan")}, args...)
+	cmd := exec.Command(phpBin, cmdArgs...)
+	cmd.Dir = projectPath
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// KeyGenerate runs artisan key:generate.
+func KeyGenerate(projectPath, phpBin string) error {
+	_, err := RunArtisan(projectPath, phpBin, "key:generate", "--force")
+	return err
+}
+
+// Migrate runs artisan migrate --force.
+func Migrate(projectPath, phpBin string) (string, error) {
+	return RunArtisan(projectPath, phpBin, "migrate", "--force")
+}
+
+// OctaneInstall runs artisan octane:install --server=frankenphp.
+func OctaneInstall(projectPath, phpBin string) error {
+	_, err := RunArtisan(projectPath, phpBin, "octane:install", "--server=frankenphp")
+	return err
+}

--- a/internal/laravel/artisan.go
+++ b/internal/laravel/artisan.go
@@ -2,6 +2,7 @@ package laravel
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +73,11 @@ func RunArtisan(projectPath, phpBin string, args ...string) (string, error) {
 	cmd := exec.Command(phpBin, cmdArgs...)
 	cmd.Dir = projectPath
 	out, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(out)), err
+	trimmed := strings.TrimSpace(string(out))
+	if err != nil {
+		return trimmed, fmt.Errorf("%w: %s", err, trimmed)
+	}
+	return trimmed, nil
 }
 
 // KeyGenerate runs artisan key:generate.

--- a/internal/laravel/artisan_test.go
+++ b/internal/laravel/artisan_test.go
@@ -1,0 +1,106 @@
+package laravel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHasComposerJSON(t *testing.T) {
+	dir := t.TempDir()
+	if HasComposerJSON(dir) {
+		t.Error("expected false for empty dir")
+	}
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte("{}"), 0644)
+	if !HasComposerJSON(dir) {
+		t.Error("expected true when composer.json exists")
+	}
+}
+
+func TestHasVendorDir(t *testing.T) {
+	dir := t.TempDir()
+	if HasVendorDir(dir) {
+		t.Error("expected false for empty dir")
+	}
+	os.MkdirAll(filepath.Join(dir, "vendor"), 0755)
+	if !HasVendorDir(dir) {
+		t.Error("expected true when vendor/ exists")
+	}
+}
+
+func TestHasEnvExample(t *testing.T) {
+	dir := t.TempDir()
+	if HasEnvExample(dir) {
+		t.Error("expected false for empty dir")
+	}
+	os.WriteFile(filepath.Join(dir, ".env.example"), []byte("APP_KEY=\n"), 0644)
+	if !HasEnvExample(dir) {
+		t.Error("expected true when .env.example exists")
+	}
+}
+
+func TestHasEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	if HasEnvFile(dir) {
+		t.Error("expected false for empty dir")
+	}
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=\n"), 0644)
+	if !HasEnvFile(dir) {
+		t.Error("expected true when .env exists")
+	}
+}
+
+func TestHasOctaneWorker(t *testing.T) {
+	dir := t.TempDir()
+	if HasOctaneWorker(dir) {
+		t.Error("expected false for empty dir")
+	}
+	os.MkdirAll(filepath.Join(dir, "public"), 0755)
+	os.WriteFile(filepath.Join(dir, "public", "frankenphp-worker.php"), []byte("<?php"), 0644)
+	if !HasOctaneWorker(dir) {
+		t.Error("expected true when worker exists")
+	}
+}
+
+func TestHasOctanePackage(t *testing.T) {
+	dir := t.TempDir()
+	if HasOctanePackage(dir) {
+		t.Error("expected false for empty dir")
+	}
+
+	// Without octane
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"laravel/framework":"^11.0"}}`), 0644)
+	if HasOctanePackage(dir) {
+		t.Error("expected false without octane in require")
+	}
+
+	// With octane
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"laravel/framework":"^11.0","laravel/octane":"^2.0"}}`), 0644)
+	if !HasOctanePackage(dir) {
+		t.Error("expected true with octane in require")
+	}
+}
+
+func TestReadAppKey_Empty(t *testing.T) {
+	dir := t.TempDir()
+	// No .env at all
+	if key := ReadAppKey(dir); key != "" {
+		t.Errorf("expected empty key, got %q", key)
+	}
+
+	// .env with empty APP_KEY
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=\n"), 0644)
+	if key := ReadAppKey(dir); key != "" {
+		t.Errorf("expected empty key, got %q", key)
+	}
+}
+
+func TestReadAppKey_Set(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=base64:abc123def456\n"), 0644)
+
+	key := ReadAppKey(dir)
+	if key != "base64:abc123def456" {
+		t.Errorf("ReadAppKey() = %q, want %q", key, "base64:abc123def456")
+	}
+}

--- a/internal/laravel/composer.go
+++ b/internal/laravel/composer.go
@@ -1,6 +1,7 @@
 package laravel
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -10,5 +11,9 @@ func ComposerInstall(projectPath string) (string, error) {
 	cmd := exec.Command("composer", "install", "--no-interaction", "--prefer-dist")
 	cmd.Dir = projectPath
 	out, err := cmd.CombinedOutput()
-	return strings.TrimSpace(string(out)), err
+	trimmed := strings.TrimSpace(string(out))
+	if err != nil {
+		return trimmed, fmt.Errorf("%w: %s", err, trimmed)
+	}
+	return trimmed, nil
 }

--- a/internal/laravel/composer.go
+++ b/internal/laravel/composer.go
@@ -1,0 +1,14 @@
+package laravel
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// ComposerInstall runs composer install in the project directory.
+func ComposerInstall(projectPath string) (string, error) {
+	cmd := exec.Command("composer", "install", "--no-interaction", "--prefer-dist")
+	cmd.Dir = projectPath
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}

--- a/internal/laravel/database.go
+++ b/internal/laravel/database.go
@@ -1,0 +1,25 @@
+package laravel
+
+import (
+	"path/filepath"
+
+	"github.com/prvious/pv/internal/services"
+)
+
+// ResolveDatabaseName reads DB_DATABASE from .env.example.
+// Returns sanitized project name if .env.example is missing, has no DB_DATABASE,
+// or DB_DATABASE is the generic "laravel" default.
+func ResolveDatabaseName(projectPath, projectName string) string {
+	envExample := filepath.Join(projectPath, ".env.example")
+	env, err := services.ReadDotEnv(envExample)
+	if err != nil {
+		return services.SanitizeProjectName(projectName)
+	}
+
+	dbName, ok := env["DB_DATABASE"]
+	if !ok || dbName == "" || dbName == "laravel" {
+		return services.SanitizeProjectName(projectName)
+	}
+
+	return dbName
+}

--- a/internal/laravel/database_test.go
+++ b/internal/laravel/database_test.go
@@ -1,0 +1,69 @@
+package laravel
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDatabaseName_FromEnvExample(t *testing.T) {
+	dir := t.TempDir()
+	envExample := filepath.Join(dir, ".env.example")
+	os.WriteFile(envExample, []byte("DB_DATABASE=my_custom_db\n"), 0644)
+
+	got := ResolveDatabaseName(dir, "my-project")
+	if got != "my_custom_db" {
+		t.Errorf("ResolveDatabaseName() = %q, want %q", got, "my_custom_db")
+	}
+}
+
+func TestResolveDatabaseName_IgnoresGenericLaravel(t *testing.T) {
+	dir := t.TempDir()
+	envExample := filepath.Join(dir, ".env.example")
+	os.WriteFile(envExample, []byte("DB_DATABASE=laravel\n"), 0644)
+
+	got := ResolveDatabaseName(dir, "my-project")
+	if got != "my_project" {
+		t.Errorf("ResolveDatabaseName() = %q, want %q", got, "my_project")
+	}
+}
+
+func TestResolveDatabaseName_NoEnvExample(t *testing.T) {
+	dir := t.TempDir()
+
+	got := ResolveDatabaseName(dir, "my-project")
+	if got != "my_project" {
+		t.Errorf("ResolveDatabaseName() = %q, want %q", got, "my_project")
+	}
+}
+
+func TestResolveDatabaseName_NoDBDatabaseKey(t *testing.T) {
+	dir := t.TempDir()
+	envExample := filepath.Join(dir, ".env.example")
+	os.WriteFile(envExample, []byte("APP_NAME=MyApp\nAPP_ENV=local\n"), 0644)
+
+	got := ResolveDatabaseName(dir, "my-project")
+	if got != "my_project" {
+		t.Errorf("ResolveDatabaseName() = %q, want %q", got, "my_project")
+	}
+}
+
+func TestResolveDatabaseName_EmptyDBDatabase(t *testing.T) {
+	dir := t.TempDir()
+	envExample := filepath.Join(dir, ".env.example")
+	os.WriteFile(envExample, []byte("DB_DATABASE=\n"), 0644)
+
+	got := ResolveDatabaseName(dir, "my-project")
+	if got != "my_project" {
+		t.Errorf("ResolveDatabaseName() = %q, want %q", got, "my_project")
+	}
+}
+
+func TestResolveDatabaseName_SanitizesHyphens(t *testing.T) {
+	dir := t.TempDir()
+
+	got := ResolveDatabaseName(dir, "my-cool-app")
+	if got != "my_cool_app" {
+		t.Errorf("ResolveDatabaseName() = %q, want %q", got, "my_cool_app")
+	}
+}

--- a/internal/laravel/env.go
+++ b/internal/laravel/env.go
@@ -1,0 +1,51 @@
+package laravel
+
+import "github.com/prvious/pv/internal/registry"
+
+// SmartEnvVars returns Laravel-specific behavioral env vars based on bound services.
+// Separate from services.EnvVars() which returns connection details.
+func SmartEnvVars(bound *registry.ProjectServices) map[string]string {
+	vars := make(map[string]string)
+	if bound.Redis {
+		vars["CACHE_STORE"] = "redis"
+		vars["SESSION_DRIVER"] = "redis"
+		vars["QUEUE_CONNECTION"] = "redis"
+	}
+	if bound.S3 {
+		vars["FILESYSTEM_DISK"] = "s3"
+	}
+	if bound.Mail {
+		vars["MAIL_MAILER"] = "smtp"
+	}
+	return vars
+}
+
+// FallbackRule defines a conditional replacement: if a key currently has
+// IfValue, it should be replaced with ReplaceWith when the service is removed.
+type FallbackRule struct {
+	IfValue     string
+	ReplaceWith string
+}
+
+// FallbackMapping returns rules for safe defaults when a service stops/is removed.
+// Only overwrites values pv set — not developer-set values.
+func FallbackMapping(serviceName string) map[string]FallbackRule {
+	switch serviceName {
+	case "redis":
+		return map[string]FallbackRule{
+			"CACHE_STORE":      {IfValue: "redis", ReplaceWith: "file"},
+			"SESSION_DRIVER":   {IfValue: "redis", ReplaceWith: "file"},
+			"QUEUE_CONNECTION": {IfValue: "redis", ReplaceWith: "sync"},
+		}
+	case "s3":
+		return map[string]FallbackRule{
+			"FILESYSTEM_DISK": {IfValue: "s3", ReplaceWith: "local"},
+		}
+	case "mail":
+		return map[string]FallbackRule{
+			"MAIL_MAILER": {IfValue: "smtp", ReplaceWith: "log"},
+		}
+	default:
+		return nil
+	}
+}

--- a/internal/laravel/env.go
+++ b/internal/laravel/env.go
@@ -1,6 +1,12 @@
 package laravel
 
-import "github.com/prvious/pv/internal/registry"
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/services"
+)
 
 // SmartEnvVars returns Laravel-specific behavioral env vars based on bound services.
 // Separate from services.EnvVars() which returns connection details.
@@ -48,4 +54,43 @@ func FallbackMapping(serviceName string) map[string]FallbackRule {
 	default:
 		return nil
 	}
+}
+
+// ApplyFallbacks reads a project's .env, replaces values that match what pv
+// would have set for the given service with safe defaults, and writes back.
+func ApplyFallbacks(envPath, serviceName string) error {
+	rules := FallbackMapping(serviceName)
+	if len(rules) == 0 {
+		return nil
+	}
+	env, err := services.ReadDotEnv(envPath)
+	if err != nil {
+		return err
+	}
+	replacements := make(map[string]string)
+	for key, rule := range rules {
+		if currentVal, ok := env[key]; ok && currentVal == rule.IfValue {
+			replacements[key] = rule.ReplaceWith
+		}
+	}
+	if len(replacements) == 0 {
+		return nil
+	}
+	backupPath := envPath + ".pv-backup"
+	return services.MergeDotEnv(envPath, backupPath, replacements)
+}
+
+// UpdateProjectEnvForService merges connection vars + smart Laravel vars into .env.
+func UpdateProjectEnvForService(projectPath, projectName, serviceName string, svc services.Service, port int, bound *registry.ProjectServices) error {
+	envPath := filepath.Join(projectPath, ".env")
+	if _, err := os.Stat(envPath); os.IsNotExist(err) {
+		return nil
+	}
+	allVars := svc.EnvVars(projectName, port)
+	smartVars := SmartEnvVars(bound)
+	for k, v := range smartVars {
+		allVars[k] = v
+	}
+	backupPath := envPath + ".pv-backup"
+	return services.MergeDotEnv(envPath, backupPath, allVars)
 }

--- a/internal/laravel/env_test.go
+++ b/internal/laravel/env_test.go
@@ -1,9 +1,12 @@
 package laravel
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/services"
 )
 
 func TestSmartEnvVars_Redis(t *testing.T) {
@@ -134,5 +137,135 @@ func TestFallbackMapping_Unknown(t *testing.T) {
 	rules := FallbackMapping("postgres")
 	if rules != nil {
 		t.Errorf("expected nil for unknown service, got %v", rules)
+	}
+}
+
+func TestApplyFallbacks_ReplacesMatchingValues(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("CACHE_STORE=redis\nSESSION_DRIVER=redis\nQUEUE_CONNECTION=redis\n"), 0644)
+
+	if err := ApplyFallbacks(envPath, "redis"); err != nil {
+		t.Fatalf("ApplyFallbacks: %v", err)
+	}
+
+	env, err := services.ReadDotEnv(envPath)
+	if err != nil {
+		t.Fatalf("ReadDotEnv: %v", err)
+	}
+	if env["CACHE_STORE"] != "file" {
+		t.Errorf("CACHE_STORE = %q, want file", env["CACHE_STORE"])
+	}
+	if env["SESSION_DRIVER"] != "file" {
+		t.Errorf("SESSION_DRIVER = %q, want file", env["SESSION_DRIVER"])
+	}
+	if env["QUEUE_CONNECTION"] != "sync" {
+		t.Errorf("QUEUE_CONNECTION = %q, want sync", env["QUEUE_CONNECTION"])
+	}
+}
+
+func TestApplyFallbacks_SkipsNonMatchingValues(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("CACHE_STORE=array\nSESSION_DRIVER=database\nQUEUE_CONNECTION=sqs\n"), 0644)
+
+	if err := ApplyFallbacks(envPath, "redis"); err != nil {
+		t.Fatalf("ApplyFallbacks: %v", err)
+	}
+
+	env, err := services.ReadDotEnv(envPath)
+	if err != nil {
+		t.Fatalf("ReadDotEnv: %v", err)
+	}
+	if env["CACHE_STORE"] != "array" {
+		t.Errorf("CACHE_STORE = %q, want array", env["CACHE_STORE"])
+	}
+	if env["SESSION_DRIVER"] != "database" {
+		t.Errorf("SESSION_DRIVER = %q, want database", env["SESSION_DRIVER"])
+	}
+	if env["QUEUE_CONNECTION"] != "sqs" {
+		t.Errorf("QUEUE_CONNECTION = %q, want sqs", env["QUEUE_CONNECTION"])
+	}
+}
+
+func TestApplyFallbacks_S3(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("FILESYSTEM_DISK=s3\n"), 0644)
+
+	if err := ApplyFallbacks(envPath, "s3"); err != nil {
+		t.Fatalf("ApplyFallbacks: %v", err)
+	}
+
+	env, _ := services.ReadDotEnv(envPath)
+	if env["FILESYSTEM_DISK"] != "local" {
+		t.Errorf("FILESYSTEM_DISK = %q, want local", env["FILESYSTEM_DISK"])
+	}
+}
+
+func TestApplyFallbacks_Mail(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("MAIL_MAILER=smtp\n"), 0644)
+
+	if err := ApplyFallbacks(envPath, "mail"); err != nil {
+		t.Fatalf("ApplyFallbacks: %v", err)
+	}
+
+	env, _ := services.ReadDotEnv(envPath)
+	if env["MAIL_MAILER"] != "log" {
+		t.Errorf("MAIL_MAILER = %q, want log", env["MAIL_MAILER"])
+	}
+}
+
+func TestApplyFallbacks_NoRulesForService(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("DB_CONNECTION=mysql\n"), 0644)
+
+	if err := ApplyFallbacks(envPath, "mysql"); err != nil {
+		t.Fatalf("ApplyFallbacks: %v", err)
+	}
+
+	env, _ := services.ReadDotEnv(envPath)
+	if env["DB_CONNECTION"] != "mysql" {
+		t.Errorf("DB_CONNECTION = %q, want mysql (unchanged)", env["DB_CONNECTION"])
+	}
+}
+
+func TestUpdateProjectEnvForService(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("APP_NAME=test\nDB_HOST=localhost\n"), 0644)
+
+	svc, _ := services.Lookup("redis")
+	bound := &registry.ProjectServices{Redis: true}
+
+	if err := UpdateProjectEnvForService(dir, "my-app", "redis", svc, 6379, bound); err != nil {
+		t.Fatalf("UpdateProjectEnvForService: %v", err)
+	}
+
+	env, _ := services.ReadDotEnv(envPath)
+	// Connection vars from Redis.EnvVars
+	if env["REDIS_HOST"] != "127.0.0.1" {
+		t.Errorf("REDIS_HOST = %q, want 127.0.0.1", env["REDIS_HOST"])
+	}
+	// Smart vars from SmartEnvVars
+	if env["CACHE_STORE"] != "redis" {
+		t.Errorf("CACHE_STORE = %q, want redis", env["CACHE_STORE"])
+	}
+	if env["SESSION_DRIVER"] != "redis" {
+		t.Errorf("SESSION_DRIVER = %q, want redis", env["SESSION_DRIVER"])
+	}
+}
+
+func TestUpdateProjectEnvForService_NoEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	svc, _ := services.Lookup("redis")
+	bound := &registry.ProjectServices{Redis: true}
+
+	// Should not error when .env doesn't exist
+	if err := UpdateProjectEnvForService(dir, "my-app", "redis", svc, 6379, bound); err != nil {
+		t.Fatalf("UpdateProjectEnvForService should not error for missing .env: %v", err)
 	}
 }

--- a/internal/laravel/env_test.go
+++ b/internal/laravel/env_test.go
@@ -1,0 +1,138 @@
+package laravel
+
+import (
+	"testing"
+
+	"github.com/prvious/pv/internal/registry"
+)
+
+func TestSmartEnvVars_Redis(t *testing.T) {
+	bound := &registry.ProjectServices{Redis: true}
+	vars := SmartEnvVars(bound)
+
+	if len(vars) != 3 {
+		t.Fatalf("expected 3 vars, got %d", len(vars))
+	}
+	if vars["CACHE_STORE"] != "redis" {
+		t.Errorf("CACHE_STORE = %q, want %q", vars["CACHE_STORE"], "redis")
+	}
+	if vars["SESSION_DRIVER"] != "redis" {
+		t.Errorf("SESSION_DRIVER = %q, want %q", vars["SESSION_DRIVER"], "redis")
+	}
+	if vars["QUEUE_CONNECTION"] != "redis" {
+		t.Errorf("QUEUE_CONNECTION = %q, want %q", vars["QUEUE_CONNECTION"], "redis")
+	}
+}
+
+func TestSmartEnvVars_S3(t *testing.T) {
+	bound := &registry.ProjectServices{S3: true}
+	vars := SmartEnvVars(bound)
+
+	if len(vars) != 1 {
+		t.Fatalf("expected 1 var, got %d", len(vars))
+	}
+	if vars["FILESYSTEM_DISK"] != "s3" {
+		t.Errorf("FILESYSTEM_DISK = %q, want %q", vars["FILESYSTEM_DISK"], "s3")
+	}
+}
+
+func TestSmartEnvVars_Mail(t *testing.T) {
+	bound := &registry.ProjectServices{Mail: true}
+	vars := SmartEnvVars(bound)
+
+	if len(vars) != 1 {
+		t.Fatalf("expected 1 var, got %d", len(vars))
+	}
+	if vars["MAIL_MAILER"] != "smtp" {
+		t.Errorf("MAIL_MAILER = %q, want %q", vars["MAIL_MAILER"], "smtp")
+	}
+}
+
+func TestSmartEnvVars_NoServices(t *testing.T) {
+	bound := &registry.ProjectServices{}
+	vars := SmartEnvVars(bound)
+
+	if len(vars) != 0 {
+		t.Errorf("expected empty map, got %d vars", len(vars))
+	}
+}
+
+func TestSmartEnvVars_AllServices(t *testing.T) {
+	bound := &registry.ProjectServices{
+		Redis: true,
+		S3:    true,
+		Mail:  true,
+	}
+	vars := SmartEnvVars(bound)
+
+	if len(vars) != 5 {
+		t.Fatalf("expected 5 vars, got %d: %v", len(vars), vars)
+	}
+	expected := map[string]string{
+		"CACHE_STORE":      "redis",
+		"SESSION_DRIVER":   "redis",
+		"QUEUE_CONNECTION": "redis",
+		"FILESYSTEM_DISK":  "s3",
+		"MAIL_MAILER":      "smtp",
+	}
+	for k, v := range expected {
+		if vars[k] != v {
+			t.Errorf("%s = %q, want %q", k, vars[k], v)
+		}
+	}
+}
+
+func TestFallbackMapping_Redis(t *testing.T) {
+	rules := FallbackMapping("redis")
+	if len(rules) != 3 {
+		t.Fatalf("expected 3 rules, got %d", len(rules))
+	}
+
+	tests := map[string]FallbackRule{
+		"CACHE_STORE":      {IfValue: "redis", ReplaceWith: "file"},
+		"SESSION_DRIVER":   {IfValue: "redis", ReplaceWith: "file"},
+		"QUEUE_CONNECTION": {IfValue: "redis", ReplaceWith: "sync"},
+	}
+	for key, want := range tests {
+		got, ok := rules[key]
+		if !ok {
+			t.Errorf("missing rule for %s", key)
+			continue
+		}
+		if got.IfValue != want.IfValue {
+			t.Errorf("%s.IfValue = %q, want %q", key, got.IfValue, want.IfValue)
+		}
+		if got.ReplaceWith != want.ReplaceWith {
+			t.Errorf("%s.ReplaceWith = %q, want %q", key, got.ReplaceWith, want.ReplaceWith)
+		}
+	}
+}
+
+func TestFallbackMapping_S3(t *testing.T) {
+	rules := FallbackMapping("s3")
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+	r := rules["FILESYSTEM_DISK"]
+	if r.IfValue != "s3" || r.ReplaceWith != "local" {
+		t.Errorf("FILESYSTEM_DISK rule = %+v", r)
+	}
+}
+
+func TestFallbackMapping_Mail(t *testing.T) {
+	rules := FallbackMapping("mail")
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(rules))
+	}
+	r := rules["MAIL_MAILER"]
+	if r.IfValue != "smtp" || r.ReplaceWith != "log" {
+		t.Errorf("MAIL_MAILER rule = %+v", r)
+	}
+}
+
+func TestFallbackMapping_Unknown(t *testing.T) {
+	rules := FallbackMapping("postgres")
+	if rules != nil {
+		t.Errorf("expected nil for unknown service, got %v", rules)
+	}
+}

--- a/internal/laravel/steps.go
+++ b/internal/laravel/steps.go
@@ -1,0 +1,292 @@
+package laravel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/services"
+)
+
+// isLaravel returns true if the project type is Laravel or Laravel with Octane.
+func isLaravel(projectType string) bool {
+	return projectType == "laravel" || projectType == "laravel-octane"
+}
+
+// --- CopyEnvStep ---
+
+// CopyEnvStep copies .env.example to .env and loads it into ctx.Env.
+type CopyEnvStep struct{}
+
+var _ automation.Step = (*CopyEnvStep)(nil)
+
+func (s *CopyEnvStep) Label() string { return "Copy .env" }
+func (s *CopyEnvStep) Gate() string  { return "copy_env" }
+
+func (s *CopyEnvStep) ShouldRun(ctx *automation.Context) bool {
+	if !isLaravel(ctx.ProjectType) {
+		return false
+	}
+	if !HasEnvExample(ctx.ProjectPath) {
+		return false
+	}
+	return !HasEnvFile(ctx.ProjectPath)
+}
+
+func (s *CopyEnvStep) Run(ctx *automation.Context) (string, error) {
+	src := filepath.Join(ctx.ProjectPath, ".env.example")
+	dst := filepath.Join(ctx.ProjectPath, ".env")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return "", fmt.Errorf("read .env.example: %w", err)
+	}
+	if err := os.WriteFile(dst, data, 0644); err != nil {
+		return "", fmt.Errorf("write .env: %w", err)
+	}
+	env, err := services.ReadDotEnv(dst)
+	if err != nil {
+		return "", fmt.Errorf("parse .env: %w", err)
+	}
+	ctx.Env = env
+	return "copied .env.example → .env", nil
+}
+
+// --- GenerateKeyStep ---
+
+// GenerateKeyStep runs artisan key:generate if APP_KEY is empty.
+type GenerateKeyStep struct{}
+
+var _ automation.Step = (*GenerateKeyStep)(nil)
+
+func (s *GenerateKeyStep) Label() string { return "Generate application key" }
+func (s *GenerateKeyStep) Gate() string  { return "generate_key" }
+
+func (s *GenerateKeyStep) ShouldRun(ctx *automation.Context) bool {
+	if !isLaravel(ctx.ProjectType) {
+		return false
+	}
+	if !HasEnvFile(ctx.ProjectPath) {
+		return false
+	}
+	return ReadAppKey(ctx.ProjectPath) == ""
+}
+
+func (s *GenerateKeyStep) Run(ctx *automation.Context) (string, error) {
+	phpBin := "php"
+	if ctx.PHPVersion != "" {
+		phpBin = "php" + ctx.PHPVersion
+	}
+	if err := KeyGenerate(ctx.ProjectPath, phpBin); err != nil {
+		return "", fmt.Errorf("artisan key:generate: %w", err)
+	}
+	return "application key generated", nil
+}
+
+// --- SetAppURLStep ---
+
+// SetAppURLStep sets APP_URL in .env to https://{name}.{tld}.
+type SetAppURLStep struct{}
+
+var _ automation.Step = (*SetAppURLStep)(nil)
+
+func (s *SetAppURLStep) Label() string { return "Set APP_URL" }
+func (s *SetAppURLStep) Gate() string  { return "set_app_url" }
+
+func (s *SetAppURLStep) ShouldRun(ctx *automation.Context) bool {
+	return isLaravel(ctx.ProjectType)
+}
+
+func (s *SetAppURLStep) Run(ctx *automation.Context) (string, error) {
+	tld := ctx.TLD
+	if tld == "" {
+		tld = "test"
+	}
+	appURL := fmt.Sprintf("https://%s.%s", ctx.ProjectName, tld)
+	envPath := filepath.Join(ctx.ProjectPath, ".env")
+	vars := map[string]string{"APP_URL": appURL}
+	if err := services.MergeDotEnv(envPath, "", vars); err != nil {
+		return "", fmt.Errorf("set APP_URL: %w", err)
+	}
+	return appURL, nil
+}
+
+// --- InstallOctaneStep ---
+
+// InstallOctaneStep runs artisan octane:install if octane is in composer.json
+// but the worker file is missing.
+type InstallOctaneStep struct{}
+
+var _ automation.Step = (*InstallOctaneStep)(nil)
+
+func (s *InstallOctaneStep) Label() string { return "Install Octane" }
+func (s *InstallOctaneStep) Gate() string  { return "install_octane" }
+
+func (s *InstallOctaneStep) ShouldRun(ctx *automation.Context) bool {
+	if !isLaravel(ctx.ProjectType) {
+		return false
+	}
+	return HasOctanePackage(ctx.ProjectPath) && !HasOctaneWorker(ctx.ProjectPath)
+}
+
+func (s *InstallOctaneStep) Run(ctx *automation.Context) (string, error) {
+	phpBin := "php"
+	if ctx.PHPVersion != "" {
+		phpBin = "php" + ctx.PHPVersion
+	}
+	if err := OctaneInstall(ctx.ProjectPath, phpBin); err != nil {
+		return "", fmt.Errorf("artisan octane:install: %w", err)
+	}
+	return "Octane installed with FrankenPHP", nil
+}
+
+// --- ComposerInstallStep ---
+
+// ComposerInstallStep runs composer install if vendor/ is missing.
+type ComposerInstallStep struct{}
+
+var _ automation.Step = (*ComposerInstallStep)(nil)
+
+func (s *ComposerInstallStep) Label() string { return "Install Composer dependencies" }
+func (s *ComposerInstallStep) Gate() string  { return "composer_install" }
+
+func (s *ComposerInstallStep) ShouldRun(ctx *automation.Context) bool {
+	if !isLaravel(ctx.ProjectType) {
+		return false
+	}
+	if !HasComposerJSON(ctx.ProjectPath) {
+		return false
+	}
+	return !HasVendorDir(ctx.ProjectPath)
+}
+
+func (s *ComposerInstallStep) Run(ctx *automation.Context) (string, error) {
+	out, err := ComposerInstall(ctx.ProjectPath)
+	if err != nil {
+		return "", fmt.Errorf("composer install: %w", err)
+	}
+	return out, nil
+}
+
+// --- DetectServicesStep ---
+
+// DetectServicesStep merges smart env vars for bound services into .env.
+type DetectServicesStep struct{}
+
+var _ automation.Step = (*DetectServicesStep)(nil)
+
+func (s *DetectServicesStep) Label() string { return "Configure service environment" }
+func (s *DetectServicesStep) Gate() string  { return "update_env_on_service" }
+
+func (s *DetectServicesStep) ShouldRun(ctx *automation.Context) bool {
+	if !isLaravel(ctx.ProjectType) {
+		return false
+	}
+	if ctx.Registry == nil {
+		return false
+	}
+	proj := ctx.Registry.Find(ctx.ProjectName)
+	if proj == nil || proj.Services == nil {
+		return false
+	}
+	// Run if any service is bound.
+	svc := proj.Services
+	return svc.Redis || svc.S3 || svc.Mail || svc.MySQL != "" || svc.Postgres != ""
+}
+
+func (s *DetectServicesStep) Run(ctx *automation.Context) (string, error) {
+	proj := ctx.Registry.Find(ctx.ProjectName)
+	if proj == nil || proj.Services == nil {
+		return "no services bound", nil
+	}
+	vars := SmartEnvVars(proj.Services)
+	if len(vars) == 0 {
+		return "no env vars to set", nil
+	}
+	envPath := filepath.Join(ctx.ProjectPath, ".env")
+	if err := services.MergeDotEnv(envPath, "", vars); err != nil {
+		return "", fmt.Errorf("merge service env: %w", err)
+	}
+	return fmt.Sprintf("set %d service env vars", len(vars)), nil
+}
+
+// --- CreateDatabaseStep ---
+
+// CreateDatabaseStep resolves the database name and records it in the registry.
+type CreateDatabaseStep struct{}
+
+var _ automation.Step = (*CreateDatabaseStep)(nil)
+
+func (s *CreateDatabaseStep) Label() string { return "Create database" }
+func (s *CreateDatabaseStep) Gate() string  { return "create_database" }
+
+func (s *CreateDatabaseStep) ShouldRun(ctx *automation.Context) bool {
+	if !isLaravel(ctx.ProjectType) {
+		return false
+	}
+	if ctx.Registry == nil {
+		return false
+	}
+	proj := ctx.Registry.Find(ctx.ProjectName)
+	if proj == nil || proj.Services == nil {
+		return false
+	}
+	// Need a database service bound.
+	return proj.Services.MySQL != "" || proj.Services.Postgres != ""
+}
+
+func (s *CreateDatabaseStep) Run(ctx *automation.Context) (string, error) {
+	dbName := ResolveDatabaseName(ctx.ProjectPath, ctx.ProjectName)
+
+	// Record in registry. Use index-based access so mutations persist
+	// in the slice (Registry.Find returns a copy via range variable).
+	for i := range ctx.Registry.Projects {
+		if ctx.Registry.Projects[i].Name != ctx.ProjectName {
+			continue
+		}
+		proj := &ctx.Registry.Projects[i]
+		found := false
+		for _, db := range proj.Databases {
+			if db == dbName {
+				found = true
+				break
+			}
+		}
+		if !found {
+			proj.Databases = append(proj.Databases, dbName)
+		}
+		break
+	}
+
+	ctx.DBCreated = true
+	return dbName, nil
+}
+
+// --- RunMigrationsStep ---
+
+// RunMigrationsStep runs artisan migrate if a database was created in this pipeline.
+type RunMigrationsStep struct{}
+
+var _ automation.Step = (*RunMigrationsStep)(nil)
+
+func (s *RunMigrationsStep) Label() string { return "Run migrations" }
+func (s *RunMigrationsStep) Gate() string  { return "run_migrations" }
+
+func (s *RunMigrationsStep) ShouldRun(ctx *automation.Context) bool {
+	if !isLaravel(ctx.ProjectType) {
+		return false
+	}
+	return ctx.DBCreated
+}
+
+func (s *RunMigrationsStep) Run(ctx *automation.Context) (string, error) {
+	phpBin := "php"
+	if ctx.PHPVersion != "" {
+		phpBin = "php" + ctx.PHPVersion
+	}
+	out, err := Migrate(ctx.ProjectPath, phpBin)
+	if err != nil {
+		return "", fmt.Errorf("artisan migrate: %w", err)
+	}
+	return out, nil
+}

--- a/internal/laravel/steps.go
+++ b/internal/laravel/steps.go
@@ -94,7 +94,7 @@ func (s *SetAppURLStep) Label() string { return "Set APP_URL" }
 func (s *SetAppURLStep) Gate() string  { return "set_app_url" }
 
 func (s *SetAppURLStep) ShouldRun(ctx *automation.Context) bool {
-	return isLaravel(ctx.ProjectType)
+	return isLaravel(ctx.ProjectType) && HasEnvFile(ctx.ProjectPath)
 }
 
 func (s *SetAppURLStep) Run(ctx *automation.Context) (string, error) {

--- a/internal/laravel/steps_test.go
+++ b/internal/laravel/steps_test.go
@@ -109,22 +109,34 @@ func TestCopyEnvStep_Run(t *testing.T) {
 
 func TestSetAppURLStep_ShouldRun_TrueForLaravel(t *testing.T) {
 	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_URL=http://localhost\n"), 0644)
 	ctx := testCtx(dir)
 	step := &SetAppURLStep{}
 
 	if !step.ShouldRun(ctx) {
-		t.Error("ShouldRun should be true for Laravel projects")
+		t.Error("ShouldRun should be true for Laravel projects with .env")
 	}
 }
 
 func TestSetAppURLStep_ShouldRun_TrueForLaravelOctane(t *testing.T) {
 	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_URL=http://localhost\n"), 0644)
 	ctx := testCtx(dir)
 	ctx.ProjectType = "laravel-octane"
 	step := &SetAppURLStep{}
 
 	if !step.ShouldRun(ctx) {
-		t.Error("ShouldRun should be true for laravel-octane projects")
+		t.Error("ShouldRun should be true for laravel-octane projects with .env")
+	}
+}
+
+func TestSetAppURLStep_ShouldRun_FalseWhenNoEnv(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	step := &SetAppURLStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false when .env does not exist")
 	}
 }
 

--- a/internal/laravel/steps_test.go
+++ b/internal/laravel/steps_test.go
@@ -1,0 +1,525 @@
+package laravel
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/services"
+)
+
+func testCtx(dir string) *automation.Context {
+	s := config.DefaultSettings()
+	return &automation.Context{
+		ProjectPath: dir,
+		ProjectName: "test-project",
+		ProjectType: "laravel",
+		TLD:         "test",
+		Settings:    s,
+		Env:         make(map[string]string),
+	}
+}
+
+// --- CopyEnvStep tests ---
+
+func TestCopyEnvStep_ShouldRun_FalseWithoutEnvExample(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	step := &CopyEnvStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false when .env.example is missing")
+	}
+}
+
+func TestCopyEnvStep_ShouldRun_TrueWhenEnvExampleExists(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env.example"), []byte("APP_KEY=\n"), 0644)
+	ctx := testCtx(dir)
+	step := &CopyEnvStep{}
+
+	if !step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be true when .env.example exists and .env is missing")
+	}
+}
+
+func TestCopyEnvStep_ShouldRun_FalseWhenEnvExists(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env.example"), []byte("APP_KEY=\n"), 0644)
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=\n"), 0644)
+	ctx := testCtx(dir)
+	step := &CopyEnvStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false when .env already exists")
+	}
+}
+
+func TestCopyEnvStep_ShouldRun_FalseForNonLaravel(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env.example"), []byte("APP_KEY=\n"), 0644)
+	ctx := testCtx(dir)
+	ctx.ProjectType = "php"
+	step := &CopyEnvStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false for non-Laravel projects")
+	}
+}
+
+func TestCopyEnvStep_Run(t *testing.T) {
+	dir := t.TempDir()
+	content := "APP_NAME=TestApp\nAPP_KEY=\nDB_HOST=localhost\n"
+	os.WriteFile(filepath.Join(dir, ".env.example"), []byte(content), 0644)
+
+	ctx := testCtx(dir)
+	step := &CopyEnvStep{}
+
+	result, err := step.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result != "copied .env.example → .env" {
+		t.Errorf("Run() result = %q", result)
+	}
+
+	// .env should exist with same content
+	data, err := os.ReadFile(filepath.Join(dir, ".env"))
+	if err != nil {
+		t.Fatalf("failed to read .env: %v", err)
+	}
+	if string(data) != content {
+		t.Errorf(".env content = %q, want %q", string(data), content)
+	}
+
+	// ctx.Env should be populated
+	if ctx.Env["APP_NAME"] != "TestApp" {
+		t.Errorf("ctx.Env[APP_NAME] = %q, want %q", ctx.Env["APP_NAME"], "TestApp")
+	}
+	if ctx.Env["DB_HOST"] != "localhost" {
+		t.Errorf("ctx.Env[DB_HOST] = %q, want %q", ctx.Env["DB_HOST"], "localhost")
+	}
+}
+
+// --- SetAppURLStep tests ---
+
+func TestSetAppURLStep_ShouldRun_TrueForLaravel(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	step := &SetAppURLStep{}
+
+	if !step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be true for Laravel projects")
+	}
+}
+
+func TestSetAppURLStep_ShouldRun_TrueForLaravelOctane(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	ctx.ProjectType = "laravel-octane"
+	step := &SetAppURLStep{}
+
+	if !step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be true for laravel-octane projects")
+	}
+}
+
+func TestSetAppURLStep_ShouldRun_FalseForPHP(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	ctx.ProjectType = "php"
+	step := &SetAppURLStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false for php projects")
+	}
+}
+
+func TestSetAppURLStep_Run(t *testing.T) {
+	dir := t.TempDir()
+	// Create .env for MergeDotEnv to work on
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_URL=http://localhost\n"), 0644)
+
+	ctx := testCtx(dir)
+	step := &SetAppURLStep{}
+
+	result, err := step.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result != "https://test-project.test" {
+		t.Errorf("Run() result = %q, want %q", result, "https://test-project.test")
+	}
+
+	// Verify .env was updated
+	env, err := services.ReadDotEnv(filepath.Join(dir, ".env"))
+	if err != nil {
+		t.Fatalf("failed to read .env: %v", err)
+	}
+	if env["APP_URL"] != "https://test-project.test" {
+		t.Errorf("APP_URL = %q, want %q", env["APP_URL"], "https://test-project.test")
+	}
+}
+
+// --- GenerateKeyStep tests ---
+
+func TestGenerateKeyStep_ShouldRun_FalseWithoutEnvFile(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	step := &GenerateKeyStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false when .env is missing")
+	}
+}
+
+func TestGenerateKeyStep_ShouldRun_TrueWhenKeyEmpty(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=\n"), 0644)
+	ctx := testCtx(dir)
+	step := &GenerateKeyStep{}
+
+	if !step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be true when APP_KEY is empty")
+	}
+}
+
+func TestGenerateKeyStep_ShouldRun_FalseWhenKeySet(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=base64:abc123\n"), 0644)
+	ctx := testCtx(dir)
+	step := &GenerateKeyStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false when APP_KEY is already set")
+	}
+}
+
+func TestGenerateKeyStep_ShouldRun_FalseForNonLaravel(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=\n"), 0644)
+	ctx := testCtx(dir)
+	ctx.ProjectType = "php"
+	step := &GenerateKeyStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false for non-Laravel projects")
+	}
+}
+
+// --- InstallOctaneStep tests ---
+
+func TestInstallOctaneStep_ShouldRun_FalseForNonLaravel(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	ctx.ProjectType = "php"
+	step := &InstallOctaneStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false for non-Laravel projects")
+	}
+}
+
+func TestInstallOctaneStep_ShouldRun_FalseWithoutOctanePackage(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"laravel/framework":"^11.0"}}`), 0644)
+	ctx := testCtx(dir)
+	step := &InstallOctaneStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false without octane in composer.json")
+	}
+}
+
+func TestInstallOctaneStep_ShouldRun_TrueWhenOctanePackageNoWorker(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"laravel/octane":"^2.0"}}`), 0644)
+	ctx := testCtx(dir)
+	step := &InstallOctaneStep{}
+
+	if !step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be true when octane is in composer.json but worker is missing")
+	}
+}
+
+func TestInstallOctaneStep_ShouldRun_FalseWhenWorkerExists(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{"require":{"laravel/octane":"^2.0"}}`), 0644)
+	os.MkdirAll(filepath.Join(dir, "public"), 0755)
+	os.WriteFile(filepath.Join(dir, "public", "frankenphp-worker.php"), []byte("<?php"), 0644)
+	ctx := testCtx(dir)
+	step := &InstallOctaneStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false when worker already exists")
+	}
+}
+
+// --- ComposerInstallStep tests ---
+
+func TestComposerInstallStep_ShouldRun_FalseForNonLaravel(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	ctx.ProjectType = "php"
+	step := &ComposerInstallStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false for non-Laravel projects")
+	}
+}
+
+func TestComposerInstallStep_ShouldRun_FalseWithoutComposerJSON(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	step := &ComposerInstallStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false without composer.json")
+	}
+}
+
+func TestComposerInstallStep_ShouldRun_TrueWhenVendorMissing(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte("{}"), 0644)
+	ctx := testCtx(dir)
+	step := &ComposerInstallStep{}
+
+	if !step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be true when vendor/ is missing")
+	}
+}
+
+func TestComposerInstallStep_ShouldRun_FalseWhenVendorExists(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "composer.json"), []byte("{}"), 0644)
+	os.MkdirAll(filepath.Join(dir, "vendor"), 0755)
+	ctx := testCtx(dir)
+	step := &ComposerInstallStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false when vendor/ exists")
+	}
+}
+
+// --- DetectServicesStep tests ---
+
+func TestDetectServicesStep_ShouldRun_FalseForNonLaravel(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	ctx.ProjectType = "php"
+	step := &DetectServicesStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false for non-Laravel projects")
+	}
+}
+
+func TestDetectServicesStep_ShouldRun_FalseWithNoRegistry(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	step := &DetectServicesStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false with nil registry")
+	}
+}
+
+func TestDetectServicesStep_ShouldRun_FalseNoServicesbound(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	reg := &registry.Registry{
+		Projects: []registry.Project{
+			{Name: "test-project", Path: dir, Services: &registry.ProjectServices{}},
+		},
+	}
+	ctx.Registry = reg
+	step := &DetectServicesStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false when no services are bound")
+	}
+}
+
+func TestDetectServicesStep_ShouldRun_TrueWithRedis(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	reg := &registry.Registry{
+		Projects: []registry.Project{
+			{Name: "test-project", Path: dir, Services: &registry.ProjectServices{Redis: true}},
+		},
+	}
+	ctx.Registry = reg
+	step := &DetectServicesStep{}
+
+	if !step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be true when Redis is bound")
+	}
+}
+
+func TestDetectServicesStep_Run(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_NAME=Test\n"), 0644)
+
+	ctx := testCtx(dir)
+	reg := &registry.Registry{
+		Projects: []registry.Project{
+			{Name: "test-project", Path: dir, Services: &registry.ProjectServices{Redis: true, Mail: true}},
+		},
+	}
+	ctx.Registry = reg
+	step := &DetectServicesStep{}
+
+	result, err := step.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if !strings.Contains(result, "4 service env vars") {
+		t.Errorf("Run() result = %q, expected mention of 4 vars", result)
+	}
+
+	// Check .env was updated
+	env, err := services.ReadDotEnv(filepath.Join(dir, ".env"))
+	if err != nil {
+		t.Fatalf("failed to read .env: %v", err)
+	}
+	if env["CACHE_STORE"] != "redis" {
+		t.Errorf("CACHE_STORE = %q, want %q", env["CACHE_STORE"], "redis")
+	}
+	if env["MAIL_MAILER"] != "smtp" {
+		t.Errorf("MAIL_MAILER = %q, want %q", env["MAIL_MAILER"], "smtp")
+	}
+}
+
+// --- CreateDatabaseStep tests ---
+
+func TestCreateDatabaseStep_ShouldRun_FalseForNonLaravel(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	ctx.ProjectType = "php"
+	step := &CreateDatabaseStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false for non-Laravel projects")
+	}
+}
+
+func TestCreateDatabaseStep_ShouldRun_FalseWithoutDBService(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	reg := &registry.Registry{
+		Projects: []registry.Project{
+			{Name: "test-project", Path: dir, Services: &registry.ProjectServices{Redis: true}},
+		},
+	}
+	ctx.Registry = reg
+	step := &CreateDatabaseStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false without a database service")
+	}
+}
+
+func TestCreateDatabaseStep_ShouldRun_TrueWithMySQL(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	reg := &registry.Registry{
+		Projects: []registry.Project{
+			{Name: "test-project", Path: dir, Services: &registry.ProjectServices{MySQL: "8.0"}},
+		},
+	}
+	ctx.Registry = reg
+	step := &CreateDatabaseStep{}
+
+	if !step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be true with MySQL bound")
+	}
+}
+
+func TestCreateDatabaseStep_Run(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	reg := &registry.Registry{
+		Projects: []registry.Project{
+			{Name: "test-project", Path: dir, Services: &registry.ProjectServices{MySQL: "8.0"}},
+		},
+	}
+	ctx.Registry = reg
+	step := &CreateDatabaseStep{}
+
+	result, err := step.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	// Should return sanitized project name as db name
+	if result != "test_project" {
+		t.Errorf("Run() result = %q, want %q", result, "test_project")
+	}
+	if !ctx.DBCreated {
+		t.Error("ctx.DBCreated should be true after Run")
+	}
+	// Verify database was recorded in registry (mutation persists via index access).
+	proj := reg.Projects[0]
+	if len(proj.Databases) != 1 || proj.Databases[0] != "test_project" {
+		t.Errorf("project databases = %v, want [test_project]", proj.Databases)
+	}
+}
+
+// --- RunMigrationsStep tests ---
+
+func TestRunMigrationsStep_ShouldRun_FalseForNonLaravel(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	ctx.ProjectType = "php"
+	step := &RunMigrationsStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false for non-Laravel projects")
+	}
+}
+
+func TestRunMigrationsStep_ShouldRun_FalseWhenDBNotCreated(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	step := &RunMigrationsStep{}
+
+	if step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be false when DBCreated is false")
+	}
+}
+
+func TestRunMigrationsStep_ShouldRun_TrueWhenDBCreated(t *testing.T) {
+	dir := t.TempDir()
+	ctx := testCtx(dir)
+	ctx.DBCreated = true
+	step := &RunMigrationsStep{}
+
+	if !step.ShouldRun(ctx) {
+		t.Error("ShouldRun should be true when DBCreated is true")
+	}
+}
+
+// --- isLaravel tests ---
+
+func TestIsLaravel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"laravel", true},
+		{"laravel-octane", true},
+		{"php", false},
+		{"static", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := isLaravel(tt.input); got != tt.want {
+				t.Errorf("isLaravel(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -88,11 +88,11 @@ func Start(tld string) error {
 	// Start file watcher for pv.yml changes in linked projects.
 	projectWatcher, watcherErr := watcher.New()
 	if watcherErr != nil {
-		fmt.Printf("Warning: cannot start file watcher: %v\n", watcherErr)
+		fmt.Fprintf(os.Stderr, "Warning: cannot start file watcher: %v\n", watcherErr)
 	} else {
 		for _, project := range reg.List() {
 			if err := projectWatcher.Watch(project.Name, project.Path); err != nil {
-				fmt.Printf("Warning: cannot watch %s: %v\n", project.Name, err)
+				fmt.Fprintf(os.Stderr, "Warning: cannot watch %s: %v\n", project.Name, err)
 			}
 		}
 		activeWatcher = projectWatcher
@@ -212,7 +212,7 @@ func handleWatcherEvents(w *watcher.Watcher, globalPHP string) {
 	for event := range w.Events() {
 		reg, err := registry.Load()
 		if err != nil {
-			fmt.Printf("Watcher: cannot load registry: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Watcher: cannot load registry: %v\n", err)
 			continue
 		}
 		project := reg.Find(event.ProjectName)
@@ -232,7 +232,7 @@ func handleWatcherEvents(w *watcher.Watcher, globalPHP string) {
 		}
 
 		if newPHP != "" && newPHP != project.PHP {
-			fmt.Printf("Watcher: %s PHP version changed %s -> %s\n", event.ProjectName, project.PHP, newPHP)
+			fmt.Fprintf(os.Stderr, "Watcher: %s PHP version changed %s -> %s\n", event.ProjectName, project.PHP, newPHP)
 			for i := range reg.Projects {
 				if reg.Projects[i].Name == event.ProjectName {
 					reg.Projects[i].PHP = newPHP
@@ -240,11 +240,11 @@ func handleWatcherEvents(w *watcher.Watcher, globalPHP string) {
 				}
 			}
 			if err := reg.Save(); err != nil {
-				fmt.Printf("Watcher: cannot save registry: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Watcher: cannot save registry: %v\n", err)
 				continue
 			}
 			if err := ReconfigureServer(); err != nil {
-				fmt.Printf("Watcher: cannot reconfigure server: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Watcher: cannot reconfigure server: %v\n", err)
 			}
 		}
 	}
@@ -252,9 +252,14 @@ func handleWatcherEvents(w *watcher.Watcher, globalPHP string) {
 
 // WatchProject adds a project directory to the active file watcher.
 // Safe to call when no watcher is running (e.g. server not started).
+// Note: this is a no-op from CLI processes (link/unlink) since activeWatcher
+// is only set in the daemon's Start(). Projects linked after server start
+// will be watched on next server restart.
 func WatchProject(name, path string) {
 	if activeWatcher != nil {
-		_ = activeWatcher.Watch(name, path)
+		if err := activeWatcher.Watch(name, path); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: cannot watch %s for config changes: %v\n", name, err)
+		}
 	}
 }
 
@@ -262,6 +267,8 @@ func WatchProject(name, path string) {
 // Safe to call when no watcher is running.
 func UnwatchProject(path string) {
 	if activeWatcher != nil {
-		_ = activeWatcher.Unwatch(path)
+		if err := activeWatcher.Unwatch(path); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: cannot unwatch project: %v\n", err)
+		}
 	}
 }

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -10,8 +10,13 @@ import (
 
 	"github.com/prvious/pv/internal/caddy"
 	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/phpenv"
 	"github.com/prvious/pv/internal/registry"
+	"github.com/prvious/pv/internal/watcher"
 )
+
+// activeWatcher holds the file watcher for pv.yml changes in linked projects.
+var activeWatcher *watcher.Watcher
 
 // Start is the supervisor entry point. It writes a PID file, starts the DNS
 // server, the main FrankenPHP, and any needed secondary FrankenPHP instances,
@@ -79,6 +84,25 @@ func Start(tld string) error {
 			fp.Stop()
 		}
 	}()
+
+	// Start file watcher for pv.yml changes in linked projects.
+	projectWatcher, watcherErr := watcher.New()
+	if watcherErr != nil {
+		fmt.Printf("Warning: cannot start file watcher: %v\n", watcherErr)
+	} else {
+		for _, project := range reg.List() {
+			if err := projectWatcher.Watch(project.Name, project.Path); err != nil {
+				fmt.Printf("Warning: cannot watch %s: %v\n", project.Name, err)
+			}
+		}
+		activeWatcher = projectWatcher
+		defer func() {
+			activeWatcher = nil
+			projectWatcher.Close()
+		}()
+
+		go handleWatcherEvents(projectWatcher, globalPHP)
+	}
 
 	// Wait for signals or child exit.
 	sigCh := make(chan os.Signal, 1)
@@ -180,4 +204,64 @@ func writePID() error {
 
 func removePID() {
 	os.Remove(config.PidFilePath())
+}
+
+// handleWatcherEvents processes pv.yml change events, re-resolves PHP versions,
+// updates the registry, and reconfigures the server when needed.
+func handleWatcherEvents(w *watcher.Watcher, globalPHP string) {
+	for event := range w.Events() {
+		reg, err := registry.Load()
+		if err != nil {
+			fmt.Printf("Watcher: cannot load registry: %v\n", err)
+			continue
+		}
+		project := reg.Find(event.ProjectName)
+		if project == nil {
+			continue
+		}
+
+		var newPHP string
+		switch event.Type {
+		case watcher.ConfigChanged, watcher.ConfigDeleted:
+			// Re-resolve PHP version (checks pv.yml -> composer.json -> global).
+			if v, err := phpenv.ResolveVersion(event.ProjectPath); err == nil && v != "" {
+				newPHP = v
+			} else {
+				newPHP = globalPHP
+			}
+		}
+
+		if newPHP != "" && newPHP != project.PHP {
+			fmt.Printf("Watcher: %s PHP version changed %s -> %s\n", event.ProjectName, project.PHP, newPHP)
+			for i := range reg.Projects {
+				if reg.Projects[i].Name == event.ProjectName {
+					reg.Projects[i].PHP = newPHP
+					break
+				}
+			}
+			if err := reg.Save(); err != nil {
+				fmt.Printf("Watcher: cannot save registry: %v\n", err)
+				continue
+			}
+			if err := ReconfigureServer(); err != nil {
+				fmt.Printf("Watcher: cannot reconfigure server: %v\n", err)
+			}
+		}
+	}
+}
+
+// WatchProject adds a project directory to the active file watcher.
+// Safe to call when no watcher is running (e.g. server not started).
+func WatchProject(name, path string) {
+	if activeWatcher != nil {
+		_ = activeWatcher.Watch(name, path)
+	}
+}
+
+// UnwatchProject removes a project directory from the active file watcher.
+// Safe to call when no watcher is running.
+func UnwatchProject(path string) {
+	if activeWatcher != nil {
+		_ = activeWatcher.Unwatch(path)
+	}
 }

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,0 +1,169 @@
+package watcher
+
+import (
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// EventType describes the kind of pv.yml change detected.
+type EventType int
+
+const (
+	// ConfigChanged indicates pv.yml was created or modified.
+	ConfigChanged EventType = iota
+	// ConfigDeleted indicates pv.yml was removed or renamed away.
+	ConfigDeleted
+)
+
+// Event carries information about a pv.yml change in a watched project.
+type Event struct {
+	ProjectName string
+	ProjectPath string
+	Type        EventType
+}
+
+const debounceDelay = 200 * time.Millisecond
+const configFile = "pv.yml"
+
+// Watcher monitors project directories for pv.yml changes using fsnotify.
+type Watcher struct {
+	fsWatcher *fsnotify.Watcher
+	events    chan Event
+	projects  map[string]string // dir path -> project name
+	mu        sync.RWMutex
+	done      chan struct{}
+	timers    map[string]*time.Timer
+	timerMu   sync.Mutex
+}
+
+// New creates a new Watcher and starts its internal event loop.
+func New() (*Watcher, error) {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Watcher{
+		fsWatcher: fsw,
+		events:    make(chan Event, 64),
+		projects:  make(map[string]string),
+		done:      make(chan struct{}),
+		timers:    make(map[string]*time.Timer),
+	}
+
+	go w.loop()
+
+	return w, nil
+}
+
+// Watch adds a project directory to the watch list.
+func (w *Watcher) Watch(projectName, projectPath string) error {
+	w.mu.Lock()
+	w.projects[projectPath] = projectName
+	w.mu.Unlock()
+
+	return w.fsWatcher.Add(projectPath)
+}
+
+// Unwatch removes a project directory from the watch list and cancels pending timers.
+func (w *Watcher) Unwatch(projectPath string) error {
+	w.mu.Lock()
+	delete(w.projects, projectPath)
+	w.mu.Unlock()
+
+	w.timerMu.Lock()
+	if t, ok := w.timers[projectPath]; ok {
+		t.Stop()
+		delete(w.timers, projectPath)
+	}
+	w.timerMu.Unlock()
+
+	return w.fsWatcher.Remove(projectPath)
+}
+
+// Events returns a read-only channel that emits pv.yml change events.
+func (w *Watcher) Events() <-chan Event {
+	return w.events
+}
+
+// Close shuts down the watcher and its internal goroutine.
+func (w *Watcher) Close() error {
+	close(w.done)
+	return w.fsWatcher.Close()
+}
+
+// loop is the internal goroutine that processes fsnotify events.
+func (w *Watcher) loop() {
+	for {
+		select {
+		case <-w.done:
+			return
+		case ev, ok := <-w.fsWatcher.Events:
+			if !ok {
+				return
+			}
+
+			// Only react to pv.yml files.
+			if filepath.Base(ev.Name) != configFile {
+				continue
+			}
+
+			dir := filepath.Dir(ev.Name)
+
+			w.mu.RLock()
+			projectName, watched := w.projects[dir]
+			w.mu.RUnlock()
+
+			if !watched {
+				continue
+			}
+
+			// Determine event type.
+			var evType EventType
+			if ev.Has(fsnotify.Remove) || ev.Has(fsnotify.Rename) {
+				evType = ConfigDeleted
+			} else if ev.Has(fsnotify.Write) || ev.Has(fsnotify.Create) {
+				evType = ConfigChanged
+			} else {
+				continue
+			}
+
+			w.debounce(dir, Event{
+				ProjectName: projectName,
+				ProjectPath: dir,
+				Type:        evType,
+			})
+
+		case _, ok := <-w.fsWatcher.Errors:
+			if !ok {
+				return
+			}
+			// Silently ignore fsnotify errors; the watcher continues.
+		}
+	}
+}
+
+// debounce coalesces rapid events for the same directory into a single event
+// after debounceDelay. The last event type wins.
+func (w *Watcher) debounce(dir string, event Event) {
+	w.timerMu.Lock()
+	defer w.timerMu.Unlock()
+
+	if t, ok := w.timers[dir]; ok {
+		t.Stop()
+	}
+
+	w.timers[dir] = time.AfterFunc(debounceDelay, func() {
+		select {
+		case <-w.done:
+		case w.events <- event:
+		}
+
+		w.timerMu.Lock()
+		delete(w.timers, dir)
+		w.timerMu.Unlock()
+	})
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,6 +1,8 @@
 package watcher
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -137,11 +139,11 @@ func (w *Watcher) loop() {
 				Type:        evType,
 			})
 
-		case _, ok := <-w.fsWatcher.Errors:
+		case err, ok := <-w.fsWatcher.Errors:
 			if !ok {
 				return
 			}
-			// Silently ignore fsnotify errors; the watcher continues.
+			fmt.Fprintf(os.Stderr, "Watcher: filesystem notification error: %v\n", err)
 		}
 	}
 }

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1,0 +1,190 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWatcher_DetectsFileChange(t *testing.T) {
+	dir := t.TempDir()
+
+	w, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer w.Close()
+
+	if err := w.Watch("myproject", dir); err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	// Let the watcher settle.
+	time.Sleep(50 * time.Millisecond)
+
+	// Write pv.yml.
+	if err := os.WriteFile(filepath.Join(dir, "pv.yml"), []byte("php: \"8.4\"\n"), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	select {
+	case ev := <-w.Events():
+		if ev.Type != ConfigChanged {
+			t.Errorf("expected ConfigChanged, got %d", ev.Type)
+		}
+		if ev.ProjectName != "myproject" {
+			t.Errorf("expected project name 'myproject', got %q", ev.ProjectName)
+		}
+		if ev.ProjectPath != dir {
+			t.Errorf("expected project path %q, got %q", dir, ev.ProjectPath)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ConfigChanged event")
+	}
+}
+
+func TestWatcher_DetectsFileDelete(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create the file first so we can delete it.
+	pvYml := filepath.Join(dir, "pv.yml")
+	if err := os.WriteFile(pvYml, []byte("php: \"8.3\"\n"), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	w, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer w.Close()
+
+	if err := w.Watch("delproject", dir); err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Remove pv.yml.
+	if err := os.Remove(pvYml); err != nil {
+		t.Fatalf("Remove error = %v", err)
+	}
+
+	select {
+	case ev := <-w.Events():
+		if ev.Type != ConfigDeleted {
+			t.Errorf("expected ConfigDeleted, got %d", ev.Type)
+		}
+		if ev.ProjectName != "delproject" {
+			t.Errorf("expected project name 'delproject', got %q", ev.ProjectName)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ConfigDeleted event")
+	}
+}
+
+func TestWatcher_Debounce(t *testing.T) {
+	dir := t.TempDir()
+
+	w, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer w.Close()
+
+	if err := w.Watch("debounce-proj", dir); err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Perform 5 rapid writes.
+	pvYml := filepath.Join(dir, "pv.yml")
+	for i := 0; i < 5; i++ {
+		if err := os.WriteFile(pvYml, []byte("php: \"8.4\"\n"), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// We should get exactly 1 event (debounced).
+	select {
+	case <-w.Events():
+		// Got the expected single event.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for debounced event")
+	}
+
+	// Wait a bit and confirm no more events arrive.
+	select {
+	case ev := <-w.Events():
+		t.Errorf("expected no more events after debounce, got %+v", ev)
+	case <-time.After(500 * time.Millisecond):
+		// Good, no extra events.
+	}
+}
+
+func TestWatcher_Unwatch(t *testing.T) {
+	dir := t.TempDir()
+
+	w, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer w.Close()
+
+	if err := w.Watch("unwatch-proj", dir); err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Unwatch the directory.
+	if err := w.Unwatch(dir); err != nil {
+		t.Fatalf("Unwatch() error = %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Write to pv.yml after unwatching.
+	if err := os.WriteFile(filepath.Join(dir, "pv.yml"), []byte("php: \"8.4\"\n"), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	// Expect no event.
+	select {
+	case ev := <-w.Events():
+		t.Errorf("expected no event after unwatch, got %+v", ev)
+	case <-time.After(500 * time.Millisecond):
+		// Good, no event received.
+	}
+}
+
+func TestWatcher_IgnoresNonPvYml(t *testing.T) {
+	dir := t.TempDir()
+
+	w, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer w.Close()
+
+	if err := w.Watch("ignore-proj", dir); err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Write to a non-pv.yml file.
+	if err := os.WriteFile(filepath.Join(dir, "other.txt"), []byte("hello\n"), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	// Expect no event.
+	select {
+	case ev := <-w.Events():
+		t.Errorf("expected no event for other.txt, got %+v", ev)
+	case <-time.After(500 * time.Millisecond):
+		// Good, no event received.
+	}
+}


### PR DESCRIPTION
## Summary

- **Automation config**: New `automation:` section in `~/.pv/pv.yml` with tri-state gates (`true`/`false`/`ask`) for each automation feature
- **Pipeline runner**: `internal/automation/` — `Step` interface + `RunPipeline()` with gate checking and interactive huh prompts
- **Laravel intelligence**: `internal/laravel/` — smart env vars (maps running services → Laravel config), database name resolution from `.env.example`, artisan/composer runners, 8 pipeline step implementations
- **`pv link` automation**: copies `.env.example`, generates `APP_KEY`, installs Octane worker, runs `composer install`, detects/binds services, sets `APP_URL`, creates databases, runs migrations
- **Service hooks**: auto-updates linked project `.env` files on `service:add`/`service:start`, applies safe fallbacks on `service:stop`/`service:remove` (only overwrites values pv originally set)
- **File watcher**: fsnotify-based `pv.yml` watcher with 200ms debounce, re-resolves PHP versions and reconfigures server on config changes
- **Caddyfile update**: `vendor/autoload.php` added to FrankenPHP Octane worker watch directive

## Test plan

- [x] `go test ./...` — all 26 packages pass (0 failures)
- [x] Config tests: default automation values, round-trip save/load, missing section defaults
- [x] Pipeline tests: gate on/off/ask, non-interactive mode, confirm/deny prompts
- [x] Laravel tests: smart env vars, fallback mapping, database name resolution, project helpers, all 8 steps
- [x] Link tests: env copy, APP_URL setting, non-Laravel skip, Octane re-detection, existing env preservation
- [x] Service hooks tests: extract helpers, fallback integration
- [x] Watcher tests: change detection, delete detection, 200ms debounce, unwatch, non-pv.yml filtering
- [x] Caddy tests: Octane template includes vendor/autoload.php watch
- [x] Manual smoke test with a real Laravel project