### PR TITLE
Resolve pv binary path dynamically for daemon plist

### DIFF
--- a/internal/daemon/plist.go
+++ b/internal/daemon/plist.go
@@ -23,11 +23,21 @@ type PlistConfig struct {
 }
 
 // DefaultPlistConfig returns a PlistConfig populated from the current environment.
+// The pv binary path is resolved from the running executable so the plist works
+// regardless of where pv was installed (e.g. ~/.local/bin, /usr/local/bin).
 func DefaultPlistConfig() PlistConfig {
 	pvDir := config.PvDir()
+
+	pvBinary := filepath.Join(config.BinDir(), "pv")
+	if exe, err := os.Executable(); err == nil {
+		if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+			pvBinary = resolved
+		}
+	}
+
 	return PlistConfig{
 		Label:        Label,
-		PvBinaryPath: filepath.Join(config.BinDir(), "pv"),
+		PvBinaryPath: pvBinary,
 		LogDir:       config.LogsDir(),
 		HomeDir:      pvDir,
 		RunAtLoad:    false,

--- a/internal/daemon/plist_test.go
+++ b/internal/daemon/plist_test.go
@@ -252,8 +252,8 @@ func TestDefaultPlistConfig(t *testing.T) {
 	if cfg.Label != Label {
 		t.Errorf("Label = %q, want %q", cfg.Label, Label)
 	}
-	if !strings.HasSuffix(cfg.PvBinaryPath, filepath.Join(".pv", "bin", "pv")) {
-		t.Errorf("PvBinaryPath = %q, want suffix .pv/bin/pv", cfg.PvBinaryPath)
+	if cfg.PvBinaryPath == "" || !filepath.IsAbs(cfg.PvBinaryPath) {
+		t.Errorf("PvBinaryPath = %q, want non-empty absolute path", cfg.PvBinaryPath)
 	}
 	if !strings.HasSuffix(cfg.LogDir, filepath.Join(".pv", "logs")) {
 		t.Errorf("LogDir = %q, want suffix .pv/logs", cfg.LogDir)


### PR DESCRIPTION
## Summary
- `DefaultPlistConfig()` now uses `os.Executable()` + `filepath.EvalSymlinks()` to resolve the actual pv binary path instead of hardcoding `~/.pv/bin/pv`
- Fixes daemon failing to start when pv is installed to `~/.local/bin/` (default) or any custom location via `install.sh`
- Falls back to `~/.pv/bin/pv` if executable resolution fails

## Test plan
- [ ] Build pv, install to `~/.local/bin/pv`, run `pv daemon:enable`, verify plist points to `~/.local/bin/pv`
- [ ] Run `pv daemon:disable && pv daemon:enable` and verify daemon starts successfully
- [ ] Run `go test ./internal/daemon/`