### PR TITLE
Add CA commands and streamline setup flows

### DIFF
--- a/cmd/ca.go
+++ b/cmd/ca.go
@@ -1,0 +1,7 @@
+package cmd
+
+import "github.com/prvious/pv/internal/commands/ca"
+
+func init() {
+	ca.Register(rootCmd)
+}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -664,14 +663,9 @@ func checkPortListening(port int) bool {
 }
 
 func checkCATrusted() bool {
-	out, err := exec.Command("security", "find-certificate", "-c", "Caddy Local Authority", "/Library/Keychains/System.keychain").CombinedOutput()
+	trusted, err := setup.IsCATrusted()
 	if err != nil {
-		// Also check login keychain.
-		out2, err2 := exec.Command("security", "find-certificate", "-c", "Caddy Local Authority").CombinedOutput()
-		if err2 != nil {
-			return false
-		}
-		return strings.Contains(string(out2), "Caddy Local Authority")
+		return false
 	}
-	return strings.Contains(string(out), "Caddy Local Authority")
+	return trusted
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ func init() {
 		&cobra.Group{ID: "mago", Title: "Mago"},
 		&cobra.Group{ID: "colima", Title: "Colima"},
 		&cobra.Group{ID: "service", Title: "Services"},
+		&cobra.Group{ID: "ca", Title: "CA"},
 		&cobra.Group{ID: "daemon", Title: "Daemon"},
 	)
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/phpenv"
 	"github.com/prvious/pv/internal/services"
+	setupinternal "github.com/prvious/pv/internal/setup"
 	"github.com/prvious/pv/internal/tools"
 	"github.com/prvious/pv/internal/ui"
 	"github.com/spf13/cobra"
@@ -117,28 +118,42 @@ var setupCmd = &cobra.Command{
 			return err
 		}
 
+		if err := ui.Step("Checking prerequisites...", func() (string, error) {
+			if err := setupinternal.CheckOS(); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("macOS %s", setupinternal.PlatformLabel()), nil
+		}); err != nil {
+			return err
+		}
+
 		// Acquire sudo upfront.
 		if err := acquireSudo(); err != nil {
 			return err
 		}
 
-		// Ensure directories exist.
-		if err := config.EnsureDirs(); err != nil {
-			return fmt.Errorf("cannot create directories: %w", err)
-		}
+		if err := ui.Step("Preparing environment...", func() (string, error) {
+			if err := config.EnsureDirs(); err != nil {
+				return "", fmt.Errorf("cannot create directories: %w", err)
+			}
 
-		// Build settings from wizard output, preserving existing PHP default.
-		s := &config.Settings{
-			Defaults:   config.Defaults{TLD: tld, PHP: settings.Defaults.PHP, Daemon: config.BoolPtr(daemon)},
-			Automation: automation,
-		}
-		if err := s.Save(); err != nil {
-			return fmt.Errorf("cannot save settings: %w", err)
-		}
+			// Build settings from wizard output, preserving existing PHP default.
+			s := &config.Settings{
+				Defaults:   config.Defaults{TLD: tld, PHP: settings.Defaults.PHP, Daemon: config.BoolPtr(daemon)},
+				Automation: automation,
+			}
+			if err := s.Save(); err != nil {
+				return "", fmt.Errorf("cannot save settings: %w", err)
+			}
 
-		// Write Valet-compatible config for Vite TLS auto-detection.
-		if err := certs.EnsureValetConfig(tld); err != nil {
-			ui.Subtle(fmt.Sprintf("Vite TLS config: %v", err))
+			// Write Valet-compatible config for Vite TLS auto-detection.
+			if err := certs.EnsureValetConfig(tld); err != nil {
+				ui.Subtle(fmt.Sprintf("Vite TLS config: %v", err))
+			}
+
+			return "Settings saved", nil
+		}); err != nil {
+			return err
 		}
 
 		// Install PHP versions.
@@ -159,11 +174,24 @@ var setupCmd = &cobra.Command{
 			}
 		}
 
-		// Set global PHP if not set.
-		if _, err := phpenv.GlobalVersion(); err != nil && len(selectedPHP) > 0 {
+		if err := ui.Step("Configuring global PHP...", func() (string, error) {
+			if len(selectedPHP) == 0 {
+				return "No PHP versions selected", nil
+			}
+
+			if _, err := phpenv.GlobalVersion(); err == nil {
+				return "Global PHP already configured", nil
+			}
+
 			latest := selectedPHP[len(selectedPHP)-1]
-			if err := phpenv.SetGlobal(latest); err == nil {
-				ui.Success(fmt.Sprintf("PHP %s set as global default", latest))
+			if err := phpenv.SetGlobal(latest); err != nil {
+				return "", err
+			}
+
+			return fmt.Sprintf("PHP %s set as global default", latest), nil
+		}); err != nil {
+			if !errors.Is(err, ui.ErrAlreadyPrinted) {
+				ui.Fail(fmt.Sprintf("Global PHP setup failed: %v", err))
 			}
 		}
 
@@ -188,20 +216,24 @@ var setupCmd = &cobra.Command{
 			}
 		}
 
-		// Expose all installed tools (shims + symlinks).
-		if err := tools.ExposeAll(); err != nil {
-			ui.Fail(fmt.Sprintf("Tool exposure failed: %v", err))
-		}
+		if err := ui.Step("Updating tool shims...", func() (string, error) {
+			if err := tools.ExposeAll(); err != nil {
+				return "", err
+			}
 
-		// Save version manifest.
-		vs, err := binaries.LoadVersions()
-		if err == nil {
-			if len(selectedPHP) > 0 {
-				vs.Set("php", selectedPHP[len(selectedPHP)-1])
+			vs, err := binaries.LoadVersions()
+			if err == nil {
+				if len(selectedPHP) > 0 {
+					vs.Set("php", selectedPHP[len(selectedPHP)-1])
+				}
+				if saveErr := vs.Save(); saveErr != nil {
+					ui.Fail(fmt.Sprintf("Cannot save version manifest: %v", saveErr))
+				}
 			}
-			if saveErr := vs.Save(); saveErr != nil {
-				ui.Fail(fmt.Sprintf("Cannot save version manifest: %v", saveErr))
-			}
+
+			return "Tool shims updated", nil
+		}); err != nil {
+			ui.Fail(fmt.Sprintf("Tool exposure failed: %v", err))
 		}
 
 		// Finalize: Caddyfile, DNS, CA trust, shell PATH.

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -32,6 +32,8 @@ var uninstallCmd = &cobra.Command{
 	GroupID: "core",
 	Short:   "Completely remove pv and all its data",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		start := time.Now()
+
 		// Confirmation prompt.
 		ui.Subtle("This will remove:")
 		ui.Subtle("- The pv binary")
@@ -81,19 +83,30 @@ var uninstallCmd = &cobra.Command{
 			}
 		}
 
-		// Read registry before deletion (for pv.yml file scan later).
-		var projectPaths []string
-		reg, err := registry.Load()
-		if err == nil {
-			for _, p := range reg.List() {
-				projectPaths = append(projectPaths, p.Path)
-			}
-		}
+		fmt.Fprintln(os.Stderr)
+		ui.Header(version)
 
-		settings, _ := config.LoadSettings()
+		var projectPaths []string
 		tld := "test"
-		if settings != nil {
-			tld = settings.Defaults.TLD
+		var reg *registry.Registry
+
+		if err := ui.Step("Preparing uninstall...", func() (string, error) {
+			loadedReg, err := registry.Load()
+			if err == nil {
+				reg = loadedReg
+				for _, p := range reg.List() {
+					projectPaths = append(projectPaths, p.Path)
+				}
+			}
+
+			settings, _ := config.LoadSettings()
+			if settings != nil {
+				tld = settings.Defaults.TLD
+			}
+
+			return fmt.Sprintf("Using .%s domain", tld), nil
+		}); err != nil {
+			return err
 		}
 
 		// Uninstall tools (each cleans up its own binary + PATH entry).
@@ -162,9 +175,31 @@ var uninstallCmd = &cobra.Command{
 			// Error already displayed by ui.Step
 		}
 
+		resolverFile := filepath.Join("/etc/resolver", tld)
+		caCertPath := config.CACertPath()
+		if err := ui.Step("Checking system cleanup requirements...", func() (string, error) {
+			needSudo := false
+			if _, err := os.Stat(resolverFile); err == nil {
+				needSudo = true
+			}
+			if _, err := os.Stat(caCertPath); err == nil {
+				needSudo = true
+			}
+
+			if needSudo {
+				if err := acquireSudo(); err != nil {
+					return "", err
+				}
+				return "Sudo ready for system cleanup", nil
+			}
+
+			return "No sudo cleanup needed", nil
+		}); err != nil {
+			return err
+		}
+
 		// Remove system configuration (sudo).
 		if err := ui.Step("Removing DNS resolver...", func() (string, error) {
-			resolverFile := filepath.Join("/etc/resolver", tld)
 			if runSudo("rm", "-f", resolverFile) {
 				return "DNS resolver removed", nil
 			}
@@ -174,30 +209,12 @@ var uninstallCmd = &cobra.Command{
 		}
 
 		// Untrust CA certificate.
-		caCertPath := config.CACertPath()
 		if _, err := os.Stat(caCertPath); err == nil {
 			if err := ui.Step("Removing CA certificate...", func() (string, error) {
-				certCmd := exec.Command("sudo", "-n", "security", "remove-trusted-cert", "-d", caCertPath)
-				certCmd.Stdout = os.Stdout
-				certCmd.Stderr = os.Stderr
-
-				if err := certCmd.Start(); err != nil {
+				if err := setup.RunSudoUntrustCACert(); err != nil {
 					return "", fmt.Errorf("could not untrust CA — run: sudo security remove-trusted-cert -d %s", caCertPath)
 				}
-
-				done := make(chan error, 1)
-				go func() { done <- certCmd.Wait() }()
-				select {
-				case err := <-done:
-					if err != nil {
-						return "", fmt.Errorf("could not untrust CA — run: sudo security remove-trusted-cert -d %s", caCertPath)
-					}
-					return "CA certificate removed", nil
-				case <-time.After(10 * time.Second):
-					certCmd.Process.Kill()
-					<-done
-					return "", fmt.Errorf("CA removal timed out — run: sudo security remove-trusted-cert -d %s", caCertPath)
-				}
+				return "CA certificate removed", nil
 			}); err != nil {
 				// Error already displayed by ui.Step
 			}
@@ -278,6 +295,7 @@ var uninstallCmd = &cobra.Command{
 		ui.Subtle("  eval \"$(pv env)\"   # if present")
 
 		ui.Success("pv has been completely uninstalled. Your projects were not modified.")
+		ui.Footer(start, "https://pv.prvious.dev/docs")
 
 		return nil
 	},

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,7 @@ Examples:
     curl -fsSL https://pv.prvious.dev/install | bash
     curl -fsSL https://pv.prvious.dev/install | bash -s -- --version 0.2.0
     curl -fsSL https://pv.prvious.dev/install | bash -s -- --install-dir /usr/local/bin
+    PV_INSTALL_LOCAL_BUILD=./pv bash install.sh
 EOF
 }
 
@@ -36,6 +37,7 @@ EOF
 requested_version=""
 no_modify_path=false
 install_dir=""
+local_build="${PV_INSTALL_LOCAL_BUILD:-}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -352,9 +354,11 @@ main() {
     local platform
     platform=$(detect_platform)
 
-    # Resolve version
-    local version
-    version=$(resolve_version)
+    # Resolve version unless we are testing with a local build.
+    local version="local"
+    if [[ -z "$local_build" ]]; then
+        version=$(resolve_version)
+    fi
 
     # Print header
     print_header "$version"
@@ -378,25 +382,36 @@ main() {
     # Check for existing installation
     check_existing
 
-    # Download pv binary
-    local url="https://github.com/prvious/pv/releases/download/v${version}/pv-${platform}"
     local tmp_dir="${TMPDIR:-/tmp}/pv_install_$$"
     mkdir -p "$tmp_dir"
     trap "rm -rf '$tmp_dir'" EXIT
 
-    echo -e "  ${MUTED}Downloading pv...${NC}"
-
-    if [[ -t 2 ]] && download_with_progress "$url" "$tmp_dir/pv" 2>&1; then
-        : # progress bar showed
-    else
-        # Fallback: no TTY or progress bar failed
-        if ! curl -fsSL -o "$tmp_dir/pv" "$url"; then
+    if [[ -n "$local_build" ]]; then
+        if [[ ! -f "$local_build" ]]; then
             echo ""
-            echo -e "  ${RED}Failed to download pv${NC}"
-            echo -e "  ${MUTED}Check your internet connection and try again.${NC}"
-            echo -e "  ${MUTED}Manual download: https://github.com/prvious/pv/releases${NC}"
+            echo -e "  ${RED}Local build not found: $local_build${NC}"
             echo ""
             exit 1
+        fi
+        echo -e "  ${MUTED}Using local pv build from ${local_build}...${NC}"
+        cp "$local_build" "$tmp_dir/pv"
+    else
+        local url="https://github.com/prvious/pv/releases/download/v${version}/pv-${platform}"
+
+        echo -e "  ${MUTED}Downloading pv...${NC}"
+
+        if [[ -t 2 ]] && download_with_progress "$url" "$tmp_dir/pv" 2>&1; then
+            : # progress bar showed
+        else
+            # Fallback: no TTY or progress bar failed
+            if ! curl -fsSL -o "$tmp_dir/pv" "$url"; then
+                echo ""
+                echo -e "  ${RED}Failed to download pv${NC}"
+                echo -e "  ${MUTED}Check your internet connection and try again.${NC}"
+                echo -e "  ${MUTED}Manual download: https://github.com/prvious/pv/releases${NC}"
+                echo ""
+                exit 1
+            fi
         fi
     fi
 

--- a/internal/commands/ca/register.go
+++ b/internal/commands/ca/register.go
@@ -1,0 +1,21 @@
+package ca
+
+import "github.com/spf13/cobra"
+
+func Register(parent *cobra.Command) {
+	parent.AddCommand(trustCmd)
+	parent.AddCommand(untrustCmd)
+	parent.AddCommand(statusCmd)
+}
+
+func RunTrust() error {
+	return trustCmd.RunE(trustCmd, nil)
+}
+
+func RunUntrust() error {
+	return untrustCmd.RunE(untrustCmd, nil)
+}
+
+func RunStatus() error {
+	return statusCmd.RunE(statusCmd, nil)
+}

--- a/internal/commands/ca/status.go
+++ b/internal/commands/ca/status.go
@@ -1,0 +1,38 @@
+package ca
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/setup"
+	"github.com/prvious/pv/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:     "ca:status",
+	Aliases: []string{"ca:check"},
+	GroupID: "ca",
+	Short:   "Show pv local CA trust status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		caPath := config.CACertPath()
+		if _, err := os.Stat(caPath); err != nil {
+			ui.Subtle(fmt.Sprintf("CA certificate not found at %s", caPath))
+			return nil
+		}
+
+		trusted, err := setup.IsCATrusted()
+		if err != nil {
+			return fmt.Errorf("cannot check CA trust status: %w", err)
+		}
+
+		if trusted {
+			ui.Success("CA certificate is trusted")
+		} else {
+			ui.Subtle("CA certificate is not trusted")
+		}
+		ui.Subtle(fmt.Sprintf("CA path: %s", caPath))
+		return nil
+	},
+}

--- a/internal/commands/ca/sudo.go
+++ b/internal/commands/ca/sudo.go
@@ -1,0 +1,22 @@
+package ca
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/prvious/pv/internal/ui"
+)
+
+func acquireSudo() error {
+	ui.Subtle("pv needs sudo to update the system keychain.")
+	cmd := exec.Command("sudo", "-v")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("sudo authentication failed: %w", err)
+	}
+	fmt.Fprintln(os.Stderr)
+	return nil
+}

--- a/internal/commands/ca/trust.go
+++ b/internal/commands/ca/trust.go
@@ -1,0 +1,47 @@
+package ca
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/prvious/pv/internal/setup"
+	"github.com/prvious/pv/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var trustCmd = &cobra.Command{
+	Use:     "ca:trust",
+	GroupID: "ca",
+	Short:   "Trust pv's local CA in the macOS System keychain",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		setup.Verbose = true
+		defer func() { setup.Verbose = false }()
+
+		if err := acquireSudo(); err != nil {
+			return err
+		}
+
+		if err := ui.Step("Trusting CA certificate...", func() (string, error) {
+			if err := setup.RunSudoTrustWithServer(); err != nil {
+				return "", err
+			}
+
+			trusted, err := setup.IsCATrusted()
+			if err != nil {
+				return "", err
+			}
+			if !trusted {
+				return "", fmt.Errorf("CA certificate is still not trusted")
+			}
+
+			return "CA certificate trusted", nil
+		}); err != nil {
+			if !errors.Is(err, ui.ErrAlreadyPrinted) {
+				return fmt.Errorf("cannot trust CA certificate: %w", err)
+			}
+			return err
+		}
+
+		return nil
+	},
+}

--- a/internal/commands/ca/untrust.go
+++ b/internal/commands/ca/untrust.go
@@ -1,0 +1,53 @@
+package ca
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/setup"
+	"github.com/prvious/pv/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var untrustCmd = &cobra.Command{
+	Use:     "ca:untrust",
+	GroupID: "ca",
+	Short:   "Remove pv's local CA from the macOS System keychain",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		setup.Verbose = true
+		defer func() { setup.Verbose = false }()
+
+		if _, err := os.Stat(config.CACertPath()); err != nil {
+			return fmt.Errorf("CA certificate not found at %s", config.CACertPath())
+		}
+
+		if err := acquireSudo(); err != nil {
+			return err
+		}
+
+		if err := ui.Step("Removing CA certificate...", func() (string, error) {
+			if err := setup.RunSudoUntrustCACert(); err != nil {
+				return "", err
+			}
+
+			trusted, err := setup.IsCATrusted()
+			if err != nil {
+				return "", err
+			}
+			if trusted {
+				return "", fmt.Errorf("CA certificate is still trusted")
+			}
+
+			return "CA certificate removed", nil
+		}); err != nil {
+			if !errors.Is(err, ui.ErrAlreadyPrinted) {
+				return fmt.Errorf("cannot remove CA certificate: %w", err)
+			}
+			return err
+		}
+
+		return nil
+	},
+}

--- a/internal/setup/resolver.go
+++ b/internal/setup/resolver.go
@@ -1,6 +1,9 @@
 package setup
 
 import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"os"
@@ -14,29 +17,27 @@ import (
 const (
 	resolverDir     = "/etc/resolver"
 	resolverContent = "nameserver 127.0.0.1\nport 10053\n"
+	systemKeychain  = "/Library/Keychains/System.keychain"
+	caCommonName    = "Caddy Local Authority"
 )
 
 // SudoSetupScript returns the shell script for the combined sudo operations:
 // creating the DNS resolver file and trusting the Caddy CA certificate.
 func SudoSetupScript(tld string) string {
 	resolverFile := filepath.Join(resolverDir, tld)
-	frankenphp := filepath.Join(config.BinDir(), "frankenphp")
-	pvDir := config.PvDir()
 	return fmt.Sprintf(
-		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s && XDG_DATA_HOME="%s" XDG_CONFIG_HOME="%s" "%s" trust`,
-		resolverDir, resolverFile, pvDir, pvDir, frankenphp,
+		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s`,
+		resolverDir, resolverFile,
 	)
 }
 
 // RunSudoSetup executes the combined sudo command for DNS resolver and CA trust.
 // It connects stdin/stdout/stderr so the user can enter their password.
 func RunSudoSetup(tld string) error {
-	script := SudoSetupScript(tld)
-	cmd := exec.Command("sudo", "sh", "-c", script)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	if err := RunSudoResolver(tld); err != nil {
+		return err
+	}
+	return RunSudoTrustWithServer()
 }
 
 // ResolverSetupScript returns the shell script for creating the DNS resolver file only (no trust).
@@ -63,8 +64,121 @@ func RunSudoResolver(tld string) error {
 	return cmd.Run()
 }
 
-// RunSudoTrustWithServer starts FrankenPHP temporarily so the admin API is
-// available, runs `sudo frankenphp trust`, then stops the server.
+func caFingerprint(certPath string) ([]byte, error) {
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, fmt.Errorf("read CA certificate: %w", err)
+	}
+
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("decode CA certificate: no PEM block found")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse CA certificate: %w", err)
+	}
+
+	return cert.Raw, nil
+}
+
+func keychainHasCert(certPath string, args ...string) (bool, error) {
+	out, err := exec.Command("security", args...).Output()
+	if err != nil {
+		return false, err
+	}
+
+	target, err := caFingerprint(certPath)
+	if err != nil {
+		return false, err
+	}
+
+	rest := out
+	for {
+		block, remaining := pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			cert, err := x509.ParseCertificate(block.Bytes)
+			if err == nil && bytes.Equal(cert.Raw, target) {
+				return true, nil
+			}
+		}
+		rest = remaining
+	}
+
+	return false, nil
+}
+
+// IsCATrusted reports whether the current Caddy local CA certificate is present
+// in the System keychain.
+func IsCATrusted() (bool, error) {
+	certPath := config.CACertPath()
+	if _, err := os.Stat(certPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat CA certificate: %w", err)
+	}
+
+	trusted, err := keychainHasCert(certPath, "find-certificate", "-c", caCommonName, "-a", "-p", systemKeychain)
+	if err != nil {
+		if _, ok := err.(*exec.ExitError); ok {
+			return false, nil
+		}
+		return false, fmt.Errorf("check System keychain: %w", err)
+	}
+
+	return trusted, nil
+}
+
+// RunSudoTrustCACert trusts the current Caddy local CA certificate using
+// FrankenPHP's trust command.
+func RunSudoTrustCACert() error {
+	frankenphp := filepath.Join(config.BinDir(), "frankenphp")
+	pvDir := config.PvDir()
+	trust := exec.Command(frankenphp, "trust")
+	trust.Env = append(os.Environ(), "XDG_DATA_HOME="+pvDir, "XDG_CONFIG_HOME="+pvDir)
+	trust.Stdin = os.Stdin
+	if Verbose {
+		trust.Stdout = os.Stdout
+		trust.Stderr = os.Stderr
+	}
+	if err := trust.Run(); err != nil {
+		return fmt.Errorf("frankenphp trust: %w", err)
+	}
+
+	return nil
+}
+
+// RunSudoUntrustCACert removes the current Caddy local CA certificate using
+// FrankenPHP's untrust command.
+func RunSudoUntrustCACert() error {
+	certPath := config.CACertPath()
+	if _, err := os.Stat(certPath); err != nil {
+		return fmt.Errorf("Caddy CA not found at %s: %w", certPath, err)
+	}
+
+	frankenphp := filepath.Join(config.BinDir(), "frankenphp")
+	pvDir := config.PvDir()
+	cmd := exec.Command(frankenphp, "untrust", "--cert", certPath)
+	cmd.Env = append(os.Environ(), "XDG_DATA_HOME="+pvDir, "XDG_CONFIG_HOME="+pvDir)
+	cmd.Stdin = os.Stdin
+	if Verbose {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("frankenphp untrust: %w", err)
+	}
+
+	return nil
+}
+
+// RunSudoTrustWithServer starts FrankenPHP temporarily so the local CA exists,
+// then trusts that CA in the System keychain.
 func RunSudoTrustWithServer() error {
 	frankenphp := filepath.Join(config.BinDir(), "frankenphp")
 	caddyfile := config.CaddyfilePath()
@@ -102,17 +216,8 @@ func RunSudoTrustWithServer() error {
 		return fmt.Errorf("FrankenPHP admin API did not become ready within 5s")
 	}
 
-	// Run trust with sudo — use sh -c with explicit env vars since sudo clears env.
-	pvDir := config.PvDir()
-	script := fmt.Sprintf(`XDG_DATA_HOME="%s" XDG_CONFIG_HOME="%s" "%s" trust`, pvDir, pvDir, frankenphp)
-	trust := exec.Command("sudo", "sh", "-c", script)
-	trust.Stdin = os.Stdin
-	if Verbose {
-		trust.Stdout = os.Stdout
-		trust.Stderr = os.Stderr
-	}
-	if err := trust.Run(); err != nil {
-		return fmt.Errorf("frankenphp trust: %w", err)
+	if err := RunSudoTrustCACert(); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/setup/resolver_test.go
+++ b/internal/setup/resolver_test.go
@@ -40,19 +40,21 @@ func TestSudoSetupScript_ContainsTrust(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	script := SudoSetupScript("test")
-	if !strings.Contains(script, "trust") {
-		t.Errorf("script missing trust command: %s", script)
+	if strings.Contains(script, "trust") {
+		t.Errorf("script should not contain trust command: %s", script)
 	}
 }
 
-func TestSudoSetupScript_UsesFrankenPHPPath(t *testing.T) {
+func TestSudoSetupScript_NoFrankenPHPOrCAPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
 	script := SudoSetupScript("test")
-	expected := filepath.Join(config.BinDir(), "frankenphp")
-	if !strings.Contains(script, expected) {
-		t.Errorf("script missing frankenphp path %q: %s", expected, script)
+	if strings.Contains(script, filepath.Join(config.BinDir(), "frankenphp")) {
+		t.Errorf("script should not call frankenphp: %s", script)
+	}
+	if strings.Contains(script, config.CACertPath()) {
+		t.Errorf("script should not contain CA path %q: %s", config.CACertPath(), script)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `ca:trust`, `ca:untrust`, and `ca:status`/`ca:check` commands while reusing FrankenPHP's trust flow with upfront sudo handling
- make `setup` and `uninstall` execute in a clearer step-oriented pipeline style similar to `install`
- add a local-build override for `install.sh` so the installer flow can be tested before a release is cut