### PR TITLE
Fix daemon and server error handling

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prvious/pv/internal/detection"
 	"github.com/prvious/pv/internal/laravel"
 	"github.com/prvious/pv/internal/phpenv"
+	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/registry"
 	"github.com/prvious/pv/internal/server"
 	"github.com/prvious/pv/internal/services"
@@ -190,11 +191,19 @@ pv link --name=myapp ~/Code/myapp`,
 		}
 
 		if server.IsRunning() {
-			if err := server.ReconfigureServer(); err != nil {
-				ui.Fail(fmt.Sprintf("Could not reconfigure server: %v", err))
-			}
-			if phpVersion != "" && phpVersion != globalPHP {
-				ui.Subtle("Restart the server to serve this project: pv stop && pv start")
+			needsRestart := phpVersion != "" && phpVersion != globalPHP
+			if needsRestart && daemon.IsLoaded() {
+				// Daemon mode: full restart to spawn secondary FrankenPHP for new PHP version.
+				if err := daemon.Restart(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not restart daemon: %v — run 'pv restart' manually", err))
+				}
+			} else {
+				if err := server.ReconfigureServer(); err != nil {
+					ui.Fail(fmt.Sprintf("Could not reconfigure server: %v", err))
+				}
+				if needsRestart {
+					ui.Subtle("Restart the server to serve this project: pv restart")
+				}
 			}
 		}
 

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -9,10 +9,10 @@ import (
 	"github.com/prvious/pv/internal/caddy"
 	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/detection"
 	"github.com/prvious/pv/internal/laravel"
 	"github.com/prvious/pv/internal/phpenv"
-	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/registry"
 	"github.com/prvious/pv/internal/server"
 	"github.com/prvious/pv/internal/services"
@@ -193,16 +193,16 @@ pv link --name=myapp ~/Code/myapp`,
 		if server.IsRunning() {
 			needsRestart := phpVersion != "" && phpVersion != globalPHP
 			if needsRestart && daemon.IsLoaded() {
-				// Daemon mode: full restart to spawn secondary FrankenPHP for new PHP version.
+				// Daemon mode: full process restart so the relaunched server spawns a secondary FrankenPHP.
 				if err := daemon.Restart(); err != nil {
-					ui.Subtle(fmt.Sprintf("Could not restart daemon: %v — run 'pv restart' manually", err))
+					ui.Fail(fmt.Sprintf("Could not restart daemon: %v — run 'pv restart' manually", err))
 				}
 			} else {
 				if err := server.ReconfigureServer(); err != nil {
 					ui.Fail(fmt.Sprintf("Could not reconfigure server: %v", err))
 				}
 				if needsRestart {
-					ui.Subtle("Restart the server to serve this project: pv restart")
+					ui.Subtle("Stop and restart the server to serve this project: pv stop && pv start")
 				}
 			}
 		}

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -72,8 +72,11 @@ pv unlink`,
 			return fmt.Errorf("cannot generate Caddyfile: %w", err)
 		}
 
-		settings, _ := config.LoadSettings()
+		settings, settingsErr := config.LoadSettings()
 		tld := "test"
+		if settingsErr != nil {
+			ui.Subtle(fmt.Sprintf("Could not load settings: %v", settingsErr))
+		}
 		if settings != nil {
 			tld = settings.Defaults.TLD
 		}
@@ -89,7 +92,8 @@ pv unlink`,
 		ui.Success(fmt.Sprintf("Unlinked %s", ui.Purple.Bold(true).Render(domain)))
 
 		if server.IsRunning() {
-			// Check if unlinking this project orphans a secondary FrankenPHP.
+			// Check if unlinking this project orphans a secondary FrankenPHP
+			// (no remaining projects use its PHP version).
 			globalPHP := ""
 			if settings != nil {
 				globalPHP = settings.Defaults.PHP
@@ -98,16 +102,16 @@ pv unlink`,
 			versionOrphaned := hadSecondary && !caddy.ActiveVersions(reg.List(), globalPHP)[projectPHP]
 
 			if versionOrphaned && daemon.IsLoaded() {
-				// Daemon mode: full restart to stop orphaned secondary FrankenPHP.
+				// Daemon mode: full process restart so the relaunched server no longer spawns the unneeded secondary.
 				if err := daemon.Restart(); err != nil {
-					ui.Subtle(fmt.Sprintf("Could not restart daemon: %v — run 'pv restart' manually", err))
+					ui.Fail(fmt.Sprintf("Could not restart daemon: %v — run 'pv restart' manually", err))
 				}
 			} else {
 				if err := server.ReconfigureServer(); err != nil {
 					ui.Fail(fmt.Sprintf("Could not reconfigure server: %v", err))
 				}
 				if versionOrphaned {
-					ui.Subtle("Restart the server to clean up unused PHP processes: pv restart")
+					ui.Subtle("Stop and restart the server to clean up unused PHP processes: pv stop && pv start")
 				}
 			}
 		}

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prvious/pv/internal/caddy"
 	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/registry"
 	"github.com/prvious/pv/internal/server"
 	"github.com/prvious/pv/internal/ui"
@@ -46,12 +47,13 @@ pv unlink`,
 			name = p.Name
 		}
 
-		// Check project exists before removing and capture path for unwatching.
+		// Check project exists before removing and capture details for cleanup.
 		project := reg.Find(name)
 		if project == nil {
 			return fmt.Errorf("project %q is not linked", name)
 		}
 		projectPath := project.Path
+		projectPHP := project.PHP
 
 		if err := reg.Remove(name); err != nil {
 			return err
@@ -87,8 +89,26 @@ pv unlink`,
 		ui.Success(fmt.Sprintf("Unlinked %s", ui.Purple.Bold(true).Render(domain)))
 
 		if server.IsRunning() {
-			if err := server.ReconfigureServer(); err != nil {
-				ui.Fail(fmt.Sprintf("Could not reconfigure server: %v", err))
+			// Check if unlinking this project orphans a secondary FrankenPHP.
+			globalPHP := ""
+			if settings != nil {
+				globalPHP = settings.Defaults.PHP
+			}
+			hadSecondary := projectPHP != "" && projectPHP != globalPHP
+			versionOrphaned := hadSecondary && !caddy.ActiveVersions(reg.List(), globalPHP)[projectPHP]
+
+			if versionOrphaned && daemon.IsLoaded() {
+				// Daemon mode: full restart to stop orphaned secondary FrankenPHP.
+				if err := daemon.Restart(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not restart daemon: %v — run 'pv restart' manually", err))
+				}
+			} else {
+				if err := server.ReconfigureServer(); err != nil {
+					ui.Fail(fmt.Sprintf("Could not reconfigure server: %v", err))
+				}
+				if versionOrphaned {
+					ui.Subtle("Restart the server to clean up unused PHP processes: pv restart")
+				}
 			}
 		}
 

--- a/internal/commands/daemon/enable.go
+++ b/internal/commands/daemon/enable.go
@@ -14,14 +14,17 @@ var enableCmd = &cobra.Command{
 	Short:   "Enable pv as a login daemon (starts on boot)",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if internaldaemon.IsLoaded() {
-			// Already running — update plist in case binary path changed, then restart.
+			// Already loaded — unload, regenerate plist (binary path, env vars, etc. may have changed), and reload.
 			return ui.Step("Updating pv daemon...", func() (string, error) {
+				if err := internaldaemon.Unload(); err != nil {
+					return "", fmt.Errorf("cannot stop daemon for update: %w", err)
+				}
 				cfg := internaldaemon.DefaultPlistConfig()
 				cfg.RunAtLoad = true
 				if err := internaldaemon.Install(cfg); err != nil {
 					return "", fmt.Errorf("cannot update daemon plist: %w", err)
 				}
-				if err := internaldaemon.Restart(); err != nil {
+				if err := internaldaemon.Load(); err != nil {
 					return "", fmt.Errorf("cannot restart daemon: %w", err)
 				}
 				return "Daemon updated and restarted", nil

--- a/internal/commands/daemon/enable.go
+++ b/internal/commands/daemon/enable.go
@@ -13,6 +13,21 @@ var enableCmd = &cobra.Command{
 	GroupID: "daemon",
 	Short:   "Enable pv as a login daemon (starts on boot)",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if internaldaemon.IsLoaded() {
+			// Already running — update plist in case binary path changed, then restart.
+			return ui.Step("Updating pv daemon...", func() (string, error) {
+				cfg := internaldaemon.DefaultPlistConfig()
+				cfg.RunAtLoad = true
+				if err := internaldaemon.Install(cfg); err != nil {
+					return "", fmt.Errorf("cannot update daemon plist: %w", err)
+				}
+				if err := internaldaemon.Restart(); err != nil {
+					return "", fmt.Errorf("cannot restart daemon: %w", err)
+				}
+				return "Daemon updated and restarted", nil
+			})
+		}
+
 		return ui.Step("Installing pv daemon...", func() (string, error) {
 			cfg := internaldaemon.DefaultPlistConfig()
 			cfg.RunAtLoad = true
@@ -21,7 +36,6 @@ var enableCmd = &cobra.Command{
 				return "", fmt.Errorf("cannot install daemon: %w", err)
 			}
 
-			// Load the daemon so it starts immediately.
 			if err := internaldaemon.Load(); err != nil {
 				return "", fmt.Errorf("cannot start daemon: %w", err)
 			}

--- a/internal/daemon/launchctl.go
+++ b/internal/daemon/launchctl.go
@@ -32,7 +32,11 @@ func Uninstall() error {
 func Load() error {
 	out, err := exec.Command("launchctl", "load", PlistPath()).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("cannot start pv service: %s", strings.TrimSpace(string(out)))
+		output := strings.TrimSpace(string(out))
+		if output != "" {
+			return fmt.Errorf("cannot start pv service: %w (%s)", err, output)
+		}
+		return fmt.Errorf("cannot start pv service: %w", err)
 	}
 	return nil
 }
@@ -41,16 +45,24 @@ func Load() error {
 func Unload() error {
 	out, err := exec.Command("launchctl", "unload", PlistPath()).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("cannot stop pv service: %s", strings.TrimSpace(string(out)))
+		output := strings.TrimSpace(string(out))
+		if output != "" {
+			return fmt.Errorf("cannot stop pv service: %w (%s)", err, output)
+		}
+		return fmt.Errorf("cannot stop pv service: %w", err)
 	}
 	return nil
 }
 
-// Restart asks launchd to kill and restart the pv service in one atomic operation.
+// Restart asks launchd to kill and re-launch the pv service via kickstart -k.
 func Restart() error {
 	out, err := exec.Command("launchctl", "kickstart", "-k", serviceTarget()).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("cannot restart pv service: %s", strings.TrimSpace(string(out)))
+		output := strings.TrimSpace(string(out))
+		if output != "" {
+			return fmt.Errorf("cannot restart pv service: %w (%s)", err, output)
+		}
+		return fmt.Errorf("cannot restart pv service: %w", err)
 	}
 	return nil
 }

--- a/internal/server/dns.go
+++ b/internal/server/dns.go
@@ -65,6 +65,10 @@ func (d *DNSServer) handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 	}
 
 	if err := w.WriteMsg(msg); err != nil {
-		fmt.Fprintf(os.Stderr, "DNS: failed to write response for %s: %v\n", r.Question[0].Name, err)
+		qname := "(unknown)"
+		if len(r.Question) > 0 {
+			qname = r.Question[0].Name
+		}
+		fmt.Fprintf(os.Stderr, "DNS: failed to write response for %s: %v\n", qname, err)
 	}
 }

--- a/internal/server/dns.go
+++ b/internal/server/dns.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/miekg/dns"
 	"github.com/prvious/pv/internal/config"
@@ -63,5 +64,7 @@ func (d *DNSServer) handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 		}
 	}
 
-	w.WriteMsg(msg)
+	if err := w.WriteMsg(msg); err != nil {
+		fmt.Fprintf(os.Stderr, "DNS: failed to write response for %s: %v\n", r.Question[0].Name, err)
+	}
 }

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -120,7 +120,7 @@ func Start(tld string) error {
 func waitForEvent(sigCh chan os.Signal, dnsErr chan error, mainFP *FrankenPHP, secondaries []*FrankenPHP) error {
 	// Since Go doesn't support dynamic select, we merge secondary done channels
 	// into a single channel.
-	merged := make(chan string, 1) // version string or "" for non-secondary event
+	merged := make(chan string, 1) // version string of the exited secondary
 	done := make(chan struct{})
 	defer close(done)
 
@@ -160,8 +160,8 @@ func waitForEvent(sigCh chan os.Signal, dnsErr chan error, mainFP *FrankenPHP, s
 	}
 }
 
-// ReconfigureServer regenerates all caddy configs and restarts/reloads as needed.
-// Called after pv link, pv unlink, and watcher-triggered config changes.
+// ReconfigureServer regenerates all caddy configs and reloads the main FrankenPHP via its admin API.
+// Called after pv link, pv unlink, pv restart (foreground mode), and watcher-triggered config changes.
 func ReconfigureServer() error {
 	settings, err := config.LoadSettings()
 	if err != nil {

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -51,9 +51,13 @@ func Start(tld string) error {
 	dnsServer := NewDNSServer(tld)
 	dnsErr := make(chan error, 1)
 	go func() { dnsErr <- dnsServer.Start() }()
-	defer dnsServer.Shutdown()
+	defer func() {
+		if err := dnsServer.Shutdown(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: DNS server shutdown error: %v\n", err)
+		}
+	}()
 
-	fmt.Printf("DNS server listening on %s\n", dnsServer.Addr)
+	fmt.Fprintf(os.Stderr, "DNS server listening on %s\n", dnsServer.Addr)
 
 	// Start main FrankenPHP.
 	mainFP, err := StartFrankenPHP()
@@ -62,22 +66,22 @@ func Start(tld string) error {
 	}
 	defer mainFP.Stop()
 
-	fmt.Println("FrankenPHP started")
-	fmt.Printf("Serving .%s domains on https (port 443) and http (port 80)\n", tld)
+	fmt.Fprintln(os.Stderr, "FrankenPHP started")
+	fmt.Fprintf(os.Stderr, "Serving .%s domains on https (port 443) and http (port 80)\n", tld)
 
 	// Start secondary FrankenPHP instances for non-global PHP versions.
 	activeVersions := caddy.ActiveVersions(reg.List(), globalPHP)
 	var secondaries []*FrankenPHP
 	for version := range activeVersions {
 		port := config.PortForVersion(version)
-		fmt.Printf("Starting FrankenPHP for PHP %s on port %d...\n", version, port)
+		fmt.Fprintf(os.Stderr, "Starting FrankenPHP for PHP %s on port %d...\n", version, port)
 		fp, err := StartVersionFrankenPHP(version)
 		if err != nil {
-			fmt.Printf("Warning: cannot start FrankenPHP for PHP %s: %v\n", version, err)
+			fmt.Fprintf(os.Stderr, "Warning: cannot start FrankenPHP for PHP %s: %v\n", version, err)
 			continue
 		}
 		secondaries = append(secondaries, fp)
-		fmt.Printf("FrankenPHP (PHP %s) started on port %d\n", version, port)
+		fmt.Fprintf(os.Stderr, "FrankenPHP (PHP %s) started on port %d\n", version, port)
 	}
 	defer func() {
 		for _, fp := range secondaries {
@@ -107,6 +111,7 @@ func Start(tld string) error {
 	// Wait for signals or child exit.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
 
 	return waitForEvent(sigCh, dnsErr, mainFP, secondaries)
 }
@@ -125,7 +130,7 @@ func waitForEvent(sigCh chan os.Signal, dnsErr chan error, mainFP *FrankenPHP, s
 			select {
 			case err := <-f.Done():
 				if err != nil {
-					fmt.Printf("FrankenPHP (PHP %s) exited: %v\n", f.Version(), err)
+					fmt.Fprintf(os.Stderr, "FrankenPHP (PHP %s) exited: %v\n", f.Version(), err)
 				}
 				select {
 				case merged <- f.Version():
@@ -138,23 +143,25 @@ func waitForEvent(sigCh chan os.Signal, dnsErr chan error, mainFP *FrankenPHP, s
 
 	select {
 	case sig := <-sigCh:
-		fmt.Printf("\nReceived %s, shutting down...\n", sig)
+		fmt.Fprintf(os.Stderr, "\nReceived %s, shutting down...\n", sig)
+		return nil
 	case err := <-dnsErr:
 		if err != nil {
-			fmt.Printf("DNS server error: %v\n", err)
+			return fmt.Errorf("DNS server failed: %w", err)
 		}
+		return fmt.Errorf("DNS server exited unexpectedly")
 	case err := <-mainFP.Done():
 		if err != nil {
-			fmt.Printf("FrankenPHP exited: %v\n", err)
+			return fmt.Errorf("FrankenPHP exited unexpectedly: %w", err)
 		}
+		return fmt.Errorf("FrankenPHP exited unexpectedly")
 	case v := <-merged:
-		fmt.Printf("Secondary FrankenPHP (PHP %s) exited\n", v)
+		return fmt.Errorf("secondary FrankenPHP (PHP %s) exited unexpectedly", v)
 	}
-	return nil
 }
 
 // ReconfigureServer regenerates all caddy configs and restarts/reloads as needed.
-// Called after pv use, pv link, pv unlink when the server is running.
+// Called after pv link, pv unlink, and watcher-triggered config changes.
 func ReconfigureServer() error {
 	settings, err := config.LoadSettings()
 	if err != nil {
@@ -203,7 +210,9 @@ func writePID() error {
 }
 
 func removePID() {
-	os.Remove(config.PidFilePath())
+	if err := os.Remove(config.PidFilePath()); err != nil && !os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Warning: cannot remove PID file: %v\n", err)
+	}
 }
 
 // handleWatcherEvents processes pv.yml change events, re-resolves PHP versions,
@@ -227,6 +236,9 @@ func handleWatcherEvents(w *watcher.Watcher, globalPHP string) {
 			if v, err := phpenv.ResolveVersion(event.ProjectPath); err == nil && v != "" {
 				newPHP = v
 			} else {
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "Watcher: cannot resolve PHP version for %s: %v (falling back to global)\n", event.ProjectName, err)
+				}
 				newPHP = globalPHP
 			}
 		}

--- a/scripts/e2e/start-curl.sh
+++ b/scripts/e2e/start-curl.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 source "$(dirname "$0")/helpers.sh"
 
+# Disable daemon if auto-enabled during install — e2e tests use foreground mode with sudo.
+pv daemon:disable 2>/dev/null || true
+sleep 1
+
 sudo -E pv start &
 sleep 8
 


### PR DESCRIPTION
## Summary
- Launchctl commands now include Go error + command output in error messages for better debugging
- `daemon:enable` handles already-loaded service gracefully (updates plist and restarts)
- Server `waitForEvent` returns actual errors instead of always nil on child exit
- All server output directed to stderr (was incorrectly using stdout)
- DNS `WriteMsg` errors, signal cleanup, PID removal errors, and watcher version resolution errors all properly logged

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] `pv daemon:enable` when daemon already running updates and restarts cleanly
- [ ] `pv start --foreground` logs to stderr, not stdout
- [ ] Killing FrankenPHP child causes server to exit with descriptive error