### PR TITLE
Add daemon toggle to setup wizard and auto-enable on install

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -176,13 +176,18 @@ pv install --with="php:8.3,service[redis:7],service[mysql:8.0]"`,
 			return err
 		}
 
-		// Step 7: Enable daemon (default: true, configurable via settings).
+		// Step 7: Enable daemon unless explicitly disabled in ~/.pv/pv.yml.
 		settings, loadErr := config.LoadSettings()
-		if loadErr == nil && settings.Defaults.DaemonEnabled() {
+		if loadErr != nil {
+			ui.Subtle(fmt.Sprintf("Warning: could not load settings for daemon setup: %v", loadErr))
+			settings = config.DefaultSettings()
+		}
+		if settings.Defaults.DaemonEnabled() {
 			if err := daemoncmds.RunEnable(); err != nil {
 				if !errors.Is(err, ui.ErrAlreadyPrinted) {
 					ui.Fail(fmt.Sprintf("Daemon setup failed: %v", err))
 				}
+				ui.Subtle("Run 'pv daemon:enable' to retry.")
 			}
 		}
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/prvious/pv/internal/commands/composer"
+	daemoncmds "github.com/prvious/pv/internal/commands/daemon"
 	"github.com/prvious/pv/internal/commands/mago"
 	"github.com/prvious/pv/internal/commands/php"
 	"github.com/prvious/pv/internal/commands/service"
@@ -175,7 +176,17 @@ pv install --with="php:8.3,service[redis:7],service[mysql:8.0]"`,
 			return err
 		}
 
-		// Step 7: Install services from --with.
+		// Step 7: Enable daemon (default: true, configurable via settings).
+		settings, loadErr := config.LoadSettings()
+		if loadErr == nil && settings.Defaults.DaemonEnabled() {
+			if err := daemoncmds.RunEnable(); err != nil {
+				if !errors.Is(err, ui.ErrAlreadyPrinted) {
+					ui.Fail(fmt.Sprintf("Daemon setup failed: %v", err))
+				}
+			}
+		}
+
+		// Step 8: Install services from --with.
 		for _, svc := range spec.services {
 			svcArgs := []string{svc.name}
 			if svc.version != "" {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prvious/pv/internal/binaries"
 	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/commands/composer"
+	daemoncmds "github.com/prvious/pv/internal/commands/daemon"
 	"github.com/prvious/pv/internal/commands/mago"
 	"github.com/prvious/pv/internal/commands/service"
 	"github.com/prvious/pv/internal/config"
@@ -80,11 +81,12 @@ var setupCmd = &cobra.Command{
 			settings = config.DefaultSettings()
 		}
 		tld := settings.Defaults.TLD
+		daemon := settings.Defaults.DaemonEnabled()
 		automation := settings.Automation
 
 		// Run the tabbed setup wizard.
 		result, err := tea.NewProgram(
-			newSetupModel(phpOpts, toolOpts, svcOpts, tld, automation),
+			newSetupModel(phpOpts, toolOpts, svcOpts, tld, daemon, automation),
 			tea.WithOutput(os.Stderr),
 		).Run()
 		if err != nil {
@@ -103,6 +105,7 @@ var setupCmd = &cobra.Command{
 		selectedTools := selectedValues(final.toolOptions)
 		selectedServices := selectedValues(final.svcOptions)
 		tld = final.tld
+		daemon = final.daemon
 		automation = final.automation
 
 		fmt.Fprintln(os.Stderr)
@@ -126,7 +129,7 @@ var setupCmd = &cobra.Command{
 
 		// Build settings from wizard output, preserving existing PHP default.
 		s := &config.Settings{
-			Defaults:   config.Defaults{TLD: tld, PHP: settings.Defaults.PHP},
+			Defaults:   config.Defaults{TLD: tld, PHP: settings.Defaults.PHP, Daemon: config.BoolPtr(daemon)},
 			Automation: automation,
 		}
 		if err := s.Save(); err != nil {
@@ -204,6 +207,15 @@ var setupCmd = &cobra.Command{
 		// Finalize: Caddyfile, DNS, CA trust, shell PATH.
 		if err := bootstrapFinalize(tld); err != nil {
 			return err
+		}
+
+		// Enable daemon if selected.
+		if daemon {
+			if err := daemoncmds.RunEnable(); err != nil {
+				if !errors.Is(err, ui.ErrAlreadyPrinted) {
+					ui.Fail(fmt.Sprintf("Daemon setup failed: %v", err))
+				}
+			}
 		}
 
 		// Spin up selected services.

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -215,6 +215,7 @@ var setupCmd = &cobra.Command{
 				if !errors.Is(err, ui.ErrAlreadyPrinted) {
 					ui.Fail(fmt.Sprintf("Daemon setup failed: %v", err))
 				}
+				ui.Subtle("Run 'pv daemon:enable' to retry.")
 			}
 		}
 

--- a/cmd/setup_tui.go
+++ b/cmd/setup_tui.go
@@ -33,8 +33,9 @@ type setupModel struct {
 	tld            string
 	tldCursor      int
 	editing        bool // Whether the TLD input is in edit mode.
+	daemon         bool
 	automation     config.Automation
-	settingsCursor int // 0=TLD, 1..N=automation items
+	settingsCursor int // 0=TLD, 1=daemon, 2..N+1=automation items
 
 	confirmed bool
 	quitting  bool
@@ -67,7 +68,7 @@ func cycleAutoMode(m config.AutoMode) config.AutoMode {
 	}
 }
 
-func newSetupModel(phpOpts, toolOpts, svcOpts []selectOption, tld string, automation config.Automation) setupModel {
+func newSetupModel(phpOpts, toolOpts, svcOpts []selectOption, tld string, daemon bool, automation config.Automation) setupModel {
 	return setupModel{
 		tabs:        []string{"PHP Versions", "Tools", "Services", "Settings"},
 		phpOptions:  phpOpts,
@@ -75,6 +76,7 @@ func newSetupModel(phpOpts, toolOpts, svcOpts []selectOption, tld string, automa
 		svcOptions:  svcOpts,
 		tld:         tld,
 		tldCursor:   len(tld),
+		daemon:      daemon,
 		automation:  automation,
 		width:       80,
 	}
@@ -140,12 +142,14 @@ func (m setupModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.settingsCursor--
 				}
 			case "down", "j":
-				if m.settingsCursor < len(automationItems) {
+				if m.settingsCursor < len(automationItems)+1 {
 					m.settingsCursor++
 				}
 			case " ", "space", "x":
-				if m.settingsCursor > 0 {
-					idx := m.settingsCursor - 1
+				if m.settingsCursor == 1 {
+					m.daemon = !m.daemon
+				} else if m.settingsCursor > 1 {
+					idx := m.settingsCursor - 2
 					current := automationItems[idx].get(&m.automation)
 					automationItems[idx].set(&m.automation, cycleAutoMode(current))
 				}
@@ -259,7 +263,7 @@ func (m setupModel) View() tea.View {
 	case 2:
 		content = renderSetupMultiSelect("Select backing services to set up:", m.svcOptions, m.svcCursor)
 	case 3:
-		content = renderSettingsTab(m.tld, m.tldCursor, m.editing, &m.automation, m.settingsCursor)
+		content = renderSettingsTab(m.tld, m.tldCursor, m.editing, m.daemon, &m.automation, m.settingsCursor)
 	}
 
 	windowStyle := lipgloss.NewStyle().
@@ -279,6 +283,8 @@ func (m setupModel) View() tea.View {
 		doc.WriteString(helpStyle.Render("type to edit • ←/→ move cursor • enter/esc stop editing"))
 	case m.activeTab == len(m.tabs)-1 && m.settingsCursor == 0:
 		doc.WriteString(helpStyle.Render("←/→ navigate • ↑/↓ move • e to edit TLD • enter confirm • esc quit"))
+	case m.activeTab == len(m.tabs)-1 && m.settingsCursor == 1:
+		doc.WriteString(helpStyle.Render("←/→ navigate • ↑/↓ move • space toggle • enter confirm • esc quit"))
 	case m.activeTab == len(m.tabs)-1:
 		doc.WriteString(helpStyle.Render("←/→ navigate • ↑/↓ move • space cycle • enter confirm • esc quit"))
 	default:
@@ -319,10 +325,11 @@ func renderSetupMultiSelect(desc string, opts []selectOption, cursor int) string
 	return b.String()
 }
 
-func renderSettingsTab(tld string, tldCursor int, editing bool, automation *config.Automation, settingsCursor int) string {
+func renderSettingsTab(tld string, tldCursor int, editing bool, daemon bool, automation *config.Automation, settingsCursor int) string {
 	var b strings.Builder
 	cursorStyle := lipgloss.NewStyle().Foreground(highlightColor).Bold(true)
 	faintStyle := lipgloss.NewStyle().Faint(true)
+	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(2))
 
 	// --- TLD section ---
 	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(highlightColor).Render("Domain"))
@@ -355,6 +362,23 @@ func renderSettingsTab(tld string, tldCursor int, editing bool, automation *conf
 		}
 	}
 
+	// --- Daemon section ---
+	b.WriteString("\n\n")
+	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(highlightColor).Render("Daemon"))
+	b.WriteString("\n")
+	b.WriteString(faintStyle.Render("Start pv automatically on login"))
+	b.WriteString("\n\n")
+
+	prefix = "  "
+	if settingsCursor == 1 {
+		prefix = cursorStyle.Render("> ")
+	}
+	if daemon {
+		b.WriteString(prefix + greenStyle.Render("true"))
+	} else {
+		b.WriteString(prefix + faintStyle.Render("false"))
+	}
+
 	// --- Automation section ---
 	b.WriteString("\n\n")
 	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(highlightColor).Render("Automation"))
@@ -362,7 +386,6 @@ func renderSettingsTab(tld string, tldCursor int, editing bool, automation *conf
 	b.WriteString(faintStyle.Render("Configure which steps run during pv link"))
 	b.WriteString("\n\n")
 
-	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(2))
 	yellowStyle := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(3))
 
 	// Find longest label for alignment.
@@ -375,7 +398,7 @@ func renderSettingsTab(tld string, tldCursor int, editing bool, automation *conf
 
 	for i, item := range automationItems {
 		prefix := "  "
-		if settingsCursor == i+1 {
+		if settingsCursor == i+2 {
 			prefix = cursorStyle.Render("> ")
 		}
 

--- a/cmd/setup_tui.go
+++ b/cmd/setup_tui.go
@@ -35,7 +35,7 @@ type setupModel struct {
 	editing        bool // Whether the TLD input is in edit mode.
 	daemon         bool
 	automation     config.Automation
-	settingsCursor int // 0=TLD, 1=daemon, 2..N+1=automation items
+	settingsCursor int // Indexes: 0=TLD, 1=daemon, i+2=automationItems[i]
 
 	confirmed bool
 	quitting  bool

--- a/internal/commands/daemon/register.go
+++ b/internal/commands/daemon/register.go
@@ -8,6 +8,10 @@ func Register(parent *cobra.Command) {
 	parent.AddCommand(restartCmd)
 }
 
+func RunEnable() error {
+	return enableCmd.RunE(enableCmd, nil)
+}
+
 func RunRestart() error {
 	return restartCmd.RunE(restartCmd, nil)
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -18,8 +18,9 @@ const (
 )
 
 type Defaults struct {
-	PHP string `yaml:"php,omitempty"`
-	TLD string `yaml:"tld"`
+	PHP    string `yaml:"php,omitempty"`
+	TLD    string `yaml:"tld"`
+	Daemon *bool  `yaml:"daemon,omitempty"`
 }
 
 // Automation controls which link-time steps run automatically.
@@ -94,9 +95,21 @@ func applyAutomationDefaults(a *Automation) {
 	}
 }
 
+// DaemonEnabled returns whether the daemon should be enabled.
+// Defaults to true when not set.
+func (d Defaults) DaemonEnabled() bool {
+	if d.Daemon == nil {
+		return true
+	}
+	return *d.Daemon
+}
+
+// BoolPtr returns a pointer to a bool value.
+func BoolPtr(b bool) *bool { return &b }
+
 func DefaultSettings() *Settings {
 	return &Settings{
-		Defaults:   Defaults{TLD: "test"},
+		Defaults:   Defaults{TLD: "test", Daemon: BoolPtr(true)},
 		Automation: DefaultAutomation(),
 	}
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -130,6 +130,9 @@ func LoadSettings() (*Settings, error) {
 	if s.Defaults.TLD == "" {
 		s.Defaults.TLD = "test"
 	}
+	if s.Defaults.Daemon == nil {
+		s.Defaults.Daemon = BoolPtr(true)
+	}
 	applyAutomationDefaults(&s.Automation)
 	return &s, nil
 }


### PR DESCRIPTION
## Summary
- Adds a **Daemon** toggle (default: `true`) to the `pv setup` wizard's Settings tab, between Domain and Automation
- After `bootstrapFinalize`, both `pv setup` and `pv install` automatically call `daemon:enable` when the setting is true
- New `defaults.daemon` field in `pv.yml` (omitted when true, persisted when false)
- Exported `RunEnable()` from daemon commands package for orchestrator use

## Test plan
- [ ] Run `pv setup`, navigate to Settings tab, verify Daemon toggle appears with `true` default
- [ ] Toggle daemon to `false` with space, confirm, verify `pv.yml` has `daemon: false`
- [ ] Run `pv setup` again, verify daemon setting loads as `false`
- [ ] Run `pv install` on a fresh env, verify daemon is auto-enabled
- [ ] Run all tests: `go test ./...`