### PR TITLE
Auto-manage Laravel installer PHAR

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -166,18 +166,32 @@ pv install --with="php:8.3,service[redis:7],service[mysql:8.0]"`,
 			return err
 		}
 
-		// Step 5: Install managed packages (laravel installer).
+		// Step 5: Install managed packages.
 		pkgClient := &http.Client{}
 		for _, pkg := range packages.Managed {
-			if err := ui.StepProgress(fmt.Sprintf("Installing %s...", pkg.Name), func(progress func(written, total int64)) (string, error) {
-				version, err := packages.Install(pkgClient, pkg, progress)
-				if err != nil {
-					return "", err
+			if pkg.Method == packages.MethodPHAR {
+				if err := ui.StepProgress(fmt.Sprintf("Installing %s...", pkg.Name), func(progress func(written, total int64)) (string, error) {
+					version, err := packages.Install(pkgClient, pkg, progress)
+					if err != nil {
+						return "", err
+					}
+					return fmt.Sprintf("%s %s", pkg.Name, version), nil
+				}); err != nil {
+					if !errors.Is(err, ui.ErrAlreadyPrinted) {
+						ui.Fail(fmt.Sprintf("%s install failed: %v", pkg.Name, err))
+					}
 				}
-				return fmt.Sprintf("%s %s", pkg.Name, version), nil
-			}); err != nil {
-				if !errors.Is(err, ui.ErrAlreadyPrinted) {
-					ui.Fail(fmt.Sprintf("%s install failed: %v", pkg.Name, err))
+			} else {
+				if err := ui.Step(fmt.Sprintf("Installing %s...", pkg.Name), func() (string, error) {
+					version, err := packages.Install(pkgClient, pkg, nil)
+					if err != nil {
+						return "", err
+					}
+					return fmt.Sprintf("%s %s", pkg.Name, version), nil
+				}); err != nil {
+					if !errors.Is(err, ui.ErrAlreadyPrinted) {
+						ui.Fail(fmt.Sprintf("%s install failed: %v", pkg.Name, err))
+					}
 				}
 			}
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -168,10 +168,11 @@ pv install --with="php:8.3,service[redis:7],service[mysql:8.0]"`,
 
 		// Step 5: Install managed packages.
 		pkgClient := &http.Client{}
+		var pkgFailures []string
 		for _, pkg := range packages.Managed {
 			if pkg.Method == packages.MethodPHAR {
 				if err := ui.StepProgress(fmt.Sprintf("Installing %s...", pkg.Name), func(progress func(written, total int64)) (string, error) {
-					version, err := packages.Install(pkgClient, pkg, progress)
+					version, err := packages.Install(cmd.Context(), pkgClient, pkg, progress)
 					if err != nil {
 						return "", err
 					}
@@ -180,10 +181,11 @@ pv install --with="php:8.3,service[redis:7],service[mysql:8.0]"`,
 					if !errors.Is(err, ui.ErrAlreadyPrinted) {
 						ui.Fail(fmt.Sprintf("%s install failed: %v", pkg.Name, err))
 					}
+					pkgFailures = append(pkgFailures, pkg.Name)
 				}
 			} else {
 				if err := ui.Step(fmt.Sprintf("Installing %s...", pkg.Name), func() (string, error) {
-					version, err := packages.Install(pkgClient, pkg, nil)
+					version, err := packages.Install(cmd.Context(), pkgClient, pkg, nil)
 					if err != nil {
 						return "", err
 					}
@@ -192,8 +194,12 @@ pv install --with="php:8.3,service[redis:7],service[mysql:8.0]"`,
 					if !errors.Is(err, ui.ErrAlreadyPrinted) {
 						ui.Fail(fmt.Sprintf("%s install failed: %v", pkg.Name, err))
 					}
+					pkgFailures = append(pkgFailures, pkg.Name)
 				}
 			}
+		}
+		if len(pkgFailures) > 0 {
+			ui.Subtle(fmt.Sprintf("Warning: some packages failed to install: %s", strings.Join(pkgFailures, ", ")))
 		}
 
 		// Step 6: Install Mago (opt-in via --with).

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/prvious/pv/internal/commands/php"
 	"github.com/prvious/pv/internal/commands/service"
 	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/packages"
 	"github.com/prvious/pv/internal/services"
 	"github.com/prvious/pv/internal/setup"
 	"github.com/prvious/pv/internal/ui"
@@ -164,19 +166,35 @@ pv install --with="php:8.3,service[redis:7],service[mysql:8.0]"`,
 			return err
 		}
 
-		// Step 5: Install Mago (opt-in via --with).
+		// Step 5: Install managed packages (laravel installer).
+		pkgClient := &http.Client{}
+		for _, pkg := range packages.Managed {
+			if err := ui.StepProgress(fmt.Sprintf("Installing %s...", pkg.Name), func(progress func(written, total int64)) (string, error) {
+				version, err := packages.Install(pkgClient, pkg, progress)
+				if err != nil {
+					return "", err
+				}
+				return fmt.Sprintf("%s %s", pkg.Name, version), nil
+			}); err != nil {
+				if !errors.Is(err, ui.ErrAlreadyPrinted) {
+					ui.Fail(fmt.Sprintf("%s install failed: %v", pkg.Name, err))
+				}
+			}
+		}
+
+		// Step 6: Install Mago (opt-in via --with).
 		if spec.mago {
 			if err := mago.RunInstall(); err != nil {
 				return err
 			}
 		}
 
-		// Step 6: Finalize (Caddyfile, DNS, CA trust, shell PATH).
+		// Step 7: Finalize (Caddyfile, DNS, CA trust, shell PATH).
 		if err := bootstrapFinalize(installTLD); err != nil {
 			return err
 		}
 
-		// Step 7: Enable daemon unless explicitly disabled in ~/.pv/pv.yml.
+		// Step 8: Enable daemon unless explicitly disabled in ~/.pv/pv.yml.
 		settings, loadErr := config.LoadSettings()
 		if loadErr != nil {
 			ui.Subtle(fmt.Sprintf("Warning: could not load settings for daemon setup: %v", loadErr))
@@ -191,7 +209,7 @@ pv install --with="php:8.3,service[redis:7],service[mysql:8.0]"`,
 			}
 		}
 
-		// Step 8: Install services from --with.
+		// Step 9: Install services from --with.
 		for _, svc := range spec.services {
 			svcArgs := []string{svc.name}
 			if svc.version != "" {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -85,7 +85,7 @@ var updateCmd = &cobra.Command{
 		// Step 3: Update managed packages.
 		for _, pkg := range packages.Managed {
 			if err := ui.Step(fmt.Sprintf("Updating %s...", pkg.Name), func() (string, error) {
-				updated, version, err := packages.Update(client, pkg)
+				updated, version, err := packages.Update(cmd.Context(), client, pkg)
 				if err != nil {
 					return "", err
 				}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prvious/pv/internal/commands/composer"
 	"github.com/prvious/pv/internal/commands/mago"
 	"github.com/prvious/pv/internal/commands/php"
+	"github.com/prvious/pv/internal/packages"
 	"github.com/prvious/pv/internal/selfupdate"
 	"github.com/prvious/pv/internal/ui"
 	"github.com/spf13/cobra"
@@ -78,6 +79,25 @@ var updateCmd = &cobra.Command{
 					ui.Fail(fmt.Sprintf("Colima update failed: %v", err))
 				}
 				failures = append(failures, "Colima")
+			}
+		}
+
+		// Step 3: Update managed packages.
+		for _, pkg := range packages.Managed {
+			if err := ui.Step(fmt.Sprintf("Updating %s...", pkg.Name), func() (string, error) {
+				updated, version, err := packages.Update(client, pkg)
+				if err != nil {
+					return "", err
+				}
+				if !updated {
+					return fmt.Sprintf("%s already up to date", pkg.Name), nil
+				}
+				return fmt.Sprintf("%s updated to %s", pkg.Name, version), nil
+			}); err != nil {
+				if !errors.Is(err, ui.ErrAlreadyPrinted) {
+					ui.Fail(fmt.Sprintf("%s update failed: %v", pkg.Name, err))
+				}
+				failures = append(failures, pkg.Name)
 			}
 		}
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -156,6 +156,10 @@ func InternalBinDir() string {
 	return filepath.Join(PvDir(), "internal", "bin")
 }
 
+func PackagesDir() string {
+	return filepath.Join(PvDir(), "internal", "packages")
+}
+
 func ColimaPath() string {
 	return filepath.Join(InternalBinDir(), "colima")
 }
@@ -185,6 +189,7 @@ func EnsureDirs() error {
 		ComposerCacheDir(),
 		ServicesDir(),
 		InternalBinDir(),
+		PackagesDir(),
 	}
 	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0755); err != nil {

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -313,6 +313,7 @@ func TestEnsureDirs(t *testing.T) {
 		ComposerDir(),
 		ComposerCacheDir(),
 		InternalBinDir(),
+		PackagesDir(),
 	}
 	for _, dir := range dirs {
 		info, err := os.Stat(dir)

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -367,3 +367,27 @@ func TestEnsureDirs_Idempotent(t *testing.T) {
 		t.Fatalf("second EnsureDirs() error = %v", err)
 	}
 }
+
+func TestPackagesDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := PackagesDir()
+	want := filepath.Join(home, ".pv", "internal", "packages")
+	if got != want {
+		t.Errorf("PackagesDir() = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureDirs_CreatesPackagesDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs() error = %v", err)
+	}
+
+	if _, err := os.Stat(PackagesDir()); os.IsNotExist(err) {
+		t.Error("EnsureDirs() did not create PackagesDir()")
+	}
+}

--- a/internal/packages/composer.go
+++ b/internal/packages/composer.go
@@ -1,0 +1,85 @@
+package packages
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+// runComposer executes a composer command and returns its output.
+// Replaceable in tests for isolation.
+var runComposer = defaultRunComposer
+
+func defaultRunComposer(args ...string) ([]byte, error) {
+	cmd := exec.Command(config.ComposerPharPath(), args...)
+	cmd.Env = composerEnv()
+	return cmd.CombinedOutput()
+}
+
+// composerEnv builds the environment for composer commands, ensuring
+// COMPOSER_HOME and COMPOSER_CACHE_DIR point to our managed directories
+// and our bin dir is on PATH for PHP resolution.
+func composerEnv() []string {
+	env := os.Environ()
+	env = replaceOrAppendEnv(env, "COMPOSER_HOME", config.ComposerDir())
+	env = replaceOrAppendEnv(env, "COMPOSER_CACHE_DIR", config.ComposerCacheDir())
+	env = replaceOrAppendEnv(env, "PATH", config.BinDir()+":"+os.Getenv("PATH"))
+	return env
+}
+
+func replaceOrAppendEnv(env []string, key, val string) []string {
+	prefix := key + "="
+	for i, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			env[i] = prefix + val
+			return env
+		}
+	}
+	return append(env, prefix+val)
+}
+
+// composerGlobalRequire installs a package via composer global require.
+func composerGlobalRequire(pkg Package) (string, error) {
+	out, err := runComposer("global", "require", pkg.Composer, "--no-interaction", "--no-ansi")
+	if err != nil {
+		return "", fmt.Errorf("composer global require %s: %s", pkg.Composer, strings.TrimSpace(string(out)))
+	}
+	return getComposerPackageVersion(pkg)
+}
+
+// composerGlobalUpdate updates a package via composer global update.
+func composerGlobalUpdate(pkg Package) (string, error) {
+	out, err := runComposer("global", "update", pkg.Composer, "--no-interaction", "--no-ansi")
+	if err != nil {
+		return "", fmt.Errorf("composer global update %s: %s", pkg.Composer, strings.TrimSpace(string(out)))
+	}
+	return getComposerPackageVersion(pkg)
+}
+
+// getComposerPackageVersion returns the installed version of a composer package.
+func getComposerPackageVersion(pkg Package) (string, error) {
+	out, err := runComposer("global", "show", pkg.Composer, "--format=json", "--no-ansi")
+	if err != nil {
+		return "", fmt.Errorf("composer show %s: %s", pkg.Composer, strings.TrimSpace(string(out)))
+	}
+
+	var info struct {
+		Version  string   `json:"version"`
+		Versions []string `json:"versions"`
+	}
+	if err := json.Unmarshal(out, &info); err != nil {
+		return "", fmt.Errorf("parse composer show output: %w", err)
+	}
+
+	if info.Version != "" {
+		return info.Version, nil
+	}
+	if len(info.Versions) > 0 {
+		return strings.TrimPrefix(info.Versions[0], "* "), nil
+	}
+	return "", fmt.Errorf("no version found for %s", pkg.Composer)
+}

--- a/internal/packages/composer.go
+++ b/internal/packages/composer.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,7 +19,16 @@ var runComposer = defaultRunComposer
 func defaultRunComposer(ctx context.Context, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, config.ComposerPharPath(), args...)
 	cmd.Env = composerEnv()
-	return cmd.CombinedOutput()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		// On error, return combined output for diagnostic messages.
+		return append(stdout.Bytes(), stderr.Bytes()...), err
+	}
+	// On success, return stdout only so JSON output is clean.
+	return stdout.Bytes(), nil
 }
 
 // composerEnv builds the environment for composer commands, ensuring

--- a/internal/packages/composer.go
+++ b/internal/packages/composer.go
@@ -52,9 +52,12 @@ func composerGlobalRequire(ctx context.Context, pkg Package) (string, error) {
 }
 
 func composerGlobalUpdate(ctx context.Context, pkg Package) (string, error) {
-	out, err := runComposer(ctx, "global", "update", pkg.Composer, "--no-interaction", "--no-ansi")
+	// Use "require" instead of "update" because require is idempotent:
+	// it installs the package if missing and updates it if already present.
+	// Plain "update" does nothing if the package isn't in the global composer.json.
+	out, err := runComposer(ctx, "global", "require", pkg.Composer, "--no-interaction", "--no-ansi")
 	if err != nil {
-		return "", fmt.Errorf("composer global update %s: %w\nOutput: %s", pkg.Composer, err, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("composer global require %s: %w\nOutput: %s", pkg.Composer, err, strings.TrimSpace(string(out)))
 	}
 	return getComposerPackageVersion(ctx, pkg)
 }

--- a/internal/packages/composer.go
+++ b/internal/packages/composer.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -14,8 +15,8 @@ import (
 // Replaceable in tests for isolation.
 var runComposer = defaultRunComposer
 
-func defaultRunComposer(args ...string) ([]byte, error) {
-	cmd := exec.Command(config.ComposerPharPath(), args...)
+func defaultRunComposer(ctx context.Context, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, config.ComposerPharPath(), args...)
 	cmd.Env = composerEnv()
 	return cmd.CombinedOutput()
 }
@@ -42,29 +43,29 @@ func replaceOrAppendEnv(env []string, key, val string) []string {
 	return append(env, prefix+val)
 }
 
-// composerGlobalRequire installs a package via composer global require.
-func composerGlobalRequire(pkg Package) (string, error) {
-	out, err := runComposer("global", "require", pkg.Composer, "--no-interaction", "--no-ansi")
+func composerGlobalRequire(ctx context.Context, pkg Package) (string, error) {
+	out, err := runComposer(ctx, "global", "require", pkg.Composer, "--no-interaction", "--no-ansi")
 	if err != nil {
-		return "", fmt.Errorf("composer global require %s: %s", pkg.Composer, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("composer global require %s: %w\nOutput: %s", pkg.Composer, err, strings.TrimSpace(string(out)))
 	}
-	return getComposerPackageVersion(pkg)
+	return getComposerPackageVersion(ctx, pkg)
 }
 
-// composerGlobalUpdate updates a package via composer global update.
-func composerGlobalUpdate(pkg Package) (string, error) {
-	out, err := runComposer("global", "update", pkg.Composer, "--no-interaction", "--no-ansi")
+func composerGlobalUpdate(ctx context.Context, pkg Package) (string, error) {
+	out, err := runComposer(ctx, "global", "update", pkg.Composer, "--no-interaction", "--no-ansi")
 	if err != nil {
-		return "", fmt.Errorf("composer global update %s: %s", pkg.Composer, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("composer global update %s: %w\nOutput: %s", pkg.Composer, err, strings.TrimSpace(string(out)))
 	}
-	return getComposerPackageVersion(pkg)
+	return getComposerPackageVersion(ctx, pkg)
 }
 
 // getComposerPackageVersion returns the installed version of a composer package.
-func getComposerPackageVersion(pkg Package) (string, error) {
-	out, err := runComposer("global", "show", pkg.Composer, "--format=json", "--no-ansi")
+// Composer >=2.x returns "version" as a string; older versions return
+// "versions" as an array where the active version is prefixed with "* ".
+func getComposerPackageVersion(ctx context.Context, pkg Package) (string, error) {
+	out, err := runComposer(ctx, "global", "show", pkg.Composer, "--format=json", "--no-ansi")
 	if err != nil {
-		return "", fmt.Errorf("composer show %s: %s", pkg.Composer, strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("composer show %s: %w\nOutput: %s", pkg.Composer, err, strings.TrimSpace(string(out)))
 	}
 
 	var info struct {

--- a/internal/packages/install.go
+++ b/internal/packages/install.go
@@ -58,13 +58,41 @@ func fetchLatestRelease(client *http.Client, pkg Package) (tag, downloadURL stri
 	return "", "", fmt.Errorf("asset %q not found in %s release %s", pkg.Asset, pkg.Repo, release.TagName)
 }
 
-// Install downloads a package PHAR, symlinks it, and records the version.
-// Returns the installed version tag.
+// Install installs a managed package and records the version.
+// For PHAR packages, downloads from GitHub releases and creates a symlink.
+// For Composer packages, runs composer global require.
 func Install(client *http.Client, pkg Package, progress binaries.ProgressFunc) (string, error) {
 	if err := config.EnsureDirs(); err != nil {
 		return "", err
 	}
 
+	switch pkg.Method {
+	case MethodComposer:
+		return installViaComposer(pkg)
+	default:
+		return installViaPHAR(client, pkg, progress)
+	}
+}
+
+func installViaComposer(pkg Package) (string, error) {
+	version, err := composerGlobalRequire(pkg)
+	if err != nil {
+		return "", err
+	}
+
+	vs, err := binaries.LoadVersions()
+	if err != nil {
+		return "", err
+	}
+	vs.Set(pkg.Name, version)
+	if err := vs.Save(); err != nil {
+		return "", err
+	}
+
+	return version, nil
+}
+
+func installViaPHAR(client *http.Client, pkg Package, progress binaries.ProgressFunc) (string, error) {
 	tag, downloadURL, err := fetchLatestRelease(client, pkg)
 	if err != nil {
 		return "", err

--- a/internal/packages/install.go
+++ b/internal/packages/install.go
@@ -1,11 +1,13 @@
 package packages
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/prvious/pv/internal/binaries"
 	"github.com/prvious/pv/internal/config"
@@ -22,8 +24,8 @@ type gitHubAsset struct {
 }
 
 // fetchLatestRelease queries GitHub for the latest release tag and asset download URL.
-func fetchLatestRelease(client *http.Client, pkg Package) (tag, downloadURL string, err error) {
-	req, err := http.NewRequest("GET", pkg.LatestReleaseURL(), nil)
+func fetchLatestRelease(ctx context.Context, client *http.Client, pkg Package) (tag, downloadURL string, err error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", pkg.LatestReleaseURL(), nil)
 	if err != nil {
 		return "", "", err
 	}
@@ -36,10 +38,11 @@ func fetchLatestRelease(client *http.Client, pkg Package) (tag, downloadURL stri
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("GitHub API returned HTTP %d for %s", resp.StatusCode, pkg.Repo)
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return "", "", fmt.Errorf("GitHub API returned HTTP %d for %s: %s", resp.StatusCode, pkg.Repo, strings.TrimSpace(string(body)))
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MB limit
 	if err != nil {
 		return "", "", err
 	}
@@ -47,6 +50,10 @@ func fetchLatestRelease(client *http.Client, pkg Package) (tag, downloadURL stri
 	var release gitHubRelease
 	if err := json.Unmarshal(body, &release); err != nil {
 		return "", "", fmt.Errorf("parse GitHub response for %s: %w", pkg.Name, err)
+	}
+
+	if release.TagName == "" {
+		return "", "", fmt.Errorf("empty tag in %s latest release", pkg.Repo)
 	}
 
 	for _, asset := range release.Assets {
@@ -58,24 +65,26 @@ func fetchLatestRelease(client *http.Client, pkg Package) (tag, downloadURL stri
 	return "", "", fmt.Errorf("asset %q not found in %s release %s", pkg.Asset, pkg.Repo, release.TagName)
 }
 
-// Install installs a managed package and records the version.
+// Install installs a managed package, records the version, and returns the installed version string.
 // For PHAR packages, downloads from GitHub releases and creates a symlink.
 // For Composer packages, runs composer global require.
-func Install(client *http.Client, pkg Package, progress binaries.ProgressFunc) (string, error) {
+func Install(ctx context.Context, client *http.Client, pkg Package, progress binaries.ProgressFunc) (string, error) {
 	if err := config.EnsureDirs(); err != nil {
 		return "", err
 	}
 
 	switch pkg.Method {
 	case MethodComposer:
-		return installViaComposer(pkg)
+		return installViaComposer(ctx, pkg)
+	case MethodPHAR:
+		return installViaPHAR(ctx, client, pkg, progress)
 	default:
-		return installViaPHAR(client, pkg, progress)
+		return "", fmt.Errorf("unknown install method %d for package %s", pkg.Method, pkg.Name)
 	}
 }
 
-func installViaComposer(pkg Package) (string, error) {
-	version, err := composerGlobalRequire(pkg)
+func installViaComposer(ctx context.Context, pkg Package) (string, error) {
+	version, err := composerGlobalRequire(ctx, pkg)
 	if err != nil {
 		return "", err
 	}
@@ -92,8 +101,8 @@ func installViaComposer(pkg Package) (string, error) {
 	return version, nil
 }
 
-func installViaPHAR(client *http.Client, pkg Package, progress binaries.ProgressFunc) (string, error) {
-	tag, downloadURL, err := fetchLatestRelease(client, pkg)
+func installViaPHAR(ctx context.Context, client *http.Client, pkg Package, progress binaries.ProgressFunc) (string, error) {
+	tag, downloadURL, err := fetchLatestRelease(ctx, client, pkg)
 	if err != nil {
 		return "", err
 	}
@@ -106,29 +115,30 @@ func installViaPHAR(client *http.Client, pkg Package, progress binaries.Progress
 		return "", err
 	}
 
-	// Create symlink (remove existing first to handle reinstalls).
-	os.Remove(pkg.SymlinkPath())
+	// Remove existing symlink to handle reinstalls; ignore only "not exist".
+	if err := os.Remove(pkg.SymlinkPath()); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("remove existing symlink for %s: %w", pkg.Name, err)
+	}
 	if err := os.Symlink(pkg.PharPath(), pkg.SymlinkPath()); err != nil {
 		return "", fmt.Errorf("symlink %s: %w", pkg.Name, err)
 	}
 
-	// Record installed version.
 	vs, err := binaries.LoadVersions()
 	if err != nil {
 		return "", err
 	}
 	vs.Set(pkg.Name, tag)
 	if err := vs.Save(); err != nil {
-		return "", err
+		return "", fmt.Errorf("save version after installing %s %s (binary already on disk): %w", pkg.Name, tag, err)
 	}
 
 	return tag, nil
 }
 
 // InstallAll installs all managed packages.
-func InstallAll(client *http.Client, progress binaries.ProgressFunc) error {
+func InstallAll(ctx context.Context, client *http.Client, progress binaries.ProgressFunc) error {
 	for _, pkg := range Managed {
-		if _, err := Install(client, pkg, progress); err != nil {
+		if _, err := Install(ctx, client, pkg, progress); err != nil {
 			return err
 		}
 	}

--- a/internal/packages/install.go
+++ b/internal/packages/install.go
@@ -1,0 +1,108 @@
+package packages
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/prvious/pv/internal/binaries"
+	"github.com/prvious/pv/internal/config"
+)
+
+type gitHubRelease struct {
+	TagName string        `json:"tag_name"`
+	Assets  []gitHubAsset `json:"assets"`
+}
+
+type gitHubAsset struct {
+	Name        string `json:"name"`
+	DownloadURL string `json:"browser_download_url"`
+}
+
+// fetchLatestRelease queries GitHub for the latest release tag and asset download URL.
+func fetchLatestRelease(client *http.Client, pkg Package) (tag, downloadURL string, err error) {
+	req, err := http.NewRequest("GET", pkg.LatestReleaseURL(), nil)
+	if err != nil {
+		return "", "", err
+	}
+	binaries.SetGitHubHeaders(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("fetch latest release for %s: %w", pkg.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("GitHub API returned HTTP %d for %s", resp.StatusCode, pkg.Repo)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", "", err
+	}
+
+	var release gitHubRelease
+	if err := json.Unmarshal(body, &release); err != nil {
+		return "", "", fmt.Errorf("parse GitHub response for %s: %w", pkg.Name, err)
+	}
+
+	for _, asset := range release.Assets {
+		if asset.Name == pkg.Asset {
+			return release.TagName, asset.DownloadURL, nil
+		}
+	}
+
+	return "", "", fmt.Errorf("asset %q not found in %s release %s", pkg.Asset, pkg.Repo, release.TagName)
+}
+
+// Install downloads a package PHAR, symlinks it, and records the version.
+// Returns the installed version tag.
+func Install(client *http.Client, pkg Package, progress binaries.ProgressFunc) (string, error) {
+	if err := config.EnsureDirs(); err != nil {
+		return "", err
+	}
+
+	tag, downloadURL, err := fetchLatestRelease(client, pkg)
+	if err != nil {
+		return "", err
+	}
+
+	if err := binaries.DownloadProgress(client, downloadURL, pkg.PharPath(), progress); err != nil {
+		return "", fmt.Errorf("download %s: %w", pkg.Name, err)
+	}
+
+	if err := binaries.MakeExecutable(pkg.PharPath()); err != nil {
+		return "", err
+	}
+
+	// Create symlink (remove existing first to handle reinstalls).
+	os.Remove(pkg.SymlinkPath())
+	if err := os.Symlink(pkg.PharPath(), pkg.SymlinkPath()); err != nil {
+		return "", fmt.Errorf("symlink %s: %w", pkg.Name, err)
+	}
+
+	// Record installed version.
+	vs, err := binaries.LoadVersions()
+	if err != nil {
+		return "", err
+	}
+	vs.Set(pkg.Name, tag)
+	if err := vs.Save(); err != nil {
+		return "", err
+	}
+
+	return tag, nil
+}
+
+// InstallAll installs all managed packages.
+func InstallAll(client *http.Client, progress binaries.ProgressFunc) error {
+	for _, pkg := range Managed {
+		if _, err := Install(client, pkg, progress); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/packages/install_test.go
+++ b/internal/packages/install_test.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -29,7 +30,7 @@ func TestFetchLatestRelease(t *testing.T) {
 	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
 
 	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
-	tag, downloadURL, err := fetchLatestRelease(client, pkg)
+	tag, downloadURL, err := fetchLatestRelease(context.Background(), client, pkg)
 	if err != nil {
 		t.Fatalf("fetchLatestRelease() error = %v", err)
 	}
@@ -71,7 +72,7 @@ func TestInstallViaPHAR(t *testing.T) {
 	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
 
 	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
-	version, err := Install(client, pkg, nil)
+	version, err := Install(context.Background(), client, pkg, nil)
 	if err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
@@ -122,7 +123,7 @@ func TestInstallViaComposer(t *testing.T) {
 	// Mock composer commands.
 	orig := runComposer
 	t.Cleanup(func() { runComposer = orig })
-	runComposer = func(args ...string) ([]byte, error) {
+	runComposer = func(_ context.Context, args ...string) ([]byte, error) {
 		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
 			return json.Marshal(map[string]any{
 				"versions": []string{"v5.3.0"},
@@ -132,7 +133,7 @@ func TestInstallViaComposer(t *testing.T) {
 	}
 
 	pkg := Package{Name: "laravel", Repo: "laravel/installer", Method: MethodComposer, Composer: "laravel/installer"}
-	version, err := Install(nil, pkg, nil)
+	version, err := Install(context.Background(), nil, pkg, nil)
 	if err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}

--- a/internal/packages/install_test.go
+++ b/internal/packages/install_test.go
@@ -1,0 +1,125 @@
+package packages
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+func TestFetchLatestRelease(t *testing.T) {
+	release := gitHubRelease{
+		TagName: "v5.3.0",
+		Assets: []gitHubAsset{
+			{Name: "laravel.phar", DownloadURL: "https://example.com/laravel.phar"},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+
+	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
+	tag, downloadURL, err := fetchLatestRelease(client, pkg)
+	if err != nil {
+		t.Fatalf("fetchLatestRelease() error = %v", err)
+	}
+	if tag != "v5.3.0" {
+		t.Errorf("tag = %q, want %q", tag, "v5.3.0")
+	}
+	if downloadURL == "" {
+		t.Error("downloadURL is empty")
+	}
+}
+
+func TestInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs() error = %v", err)
+	}
+
+	pharContent := "#!/usr/bin/env php\n<?php echo 'hello';\n"
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/laravel/installer/releases/latest" {
+			release := gitHubRelease{
+				TagName: "v5.3.0",
+				Assets: []gitHubAsset{
+					{Name: "laravel.phar", DownloadURL: srv.URL + "/download/laravel.phar"},
+				},
+			}
+			json.NewEncoder(w).Encode(release)
+			return
+		}
+		w.Write([]byte(pharContent))
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+
+	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
+	version, err := Install(client, pkg, nil)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if version != "v5.3.0" {
+		t.Errorf("Install() version = %q, want %q", version, "v5.3.0")
+	}
+
+	// Verify PHAR exists and is executable.
+	info, err := os.Stat(pkg.PharPath())
+	if err != nil {
+		t.Fatalf("PHAR file not found: %v", err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Error("PHAR is not executable")
+	}
+
+	// Verify symlink exists and points to PHAR.
+	target, err := os.Readlink(pkg.SymlinkPath())
+	if err != nil {
+		t.Fatalf("symlink not found: %v", err)
+	}
+	if target != pkg.PharPath() {
+		t.Errorf("symlink target = %q, want %q", target, pkg.PharPath())
+	}
+
+	// Verify version was saved.
+	data, err := os.ReadFile(filepath.Join(home, ".pv", "data", "versions.json"))
+	if err != nil {
+		t.Fatalf("versions.json not found: %v", err)
+	}
+	var vs struct {
+		Versions map[string]string `json:"versions"`
+	}
+	json.Unmarshal(data, &vs)
+	if vs.Versions["laravel"] != "v5.3.0" {
+		t.Errorf("versions.json[laravel] = %q, want %q", vs.Versions["laravel"], "v5.3.0")
+	}
+}
+
+// urlRewriteTransport redirects all requests to a test server URL.
+// This type is shared across all test files in this package.
+type urlRewriteTransport struct {
+	base    http.RoundTripper
+	testURL string
+}
+
+func (t *urlRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.URL.Scheme = "http"
+	req.URL.Host = t.testURL[len("http://"):]
+	return t.base.RoundTrip(req)
+}

--- a/internal/packages/install_test.go
+++ b/internal/packages/install_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/prvious/pv/internal/binaries"
 	"github.com/prvious/pv/internal/config"
 )
 
@@ -15,7 +16,7 @@ func TestFetchLatestRelease(t *testing.T) {
 	release := gitHubRelease{
 		TagName: "v5.3.0",
 		Assets: []gitHubAsset{
-			{Name: "laravel.phar", DownloadURL: "https://example.com/laravel.phar"},
+			{Name: "phpstan.phar", DownloadURL: "https://example.com/phpstan.phar"},
 		},
 	}
 
@@ -27,7 +28,7 @@ func TestFetchLatestRelease(t *testing.T) {
 	client := srv.Client()
 	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
 
-	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
+	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
 	tag, downloadURL, err := fetchLatestRelease(client, pkg)
 	if err != nil {
 		t.Fatalf("fetchLatestRelease() error = %v", err)
@@ -40,7 +41,7 @@ func TestFetchLatestRelease(t *testing.T) {
 	}
 }
 
-func TestInstall(t *testing.T) {
+func TestInstallViaPHAR(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -52,11 +53,11 @@ func TestInstall(t *testing.T) {
 
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/repos/laravel/installer/releases/latest" {
+		if r.URL.Path == "/repos/phpstan/phpstan/releases/latest" {
 			release := gitHubRelease{
-				TagName: "v5.3.0",
+				TagName: "v2.1.0",
 				Assets: []gitHubAsset{
-					{Name: "laravel.phar", DownloadURL: srv.URL + "/download/laravel.phar"},
+					{Name: "phpstan.phar", DownloadURL: srv.URL + "/download/phpstan.phar"},
 				},
 			}
 			json.NewEncoder(w).Encode(release)
@@ -69,13 +70,13 @@ func TestInstall(t *testing.T) {
 	client := srv.Client()
 	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
 
-	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
+	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
 	version, err := Install(client, pkg, nil)
 	if err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
-	if version != "v5.3.0" {
-		t.Errorf("Install() version = %q, want %q", version, "v5.3.0")
+	if version != "v2.1.0" {
+		t.Errorf("Install() version = %q, want %q", version, "v2.1.0")
 	}
 
 	// Verify PHAR exists and is executable.
@@ -105,8 +106,47 @@ func TestInstall(t *testing.T) {
 		Versions map[string]string `json:"versions"`
 	}
 	json.Unmarshal(data, &vs)
-	if vs.Versions["laravel"] != "v5.3.0" {
-		t.Errorf("versions.json[laravel] = %q, want %q", vs.Versions["laravel"], "v5.3.0")
+	if vs.Versions["phpstan"] != "v2.1.0" {
+		t.Errorf("versions.json[phpstan] = %q, want %q", vs.Versions["phpstan"], "v2.1.0")
+	}
+}
+
+func TestInstallViaComposer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := config.EnsureDirs(); err != nil {
+		t.Fatalf("EnsureDirs() error = %v", err)
+	}
+
+	// Mock composer commands.
+	orig := runComposer
+	t.Cleanup(func() { runComposer = orig })
+	runComposer = func(args ...string) ([]byte, error) {
+		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
+			return json.Marshal(map[string]any{
+				"versions": []string{"v5.3.0"},
+			})
+		}
+		return []byte(""), nil
+	}
+
+	pkg := Package{Name: "laravel", Repo: "laravel/installer", Method: MethodComposer, Composer: "laravel/installer"}
+	version, err := Install(nil, pkg, nil)
+	if err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if version != "v5.3.0" {
+		t.Errorf("Install() version = %q, want %q", version, "v5.3.0")
+	}
+
+	// Verify version was saved.
+	loaded, err := binaries.LoadVersions()
+	if err != nil {
+		t.Fatalf("LoadVersions() error = %v", err)
+	}
+	if loaded.Get("laravel") != "v5.3.0" {
+		t.Errorf("versions.json[laravel] = %q, want %q", loaded.Get("laravel"), "v5.3.0")
 	}
 }
 

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -6,16 +6,28 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-// Package defines a managed PHAR package that pv keeps up-to-date.
+// InstallMethod determines how a package is installed.
+type InstallMethod int
+
+const (
+	// MethodPHAR downloads a standalone PHAR from GitHub releases.
+	MethodPHAR InstallMethod = iota
+	// MethodComposer installs via composer global require.
+	MethodComposer
+)
+
+// Package defines a managed package that pv keeps up-to-date.
 type Package struct {
-	Name  string // binary name and symlink name (e.g., "laravel")
-	Repo  string // GitHub owner/repo (e.g., "laravel/installer")
-	Asset string // release asset filename (e.g., "laravel.phar")
+	Name     string        // binary name (e.g., "laravel", "phpstan")
+	Repo     string        // GitHub owner/repo (e.g., "laravel/installer")
+	Asset    string        // release asset filename (MethodPHAR only)
+	Method   InstallMethod // how to install this package
+	Composer string        // composer package name (MethodComposer only)
 }
 
 // Managed is the compiled-in registry of packages pv manages.
 var Managed = []Package{
-	{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"},
+	{Name: "laravel", Repo: "laravel/installer", Method: MethodComposer, Composer: "laravel/installer"},
 }
 
 // PharPath returns the full path where this package's PHAR is stored.

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/prvious/pv/internal/config"
@@ -30,12 +31,45 @@ var Managed = []Package{
 	{Name: "laravel", Repo: "laravel/installer", Method: MethodComposer, Composer: "laravel/installer"},
 }
 
-// PharPath returns the full path where this package's PHAR is stored.
+func init() {
+	seen := make(map[string]bool)
+	for _, pkg := range Managed {
+		if err := pkg.Validate(); err != nil {
+			panic(fmt.Sprintf("invalid managed package: %v", err))
+		}
+		if seen[pkg.Name] {
+			panic(fmt.Sprintf("duplicate managed package name: %q", pkg.Name))
+		}
+		seen[pkg.Name] = true
+	}
+}
+
+// Validate checks that a Package has all required fields for its install method.
+func (p Package) Validate() error {
+	if p.Name == "" {
+		return fmt.Errorf("package name is required")
+	}
+	switch p.Method {
+	case MethodPHAR:
+		if p.Repo == "" || p.Asset == "" {
+			return fmt.Errorf("PHAR package %q requires Repo and Asset", p.Name)
+		}
+	case MethodComposer:
+		if p.Composer == "" {
+			return fmt.Errorf("Composer package %q requires Composer field", p.Name)
+		}
+	default:
+		return fmt.Errorf("unknown install method %d for %q", p.Method, p.Name)
+	}
+	return nil
+}
+
+// PharPath returns the full path where this package's PHAR is stored (MethodPHAR only).
 func (p Package) PharPath() string {
 	return filepath.Join(config.PackagesDir(), p.Name+".phar")
 }
 
-// SymlinkPath returns the full path for the symlink in the user's PATH.
+// SymlinkPath returns the full path for the symlink in the user's PATH (MethodPHAR only).
 func (p Package) SymlinkPath() string {
 	return filepath.Join(config.BinDir(), p.Name)
 }

--- a/internal/packages/package.go
+++ b/internal/packages/package.go
@@ -1,0 +1,34 @@
+package packages
+
+import (
+	"path/filepath"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+// Package defines a managed PHAR package that pv keeps up-to-date.
+type Package struct {
+	Name  string // binary name and symlink name (e.g., "laravel")
+	Repo  string // GitHub owner/repo (e.g., "laravel/installer")
+	Asset string // release asset filename (e.g., "laravel.phar")
+}
+
+// Managed is the compiled-in registry of packages pv manages.
+var Managed = []Package{
+	{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"},
+}
+
+// PharPath returns the full path where this package's PHAR is stored.
+func (p Package) PharPath() string {
+	return filepath.Join(config.PackagesDir(), p.Name+".phar")
+}
+
+// SymlinkPath returns the full path for the symlink in the user's PATH.
+func (p Package) SymlinkPath() string {
+	return filepath.Join(config.BinDir(), p.Name)
+}
+
+// LatestReleaseURL returns the GitHub API URL for the latest release.
+func (p Package) LatestReleaseURL() string {
+	return "https://api.github.com/repos/" + p.Repo + "/releases/latest"
+}

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -17,8 +17,11 @@ func TestManagedRegistryContainsLaravel(t *testing.T) {
 			if pkg.Repo != "laravel/installer" {
 				t.Errorf("laravel.Repo = %q, want %q", pkg.Repo, "laravel/installer")
 			}
-			if pkg.Asset != "laravel.phar" {
-				t.Errorf("laravel.Asset = %q, want %q", pkg.Asset, "laravel.phar")
+			if pkg.Method != MethodComposer {
+				t.Errorf("laravel.Method = %d, want MethodComposer", pkg.Method)
+			}
+			if pkg.Composer != "laravel/installer" {
+				t.Errorf("laravel.Composer = %q, want %q", pkg.Composer, "laravel/installer")
 			}
 		}
 	}
@@ -31,9 +34,9 @@ func TestPackagePharPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	pkg := Managed[0]
+	pkg := Package{Name: "phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
 	got := pkg.PharPath()
-	want := filepath.Join(home, ".pv", "internal", "packages", "laravel.phar")
+	want := filepath.Join(home, ".pv", "internal", "packages", "phpstan.phar")
 	if got != want {
 		t.Errorf("PharPath() = %q, want %q", got, want)
 	}
@@ -43,9 +46,9 @@ func TestPackageSymlinkPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	pkg := Managed[0]
+	pkg := Package{Name: "phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
 	got := pkg.SymlinkPath()
-	want := filepath.Join(home, ".pv", "bin", "laravel")
+	want := filepath.Join(home, ".pv", "bin", "phpstan")
 	if got != want {
 		t.Errorf("SymlinkPath() = %q, want %q", got, want)
 	}

--- a/internal/packages/package_test.go
+++ b/internal/packages/package_test.go
@@ -1,0 +1,52 @@
+package packages
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestManagedRegistryContainsLaravel(t *testing.T) {
+	if len(Managed) == 0 {
+		t.Fatal("Managed registry is empty")
+	}
+
+	found := false
+	for _, pkg := range Managed {
+		if pkg.Name == "laravel" {
+			found = true
+			if pkg.Repo != "laravel/installer" {
+				t.Errorf("laravel.Repo = %q, want %q", pkg.Repo, "laravel/installer")
+			}
+			if pkg.Asset != "laravel.phar" {
+				t.Errorf("laravel.Asset = %q, want %q", pkg.Asset, "laravel.phar")
+			}
+		}
+	}
+	if !found {
+		t.Error("laravel not found in Managed registry")
+	}
+}
+
+func TestPackagePharPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pkg := Managed[0]
+	got := pkg.PharPath()
+	want := filepath.Join(home, ".pv", "internal", "packages", "laravel.phar")
+	if got != want {
+		t.Errorf("PharPath() = %q, want %q", got, want)
+	}
+}
+
+func TestPackageSymlinkPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pkg := Managed[0]
+	got := pkg.SymlinkPath()
+	want := filepath.Join(home, ".pv", "bin", "laravel")
+	if got != want {
+		t.Errorf("SymlinkPath() = %q, want %q", got, want)
+	}
+}

--- a/internal/packages/update.go
+++ b/internal/packages/update.go
@@ -8,14 +8,47 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-// Update checks if a package has a newer version and downloads it if so.
-// Returns whether an update occurred and the current/new version tag.
-// The symlink is not touched — the PHAR is replaced in-place.
+// Update checks if a package has a newer version and updates it.
+// For PHAR packages, the PHAR is replaced in-place (symlink untouched).
+// For Composer packages, runs composer global update.
 func Update(client *http.Client, pkg Package) (updated bool, version string, err error) {
 	if err := config.EnsureDirs(); err != nil {
 		return false, "", err
 	}
 
+	switch pkg.Method {
+	case MethodComposer:
+		return updateViaComposer(pkg)
+	default:
+		return updateViaPHAR(client, pkg)
+	}
+}
+
+func updateViaComposer(pkg Package) (bool, string, error) {
+	vs, err := binaries.LoadVersions()
+	if err != nil {
+		return false, "", err
+	}
+	installed := vs.Get(pkg.Name)
+
+	version, err := composerGlobalUpdate(pkg)
+	if err != nil {
+		return false, "", err
+	}
+
+	if normalizeVersion(installed) == normalizeVersion(version) {
+		return false, version, nil
+	}
+
+	vs.Set(pkg.Name, version)
+	if err := vs.Save(); err != nil {
+		return false, "", err
+	}
+
+	return true, version, nil
+}
+
+func updateViaPHAR(client *http.Client, pkg Package) (bool, string, error) {
 	tag, downloadURL, err := fetchLatestRelease(client, pkg)
 	if err != nil {
 		return false, "", err

--- a/internal/packages/update.go
+++ b/internal/packages/update.go
@@ -1,6 +1,8 @@
 package packages
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -8,30 +10,32 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-// Update checks if a package has a newer version and updates it.
-// For PHAR packages, the PHAR is replaced in-place (symlink untouched).
-// For Composer packages, runs composer global update.
-func Update(client *http.Client, pkg Package) (updated bool, version string, err error) {
+// Update updates a managed package and reports whether the version changed.
+// For PHAR packages, checks the latest GitHub release first and only downloads if newer.
+// For Composer packages, runs composer global update and detects version changes after.
+func Update(ctx context.Context, client *http.Client, pkg Package) (updated bool, version string, err error) {
 	if err := config.EnsureDirs(); err != nil {
 		return false, "", err
 	}
 
 	switch pkg.Method {
 	case MethodComposer:
-		return updateViaComposer(pkg)
+		return updateViaComposer(ctx, pkg)
+	case MethodPHAR:
+		return updateViaPHAR(ctx, client, pkg)
 	default:
-		return updateViaPHAR(client, pkg)
+		return false, "", fmt.Errorf("unknown install method %d for package %s", pkg.Method, pkg.Name)
 	}
 }
 
-func updateViaComposer(pkg Package) (bool, string, error) {
+func updateViaComposer(ctx context.Context, pkg Package) (bool, string, error) {
 	vs, err := binaries.LoadVersions()
 	if err != nil {
 		return false, "", err
 	}
 	installed := vs.Get(pkg.Name)
 
-	version, err := composerGlobalUpdate(pkg)
+	version, err := composerGlobalUpdate(ctx, pkg)
 	if err != nil {
 		return false, "", err
 	}
@@ -48,8 +52,8 @@ func updateViaComposer(pkg Package) (bool, string, error) {
 	return true, version, nil
 }
 
-func updateViaPHAR(client *http.Client, pkg Package) (bool, string, error) {
-	tag, downloadURL, err := fetchLatestRelease(client, pkg)
+func updateViaPHAR(ctx context.Context, client *http.Client, pkg Package) (bool, string, error) {
+	tag, downloadURL, err := fetchLatestRelease(ctx, client, pkg)
 	if err != nil {
 		return false, "", err
 	}
@@ -74,18 +78,19 @@ func updateViaPHAR(client *http.Client, pkg Package) (bool, string, error) {
 
 	vs.Set(pkg.Name, tag)
 	if err := vs.Save(); err != nil {
-		return false, "", err
+		return false, "", fmt.Errorf("save version after updating %s to %s (binary already on disk): %w", pkg.Name, tag, err)
 	}
 
 	return true, tag, nil
 }
 
 // UpdateAll checks and updates all managed packages.
-// Returns a slice of package names that were updated.
-func UpdateAll(client *http.Client) ([]string, error) {
+// Returns the names of packages that were successfully updated.
+// On error, returns the packages updated so far along with the error.
+func UpdateAll(ctx context.Context, client *http.Client) ([]string, error) {
 	var updated []string
 	for _, pkg := range Managed {
-		wasUpdated, _, err := Update(client, pkg)
+		wasUpdated, _, err := Update(ctx, client, pkg)
 		if err != nil {
 			return updated, err
 		}

--- a/internal/packages/update.go
+++ b/internal/packages/update.go
@@ -1,0 +1,68 @@
+package packages
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/prvious/pv/internal/binaries"
+	"github.com/prvious/pv/internal/config"
+)
+
+// Update checks if a package has a newer version and downloads it if so.
+// Returns whether an update occurred and the current/new version tag.
+// The symlink is not touched — the PHAR is replaced in-place.
+func Update(client *http.Client, pkg Package) (updated bool, version string, err error) {
+	if err := config.EnsureDirs(); err != nil {
+		return false, "", err
+	}
+
+	tag, downloadURL, err := fetchLatestRelease(client, pkg)
+	if err != nil {
+		return false, "", err
+	}
+
+	vs, err := binaries.LoadVersions()
+	if err != nil {
+		return false, "", err
+	}
+
+	installed := vs.Get(pkg.Name)
+	if normalizeVersion(installed) == normalizeVersion(tag) {
+		return false, tag, nil
+	}
+
+	if err := binaries.DownloadProgress(client, downloadURL, pkg.PharPath(), nil); err != nil {
+		return false, "", err
+	}
+
+	if err := binaries.MakeExecutable(pkg.PharPath()); err != nil {
+		return false, "", err
+	}
+
+	vs.Set(pkg.Name, tag)
+	if err := vs.Save(); err != nil {
+		return false, "", err
+	}
+
+	return true, tag, nil
+}
+
+// UpdateAll checks and updates all managed packages.
+// Returns a slice of package names that were updated.
+func UpdateAll(client *http.Client) ([]string, error) {
+	var updated []string
+	for _, pkg := range Managed {
+		wasUpdated, _, err := Update(client, pkg)
+		if err != nil {
+			return updated, err
+		}
+		if wasUpdated {
+			updated = append(updated, pkg.Name)
+		}
+	}
+	return updated, nil
+}
+
+func normalizeVersion(v string) string {
+	return strings.TrimPrefix(v, "v")
+}

--- a/internal/packages/update_test.go
+++ b/internal/packages/update_test.go
@@ -12,19 +12,19 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-func TestUpdate_AlreadyUpToDate(t *testing.T) {
+func TestUpdatePHAR_AlreadyUpToDate(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	config.EnsureDirs()
 
-	vs := &binaries.VersionState{Versions: map[string]string{"laravel": "v5.3.0"}}
+	vs := &binaries.VersionState{Versions: map[string]string{"phpstan": "v2.1.0"}}
 	vs.Save()
 
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		release := gitHubRelease{
-			TagName: "v5.3.0",
-			Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
+			TagName: "v2.1.0",
+			Assets:  []gitHubAsset{{Name: "phpstan.phar", DownloadURL: srv.URL + "/dl"}},
 		}
 		json.NewEncoder(w).Encode(release)
 	}))
@@ -33,7 +33,7 @@ func TestUpdate_AlreadyUpToDate(t *testing.T) {
 	client := srv.Client()
 	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
 
-	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
+	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
 	updated, version, err := Update(client, pkg)
 	if err != nil {
 		t.Fatalf("Update() error = %v", err)
@@ -41,29 +41,29 @@ func TestUpdate_AlreadyUpToDate(t *testing.T) {
 	if updated {
 		t.Error("Update() updated = true, want false (already up to date)")
 	}
-	if version != "v5.3.0" {
-		t.Errorf("Update() version = %q, want %q", version, "v5.3.0")
+	if version != "v2.1.0" {
+		t.Errorf("Update() version = %q, want %q", version, "v2.1.0")
 	}
 }
 
-func TestUpdate_NewVersionAvailable(t *testing.T) {
+func TestUpdatePHAR_NewVersionAvailable(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	config.EnsureDirs()
 
-	vs := &binaries.VersionState{Versions: map[string]string{"laravel": "v5.2.0"}}
+	vs := &binaries.VersionState{Versions: map[string]string{"phpstan": "v2.0.0"}}
 	vs.Save()
 
-	os.WriteFile(filepath.Join(config.PackagesDir(), "laravel.phar"), []byte("old"), 0755)
+	os.WriteFile(filepath.Join(config.PackagesDir(), "phpstan.phar"), []byte("old"), 0755)
 
 	pharContent := "#!/usr/bin/env php\n<?php echo 'new';\n"
 
 	var srv *httptest.Server
 	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/repos/laravel/installer/releases/latest" {
+		if r.URL.Path == "/repos/phpstan/phpstan/releases/latest" {
 			release := gitHubRelease{
-				TagName: "v5.3.0",
-				Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
+				TagName: "v2.1.0",
+				Assets:  []gitHubAsset{{Name: "phpstan.phar", DownloadURL: srv.URL + "/dl"}},
 			}
 			json.NewEncoder(w).Encode(release)
 			return
@@ -75,8 +75,113 @@ func TestUpdate_NewVersionAvailable(t *testing.T) {
 	client := srv.Client()
 	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
 
-	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
+	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
 	updated, version, err := Update(client, pkg)
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if !updated {
+		t.Error("Update() updated = false, want true")
+	}
+	if version != "v2.1.0" {
+		t.Errorf("Update() version = %q, want %q", version, "v2.1.0")
+	}
+
+	content, _ := os.ReadFile(pkg.PharPath())
+	if string(content) != pharContent {
+		t.Errorf("PHAR content = %q, want new content", string(content))
+	}
+
+	loaded, _ := binaries.LoadVersions()
+	if loaded.Get("phpstan") != "v2.1.0" {
+		t.Errorf("versions.json[phpstan] = %q, want %q", loaded.Get("phpstan"), "v2.1.0")
+	}
+}
+
+func TestUpdatePHAR_NormalizesVPrefix(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	config.EnsureDirs()
+
+	vs := &binaries.VersionState{Versions: map[string]string{"phpstan": "2.1.0"}}
+	vs.Save()
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		release := gitHubRelease{
+			TagName: "v2.1.0",
+			Assets:  []gitHubAsset{{Name: "phpstan.phar", DownloadURL: srv.URL + "/dl"}},
+		}
+		json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+
+	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
+	updated, _, err := Update(client, pkg)
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated {
+		t.Error("Update() updated = true, want false (v-prefix normalization)")
+	}
+}
+
+func TestUpdateComposer_AlreadyUpToDate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	config.EnsureDirs()
+
+	vs := &binaries.VersionState{Versions: map[string]string{"laravel": "v5.3.0"}}
+	vs.Save()
+
+	orig := runComposer
+	t.Cleanup(func() { runComposer = orig })
+	runComposer = func(args ...string) ([]byte, error) {
+		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
+			return json.Marshal(map[string]any{
+				"versions": []string{"v5.3.0"},
+			})
+		}
+		return []byte(""), nil
+	}
+
+	pkg := Package{Name: "laravel", Repo: "laravel/installer", Method: MethodComposer, Composer: "laravel/installer"}
+	updated, version, err := Update(nil, pkg)
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated {
+		t.Error("Update() updated = true, want false")
+	}
+	if version != "v5.3.0" {
+		t.Errorf("Update() version = %q, want %q", version, "v5.3.0")
+	}
+}
+
+func TestUpdateComposer_NewVersionAvailable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	config.EnsureDirs()
+
+	vs := &binaries.VersionState{Versions: map[string]string{"laravel": "v5.2.0"}}
+	vs.Save()
+
+	orig := runComposer
+	t.Cleanup(func() { runComposer = orig })
+	runComposer = func(args ...string) ([]byte, error) {
+		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
+			return json.Marshal(map[string]any{
+				"versions": []string{"v5.3.0"},
+			})
+		}
+		return []byte(""), nil
+	}
+
+	pkg := Package{Name: "laravel", Repo: "laravel/installer", Method: MethodComposer, Composer: "laravel/installer"}
+	updated, version, err := Update(nil, pkg)
 	if err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
@@ -87,44 +192,8 @@ func TestUpdate_NewVersionAvailable(t *testing.T) {
 		t.Errorf("Update() version = %q, want %q", version, "v5.3.0")
 	}
 
-	content, _ := os.ReadFile(pkg.PharPath())
-	if string(content) != pharContent {
-		t.Errorf("PHAR content = %q, want new content", string(content))
-	}
-
 	loaded, _ := binaries.LoadVersions()
 	if loaded.Get("laravel") != "v5.3.0" {
 		t.Errorf("versions.json[laravel] = %q, want %q", loaded.Get("laravel"), "v5.3.0")
-	}
-}
-
-func TestUpdate_NormalizesVPrefix(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	config.EnsureDirs()
-
-	vs := &binaries.VersionState{Versions: map[string]string{"laravel": "5.3.0"}}
-	vs.Save()
-
-	var srv *httptest.Server
-	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		release := gitHubRelease{
-			TagName: "v5.3.0",
-			Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
-		}
-		json.NewEncoder(w).Encode(release)
-	}))
-	defer srv.Close()
-
-	client := srv.Client()
-	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
-
-	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
-	updated, _, err := Update(client, pkg)
-	if err != nil {
-		t.Fatalf("Update() error = %v", err)
-	}
-	if updated {
-		t.Error("Update() updated = true, want false (v-prefix normalization)")
 	}
 }

--- a/internal/packages/update_test.go
+++ b/internal/packages/update_test.go
@@ -1,6 +1,7 @@
 package packages
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -34,7 +35,7 @@ func TestUpdatePHAR_AlreadyUpToDate(t *testing.T) {
 	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
 
 	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
-	updated, version, err := Update(client, pkg)
+	updated, version, err := Update(context.Background(), client, pkg)
 	if err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
@@ -76,7 +77,7 @@ func TestUpdatePHAR_NewVersionAvailable(t *testing.T) {
 	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
 
 	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
-	updated, version, err := Update(client, pkg)
+	updated, version, err := Update(context.Background(), client, pkg)
 	if err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
@@ -120,7 +121,7 @@ func TestUpdatePHAR_NormalizesVPrefix(t *testing.T) {
 	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
 
 	pkg := Package{Name: "phpstan", Repo: "phpstan/phpstan", Method: MethodPHAR, Asset: "phpstan.phar"}
-	updated, _, err := Update(client, pkg)
+	updated, _, err := Update(context.Background(), client, pkg)
 	if err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
@@ -139,7 +140,7 @@ func TestUpdateComposer_AlreadyUpToDate(t *testing.T) {
 
 	orig := runComposer
 	t.Cleanup(func() { runComposer = orig })
-	runComposer = func(args ...string) ([]byte, error) {
+	runComposer = func(_ context.Context, args ...string) ([]byte, error) {
 		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
 			return json.Marshal(map[string]any{
 				"versions": []string{"v5.3.0"},
@@ -149,7 +150,7 @@ func TestUpdateComposer_AlreadyUpToDate(t *testing.T) {
 	}
 
 	pkg := Package{Name: "laravel", Repo: "laravel/installer", Method: MethodComposer, Composer: "laravel/installer"}
-	updated, version, err := Update(nil, pkg)
+	updated, version, err := Update(context.Background(), nil, pkg)
 	if err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}
@@ -171,7 +172,7 @@ func TestUpdateComposer_NewVersionAvailable(t *testing.T) {
 
 	orig := runComposer
 	t.Cleanup(func() { runComposer = orig })
-	runComposer = func(args ...string) ([]byte, error) {
+	runComposer = func(_ context.Context, args ...string) ([]byte, error) {
 		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
 			return json.Marshal(map[string]any{
 				"versions": []string{"v5.3.0"},
@@ -181,7 +182,7 @@ func TestUpdateComposer_NewVersionAvailable(t *testing.T) {
 	}
 
 	pkg := Package{Name: "laravel", Repo: "laravel/installer", Method: MethodComposer, Composer: "laravel/installer"}
-	updated, version, err := Update(nil, pkg)
+	updated, version, err := Update(context.Background(), nil, pkg)
 	if err != nil {
 		t.Fatalf("Update() error = %v", err)
 	}

--- a/internal/packages/update_test.go
+++ b/internal/packages/update_test.go
@@ -1,0 +1,130 @@
+package packages
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prvious/pv/internal/binaries"
+	"github.com/prvious/pv/internal/config"
+)
+
+func TestUpdate_AlreadyUpToDate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	config.EnsureDirs()
+
+	vs := &binaries.VersionState{Versions: map[string]string{"laravel": "v5.3.0"}}
+	vs.Save()
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		release := gitHubRelease{
+			TagName: "v5.3.0",
+			Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
+		}
+		json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+
+	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
+	updated, version, err := Update(client, pkg)
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated {
+		t.Error("Update() updated = true, want false (already up to date)")
+	}
+	if version != "v5.3.0" {
+		t.Errorf("Update() version = %q, want %q", version, "v5.3.0")
+	}
+}
+
+func TestUpdate_NewVersionAvailable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	config.EnsureDirs()
+
+	vs := &binaries.VersionState{Versions: map[string]string{"laravel": "v5.2.0"}}
+	vs.Save()
+
+	os.WriteFile(filepath.Join(config.PackagesDir(), "laravel.phar"), []byte("old"), 0755)
+
+	pharContent := "#!/usr/bin/env php\n<?php echo 'new';\n"
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/laravel/installer/releases/latest" {
+			release := gitHubRelease{
+				TagName: "v5.3.0",
+				Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
+			}
+			json.NewEncoder(w).Encode(release)
+			return
+		}
+		w.Write([]byte(pharContent))
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+
+	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
+	updated, version, err := Update(client, pkg)
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if !updated {
+		t.Error("Update() updated = false, want true")
+	}
+	if version != "v5.3.0" {
+		t.Errorf("Update() version = %q, want %q", version, "v5.3.0")
+	}
+
+	content, _ := os.ReadFile(pkg.PharPath())
+	if string(content) != pharContent {
+		t.Errorf("PHAR content = %q, want new content", string(content))
+	}
+
+	loaded, _ := binaries.LoadVersions()
+	if loaded.Get("laravel") != "v5.3.0" {
+		t.Errorf("versions.json[laravel] = %q, want %q", loaded.Get("laravel"), "v5.3.0")
+	}
+}
+
+func TestUpdate_NormalizesVPrefix(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	config.EnsureDirs()
+
+	vs := &binaries.VersionState{Versions: map[string]string{"laravel": "5.3.0"}}
+	vs.Save()
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		release := gitHubRelease{
+			TagName: "v5.3.0",
+			Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
+		}
+		json.NewEncoder(w).Encode(release)
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+
+	pkg := Package{Name: "laravel", Repo: "laravel/installer", Asset: "laravel.phar"}
+	updated, _, err := Update(client, pkg)
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if updated {
+		t.Error("Update() updated = true, want false (v-prefix normalization)")
+	}
+}

--- a/internal/packages/updater.go
+++ b/internal/packages/updater.go
@@ -2,7 +2,9 @@ package packages
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -10,10 +12,9 @@ const retryDelay = 30 * time.Second
 
 // StartBackgroundUpdater starts a goroutine that checks for package updates
 // immediately, then on every tick of the given interval. Stops when ctx is cancelled.
-// The client parameter enables testability via urlRewriteTransport.
 func StartBackgroundUpdater(ctx context.Context, client *http.Client, interval time.Duration) {
 	go func() {
-		updateAllSilent(client)
+		updateAllSilent(ctx, client)
 
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -23,20 +24,35 @@ func StartBackgroundUpdater(ctx context.Context, client *http.Client, interval t
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				updateAllSilent(client)
+				updateAllSilent(ctx, client)
 			}
 		}
 	}()
 }
 
 // updateAllSilent updates all packages, retrying once on failure per package.
-// All errors are swallowed — this runs in the background.
-func updateAllSilent(client *http.Client) {
+// Errors are logged to stderr but do not propagate — this runs in the background.
+// Note: the retry delay is context-aware and will abort on shutdown.
+func updateAllSilent(ctx context.Context, client *http.Client) {
 	for _, pkg := range Managed {
-		_, _, err := Update(client, pkg)
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		_, _, err := Update(ctx, client, pkg)
 		if err != nil {
-			time.Sleep(retryDelay)
-			Update(client, pkg) //nolint:errcheck // best-effort retry
+			fmt.Fprintf(os.Stderr, "pv: background update for %s failed, retrying in %s: %v\n", pkg.Name, retryDelay, err)
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(retryDelay):
+			}
+			_, _, retryErr := Update(ctx, client, pkg)
+			if retryErr != nil {
+				fmt.Fprintf(os.Stderr, "pv: background update for %s failed after retry: %v\n", pkg.Name, retryErr)
+			}
 		}
 	}
 }

--- a/internal/packages/updater.go
+++ b/internal/packages/updater.go
@@ -1,0 +1,42 @@
+package packages
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+const retryDelay = 30 * time.Second
+
+// StartBackgroundUpdater starts a goroutine that checks for package updates
+// immediately, then on every tick of the given interval. Stops when ctx is cancelled.
+// The client parameter enables testability via urlRewriteTransport.
+func StartBackgroundUpdater(ctx context.Context, client *http.Client, interval time.Duration) {
+	go func() {
+		updateAllSilent(client)
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				updateAllSilent(client)
+			}
+		}
+	}()
+}
+
+// updateAllSilent updates all packages, retrying once on failure per package.
+// All errors are swallowed — this runs in the background.
+func updateAllSilent(client *http.Client) {
+	for _, pkg := range Managed {
+		_, _, err := Update(client, pkg)
+		if err != nil {
+			time.Sleep(retryDelay)
+			Update(client, pkg) //nolint:errcheck // best-effort retry
+		}
+	}
+}

--- a/internal/packages/updater_test.go
+++ b/internal/packages/updater_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,28 +18,24 @@ func TestStartBackgroundUpdater_RunsImmediately(t *testing.T) {
 
 	var callCount atomic.Int32
 
-	var srv *httptest.Server
-	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Mock composer commands since Managed[0] is MethodComposer.
+	orig := runComposer
+	t.Cleanup(func() { runComposer = orig })
+	runComposer = func(args ...string) ([]byte, error) {
 		callCount.Add(1)
-		if r.URL.Path == "/repos/laravel/installer/releases/latest" {
-			release := gitHubRelease{
-				TagName: "v5.3.0",
-				Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
-			}
-			json.NewEncoder(w).Encode(release)
-			return
+		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
+			out, _ := json.Marshal(map[string]any{
+				"versions": []string{"v5.3.0"},
+			})
+			return out, nil
 		}
-		w.Write([]byte("phar-content"))
-	}))
-	defer srv.Close()
-
-	client := srv.Client()
-	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+		return []byte(""), nil
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	StartBackgroundUpdater(ctx, client, 1*time.Hour)
+	StartBackgroundUpdater(ctx, &http.Client{}, 1*time.Hour)
 
 	// Give the immediate check time to complete.
 	time.Sleep(500 * time.Millisecond)
@@ -55,25 +50,21 @@ func TestStartBackgroundUpdater_StopsOnCancel(t *testing.T) {
 	t.Setenv("HOME", home)
 	config.EnsureDirs()
 
-	var srv *httptest.Server
-	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/repos/laravel/installer/releases/latest" {
-			release := gitHubRelease{
-				TagName: "v5.3.0",
-				Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
-			}
-			json.NewEncoder(w).Encode(release)
-			return
+	// Mock composer commands since Managed[0] is MethodComposer.
+	orig := runComposer
+	t.Cleanup(func() { runComposer = orig })
+	runComposer = func(args ...string) ([]byte, error) {
+		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
+			out, _ := json.Marshal(map[string]any{
+				"versions": []string{"v5.3.0"},
+			})
+			return out, nil
 		}
-		w.Write([]byte("phar-content"))
-	}))
-	defer srv.Close()
-
-	client := srv.Client()
-	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+		return []byte(""), nil
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	StartBackgroundUpdater(ctx, client, 50*time.Millisecond)
+	StartBackgroundUpdater(ctx, &http.Client{}, 50*time.Millisecond)
 
 	time.Sleep(200 * time.Millisecond)
 	cancel()

--- a/internal/packages/updater_test.go
+++ b/internal/packages/updater_test.go
@@ -21,7 +21,7 @@ func TestStartBackgroundUpdater_RunsImmediately(t *testing.T) {
 	// Mock composer commands since Managed[0] is MethodComposer.
 	orig := runComposer
 	t.Cleanup(func() { runComposer = orig })
-	runComposer = func(args ...string) ([]byte, error) {
+	runComposer = func(_ context.Context, args ...string) ([]byte, error) {
 		callCount.Add(1)
 		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
 			out, _ := json.Marshal(map[string]any{
@@ -53,7 +53,7 @@ func TestStartBackgroundUpdater_StopsOnCancel(t *testing.T) {
 	// Mock composer commands since Managed[0] is MethodComposer.
 	orig := runComposer
 	t.Cleanup(func() { runComposer = orig })
-	runComposer = func(args ...string) ([]byte, error) {
+	runComposer = func(_ context.Context, args ...string) ([]byte, error) {
 		if len(args) >= 3 && args[0] == "global" && args[1] == "show" {
 			out, _ := json.Marshal(map[string]any{
 				"versions": []string{"v5.3.0"},

--- a/internal/packages/updater_test.go
+++ b/internal/packages/updater_test.go
@@ -1,0 +1,83 @@
+package packages
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+func TestStartBackgroundUpdater_RunsImmediately(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	config.EnsureDirs()
+
+	var callCount atomic.Int32
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		if r.URL.Path == "/repos/laravel/installer/releases/latest" {
+			release := gitHubRelease{
+				TagName: "v5.3.0",
+				Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
+			}
+			json.NewEncoder(w).Encode(release)
+			return
+		}
+		w.Write([]byte("phar-content"))
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	StartBackgroundUpdater(ctx, client, 1*time.Hour)
+
+	// Give the immediate check time to complete.
+	time.Sleep(500 * time.Millisecond)
+
+	if callCount.Load() == 0 {
+		t.Error("background updater did not run immediately")
+	}
+}
+
+func TestStartBackgroundUpdater_StopsOnCancel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	config.EnsureDirs()
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/laravel/installer/releases/latest" {
+			release := gitHubRelease{
+				TagName: "v5.3.0",
+				Assets:  []gitHubAsset{{Name: "laravel.phar", DownloadURL: srv.URL + "/dl"}},
+			}
+			json.NewEncoder(w).Encode(release)
+			return
+		}
+		w.Write([]byte("phar-content"))
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	client.Transport = &urlRewriteTransport{base: http.DefaultTransport, testURL: srv.URL}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	StartBackgroundUpdater(ctx, client, 50*time.Millisecond)
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	// Should not panic or hang after cancel.
+	time.Sleep(100 * time.Millisecond)
+}

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -1,15 +1,19 @@
 package server
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/prvious/pv/internal/caddy"
 	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/packages"
 	"github.com/prvious/pv/internal/phpenv"
 	"github.com/prvious/pv/internal/registry"
 	"github.com/prvious/pv/internal/watcher"
@@ -107,6 +111,11 @@ func Start(tld string) error {
 
 		go handleWatcherEvents(projectWatcher, globalPHP)
 	}
+
+	// Start background package updater.
+	pkgCtx, pkgCancel := context.WithCancel(context.Background())
+	defer pkgCancel()
+	packages.StartBackgroundUpdater(pkgCtx, &http.Client{}, 24*time.Hour)
 
 	// Wait for signals or child exit.
 	sigCh := make(chan os.Signal, 1)


### PR DESCRIPTION
## Summary
- Add `internal/packages/` module that downloads, installs, and auto-updates managed PHAR packages (starting with `laravel/installer`)
- PHARs are downloaded from GitHub releases to `~/.pv/internal/packages/`, symlinked into `~/.pv/bin/`, with versions tracked in `versions.json`
- Background updater goroutine checks for updates every 24h while server runs, with one retry on failure
- Wired into `pv install` (per-package progress bar), `pv update` (per-package status), and `server.Start()` (background goroutine with context-based shutdown)

## Test Plan
- [ ] `go test ./internal/packages/ -v` — 10 tests covering install, update, version normalization, background updater lifecycle
- [ ] `go test ./internal/config/ -run TestPackagesDir -v` — PackagesDir path helper
- [ ] `go test ./... -timeout 60s` — full suite passes (no regressions)
- [ ] `go vet ./...` and `gofmt -l .` — clean
- [ ] Manual: `pv install` shows `✓ laravel v*` step
- [ ] Manual: `pv update` shows `✓ laravel already up to date` or `✓ laravel updated to v*`