### PR TITLE
Auto-install missing PHP version during pv link

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prvious/pv/internal/automation"
 	"github.com/prvious/pv/internal/caddy"
 	"github.com/prvious/pv/internal/certs"
+	"github.com/prvious/pv/internal/commands/php"
 	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/detection"
@@ -76,6 +77,36 @@ pv link --name=myapp ~/Code/myapp`,
 		phpVersion := globalPHP
 		if v, err := phpenv.ResolveVersion(absPath); err == nil && v != "" {
 			phpVersion = v
+		}
+
+		// Auto-install missing PHP version if needed.
+		if phpVersion != "" && phpVersion != globalPHP && !phpenv.IsInstalled(phpVersion) {
+			mode := automation.LookupGate(&settings.Automation, "install_php_version")
+
+			switch mode {
+			case config.AutoOff:
+				ui.Subtle(fmt.Sprintf("PHP %s is not installed (auto-install disabled). Site may not work until installed.", phpVersion))
+			case config.AutoAsk:
+				if automation.IsInteractive() {
+					confirmed, err := automation.ConfirmFunc(fmt.Sprintf("Install PHP %s", phpVersion))
+					if err != nil {
+						return fmt.Errorf("aborted")
+					}
+					if confirmed {
+						if err := php.RunInstall([]string{phpVersion}); err != nil {
+							return fmt.Errorf("cannot install PHP %s: %w", phpVersion, err)
+						}
+					} else {
+						ui.Subtle(fmt.Sprintf("PHP %s is not installed. Site may not work until installed.", phpVersion))
+					}
+				} else {
+					ui.Subtle(fmt.Sprintf("PHP %s is not installed (non-interactive). Site may not work until installed.", phpVersion))
+				}
+			default: // AutoOn
+				if err := php.RunInstall([]string{phpVersion}); err != nil {
+					return fmt.Errorf("cannot install PHP %s: %w", phpVersion, err)
+				}
+			}
 		}
 
 		project := registry.Project{Name: name, Path: absPath, Type: projectType, PHP: phpVersion}

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -102,7 +102,7 @@ pv link --name=myapp ~/Code/myapp`,
 				} else {
 					ui.Subtle(fmt.Sprintf("PHP %s is not installed (non-interactive). Site may not work until installed.", phpVersion))
 				}
-			default: // AutoOn
+			case config.AutoOn:
 				if err := php.RunInstall([]string{phpVersion}); err != nil {
 					return fmt.Errorf("cannot install PHP %s: %w", phpVersion, err)
 				}

--- a/cmd/link_test.go
+++ b/cmd/link_test.go
@@ -475,6 +475,87 @@ func TestLink_AutomationLoadsExistingEnv(t *testing.T) {
 	}
 }
 
+func TestLink_AutoOffWarnsButLinksWithMissingVersion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := config.DefaultSettings()
+	s.Defaults.PHP = "8.4"
+	s.Automation.InstallPHPVersion = config.AutoOff
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save settings error = %v", err)
+	}
+
+	// Fake that 8.4 is installed (global).
+	versionDir := config.PhpVersionDir("8.4")
+	if err := os.MkdirAll(versionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "frankenphp"), []byte("fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Project requests 8.3, which is NOT installed.
+	projDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projDir, "pv.yml"), []byte("php: \"8.3\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newLinkCmd()
+	cmd.SetArgs([]string{"link", projDir, "--name", "offtest"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("link command error = %v (AutoOff should warn, not fail)", err)
+	}
+
+	reg, _ := registry.Load()
+	p := reg.Find("offtest")
+	if p == nil {
+		t.Fatal("project not found — AutoOff should still link")
+	}
+	if p.PHP != "8.3" {
+		t.Errorf("PHP = %q, want %q", p.PHP, "8.3")
+	}
+}
+
+func TestLink_SkipsInstallWhenNonGlobalVersionIsInstalled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := config.DefaultSettings()
+	s.Defaults.PHP = "8.4"
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save settings error = %v", err)
+	}
+
+	// Fake both versions installed.
+	for _, ver := range []string{"8.4", "8.3"} {
+		versionDir := config.PhpVersionDir(ver)
+		if err := os.MkdirAll(versionDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(versionDir, "frankenphp"), []byte("fake"), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Project requests 8.3 (non-global but installed).
+	projDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projDir, "pv.yml"), []byte("php: \"8.3\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newLinkCmd()
+	cmd.SetArgs([]string{"link", projDir, "--name", "installedtest"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("link command error = %v", err)
+	}
+
+	reg, _ := registry.Load()
+	p := reg.Find("installedtest")
+	if p == nil {
+		t.Fatal("project not found")
+	}
+	if p.PHP != "8.3" {
+		t.Errorf("PHP = %q, want %q", p.PHP, "8.3")
+	}
+}
+
 func TestLink_SkipsInstallWhenVersionIsGlobal(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	s := config.DefaultSettings()

--- a/cmd/link_test.go
+++ b/cmd/link_test.go
@@ -474,3 +474,41 @@ func TestLink_AutomationLoadsExistingEnv(t *testing.T) {
 		t.Errorf("APP_KEY = %q, want %q", env["APP_KEY"], "base64:existingkey")
 	}
 }
+
+func TestLink_SkipsInstallWhenVersionIsGlobal(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s := config.DefaultSettings()
+	s.Defaults.PHP = "8.4"
+	if err := s.Save(); err != nil {
+		t.Fatalf("Save settings error = %v", err)
+	}
+
+	projDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projDir, "pv.yml"), []byte("php: \"8.4\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake that 8.4 is installed by creating the frankenphp binary.
+	versionDir := config.PhpVersionDir("8.4")
+	if err := os.MkdirAll(versionDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "frankenphp"), []byte("fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newLinkCmd()
+	cmd.SetArgs([]string{"link", projDir, "--name", "globalver"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("link command error = %v", err)
+	}
+
+	reg, _ := registry.Load()
+	p := reg.Find("globalver")
+	if p == nil {
+		t.Fatal("project not found")
+	}
+	if p.PHP != "8.4" {
+		t.Errorf("PHP = %q, want %q", p.PHP, "8.4")
+	}
+}

--- a/cmd/setup_tui.go
+++ b/cmd/setup_tui.go
@@ -46,6 +46,7 @@ var automationItems = []struct {
 	get   func(*config.Automation) config.AutoMode
 	set   func(*config.Automation, config.AutoMode)
 }{
+	{"Auto install missing PHP version", func(a *config.Automation) config.AutoMode { return a.InstallPHPVersion }, func(a *config.Automation, m config.AutoMode) { a.InstallPHPVersion = m }},
 	{"Run composer install", func(a *config.Automation) config.AutoMode { return a.ComposerInstall }, func(a *config.Automation, m config.AutoMode) { a.ComposerInstall = m }},
 	{"Copy .env.example to .env", func(a *config.Automation) config.AutoMode { return a.CopyEnv }, func(a *config.Automation, m config.AutoMode) { a.CopyEnv = m }},
 	{"Generate APP_KEY", func(a *config.Automation) config.AutoMode { return a.GenerateKey }, func(a *config.Automation, m config.AutoMode) { a.GenerateKey = m }},

--- a/internal/automation/pipeline.go
+++ b/internal/automation/pipeline.go
@@ -100,6 +100,8 @@ func RunPipeline(steps []Step, ctx *Context) error {
 // Unknown gates default to AutoAsk to avoid accidentally running unconfigured steps.
 func LookupGate(a *config.Automation, gate string) config.AutoMode {
 	switch gate {
+	case "install_php_version":
+		return a.InstallPHPVersion
 	case "composer_install":
 		return a.ComposerInstall
 	case "copy_env":

--- a/internal/automation/pipeline_test.go
+++ b/internal/automation/pipeline_test.go
@@ -169,6 +169,20 @@ func TestRunPipeline_AskSkipsWhenDenied(t *testing.T) {
 	}
 }
 
+func TestLookupGate_InstallPHPVersion(t *testing.T) {
+	a := config.DefaultAutomation()
+	mode := LookupGate(&a, "install_php_version")
+	if mode != config.AutoOn {
+		t.Errorf("LookupGate(install_php_version) = %q, want %q", mode, config.AutoOn)
+	}
+
+	a.InstallPHPVersion = config.AutoAsk
+	mode = LookupGate(&a, "install_php_version")
+	if mode != config.AutoAsk {
+		t.Errorf("LookupGate(install_php_version) = %q, want %q", mode, config.AutoAsk)
+	}
+}
+
 func TestLookupGate(t *testing.T) {
 	a := config.DefaultAutomation()
 
@@ -176,6 +190,7 @@ func TestLookupGate(t *testing.T) {
 		gate string
 		want config.AutoMode
 	}{
+		{"install_php_version", a.InstallPHPVersion},
 		{"composer_install", a.ComposerInstall},
 		{"copy_env", a.CopyEnv},
 		{"generate_key", a.GenerateKey},

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -25,15 +25,16 @@ type Defaults struct {
 
 // Automation controls which link-time steps run automatically.
 type Automation struct {
-	ComposerInstall  AutoMode `yaml:"composer_install,omitempty"`
-	CopyEnv          AutoMode `yaml:"copy_env,omitempty"`
-	GenerateKey      AutoMode `yaml:"generate_key,omitempty"`
-	SetAppURL        AutoMode `yaml:"set_app_url,omitempty"`
-	InstallOctane    AutoMode `yaml:"install_octane,omitempty"`
-	CreateDatabase   AutoMode `yaml:"create_database,omitempty"`
-	RunMigrations    AutoMode `yaml:"run_migrations,omitempty"`
-	ServiceEnvUpdate AutoMode `yaml:"update_env_on_service,omitempty"`
-	ServiceFallback  AutoMode `yaml:"service_fallback,omitempty"`
+	InstallPHPVersion AutoMode `yaml:"install_php_version,omitempty"`
+	ComposerInstall   AutoMode `yaml:"composer_install,omitempty"`
+	CopyEnv           AutoMode `yaml:"copy_env,omitempty"`
+	GenerateKey       AutoMode `yaml:"generate_key,omitempty"`
+	SetAppURL         AutoMode `yaml:"set_app_url,omitempty"`
+	InstallOctane     AutoMode `yaml:"install_octane,omitempty"`
+	CreateDatabase    AutoMode `yaml:"create_database,omitempty"`
+	RunMigrations     AutoMode `yaml:"run_migrations,omitempty"`
+	ServiceEnvUpdate  AutoMode `yaml:"update_env_on_service,omitempty"`
+	ServiceFallback   AutoMode `yaml:"service_fallback,omitempty"`
 }
 
 type Settings struct {
@@ -46,15 +47,16 @@ var validTLD = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`)
 // DefaultAutomation returns the default automation settings.
 func DefaultAutomation() Automation {
 	return Automation{
-		ComposerInstall:  AutoOn,
-		CopyEnv:          AutoOn,
-		GenerateKey:      AutoOn,
-		SetAppURL:        AutoOn,
-		InstallOctane:    AutoAsk,
-		CreateDatabase:   AutoOn,
-		RunMigrations:    AutoAsk,
-		ServiceEnvUpdate: AutoOn,
-		ServiceFallback:  AutoOn,
+		InstallPHPVersion: AutoOn,
+		ComposerInstall:   AutoOn,
+		CopyEnv:           AutoOn,
+		GenerateKey:       AutoOn,
+		SetAppURL:         AutoOn,
+		InstallOctane:     AutoAsk,
+		CreateDatabase:    AutoOn,
+		RunMigrations:     AutoAsk,
+		ServiceEnvUpdate:  AutoOn,
+		ServiceFallback:   AutoOn,
 	}
 }
 
@@ -66,6 +68,9 @@ func validAutoMode(m AutoMode) bool {
 // and replaces invalid values with the default.
 func applyAutomationDefaults(a *Automation) {
 	d := DefaultAutomation()
+	if !validAutoMode(a.InstallPHPVersion) {
+		a.InstallPHPVersion = d.InstallPHPVersion
+	}
 	if !validAutoMode(a.ComposerInstall) {
 		a.ComposerInstall = d.ComposerInstall
 	}

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -186,10 +186,20 @@ func TestSettings_SaveWithPHPOnlyDefaultsTLD(t *testing.T) {
 	}
 }
 
+func TestDefaultSettings_HasInstallPHPVersion(t *testing.T) {
+	s := DefaultSettings()
+	if s.Automation.InstallPHPVersion != AutoOn {
+		t.Errorf("InstallPHPVersion = %q, want %q", s.Automation.InstallPHPVersion, AutoOn)
+	}
+}
+
 func TestDefaultSettings_HasAutomationDefaults(t *testing.T) {
 	s := DefaultSettings()
 
 	a := s.Automation
+	if a.InstallPHPVersion != AutoOn {
+		t.Errorf("InstallPHPVersion = %q, want %q", a.InstallPHPVersion, AutoOn)
+	}
 	if a.ComposerInstall != AutoOn {
 		t.Errorf("ComposerInstall = %q, want %q", a.ComposerInstall, AutoOn)
 	}
@@ -268,6 +278,9 @@ func TestLoadSettings_MissingAutomationGetsDefaults(t *testing.T) {
 	}
 
 	a := loaded.Automation
+	if a.InstallPHPVersion != AutoOn {
+		t.Errorf("InstallPHPVersion = %q, want %q", a.InstallPHPVersion, AutoOn)
+	}
 	if a.ComposerInstall != AutoOn {
 		t.Errorf("ComposerInstall = %q, want %q", a.ComposerInstall, AutoOn)
 	}


### PR DESCRIPTION
## Summary

- Adds `install_php_version` automation setting (default: `true`) to control whether `pv link` auto-installs a missing PHP version
- When `pv link` resolves a PHP version (from `pv.yml` or `composer.json`) that isn't installed, it now installs it automatically, prompts, or warns based on the setting
- Adds the setting to the setup wizard as "Auto install missing PHP version" and to the automation gate system

## How it works

After version resolution in `pv link`, if the resolved PHP version differs from the global default and isn't installed:

| Setting | Behavior |
|---------|----------|
| `true` (default) | Auto-installs via `php:install` |
| `ask` | Prompts with huh confirm (skips in non-interactive mode) |
| `false` | Warns and continues linking |

If installation fails, linking is aborted. If the user declines or the setting is off, linking continues with a warning.

## Motivation

Previously, linking a project with an uninstalled PHP version succeeded silently, and the failure only surfaced as a 502 Bad Gateway when visiting the site. This change catches it at link time — the natural moment to bootstrap project dependencies. This also lays the groundwork for a richer `pv link` / `pv init` that fully bootstraps from `pv.yml`.

## Test plan

- [x] `go vet ./...` passes clean
- [x] `gofmt -l .` reports no issues
- [x] Full test suite passes (`go test ./...`)
- [x] New tests: `TestDefaultSettings_HasInstallPHPVersion`, `TestLookupGate_InstallPHPVersion`, `TestLink_SkipsInstallWhenVersionIsGlobal`
- [ ] Manual: `pv link` on a project with `pv.yml` specifying an uninstalled version triggers install
- [ ] Manual: Set `install_php_version: ask` in `~/.pv/pv.yml`, verify prompt appears
- [ ] Manual: Set `install_php_version: "false"`, verify warning is shown but link succeeds