### PR TITLE
Improve DNS and Colima reliability and security

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/miekg/dns"
 	"github.com/prvious/pv/internal/caddy"
 	"github.com/prvious/pv/internal/colima"
 	"github.com/prvious/pv/internal/config"
@@ -645,12 +647,22 @@ func containsPath(paths []string, target string) bool {
 }
 
 func checkDNSResponding(tld string) bool {
-	conn, err := net.Dial("udp", fmt.Sprintf("127.0.0.1:%d", config.DNSPort))
-	if err != nil {
+	c := new(dns.Client)
+	c.Timeout = 2 * time.Second
+	m := new(dns.Msg)
+	m.SetQuestion("healthcheck."+tld+".", dns.TypeA)
+
+	r, _, err := c.Exchange(m, fmt.Sprintf("127.0.0.1:%d", config.DNSPort))
+	if err != nil || r == nil {
 		return false
 	}
-	conn.Close()
-	return true
+
+	for _, ans := range r.Answer {
+		if a, ok := ans.(*dns.A); ok && a.A.Equal(net.ParseIP("127.0.0.1")) {
+			return true
+		}
+	}
+	return false
 }
 
 func checkPortListening(port int) bool {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -137,9 +137,9 @@ var setupCmd = &cobra.Command{
 				return "", fmt.Errorf("cannot create directories: %w", err)
 			}
 
-			// Build settings from wizard output, preserving existing PHP default.
+			// Build settings from wizard output, preserving existing PHP default and VM config.
 			s := &config.Settings{
-				Defaults:   config.Defaults{TLD: tld, PHP: settings.Defaults.PHP, Daemon: config.BoolPtr(daemon)},
+				Defaults:   config.Defaults{TLD: tld, PHP: settings.Defaults.PHP, Daemon: config.BoolPtr(daemon), VM: settings.Defaults.VM},
 				Automation: automation,
 			}
 			if err := s.Save(); err != nil {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -67,9 +67,14 @@ var stopCmd = &cobra.Command{
 			}
 
 			if !exited {
-				_ = proc.Signal(syscall.SIGKILL)
+				if killErr := proc.Signal(syscall.SIGKILL); killErr != nil {
+					return "", fmt.Errorf("process %d did not respond to SIGTERM and SIGKILL failed: %w", pid, killErr)
+				}
 				// Brief wait for SIGKILL to take effect.
 				time.Sleep(500 * time.Millisecond)
+				if proc.Signal(syscall.Signal(0)) == nil {
+					return "", fmt.Errorf("process %d did not exit after SIGKILL", pid)
+				}
 			}
 
 			return "pv stopped", nil

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -56,12 +56,20 @@ var stopCmd = &cobra.Command{
 				return "", fmt.Errorf("cannot send signal to process %d: %w", pid, err)
 			}
 
-			// Wait for process to exit.
+			// Wait for process to exit (5s).
+			exited := false
 			for i := 0; i < 25; i++ {
 				time.Sleep(200 * time.Millisecond)
 				if proc.Signal(syscall.Signal(0)) != nil {
+					exited = true
 					break
 				}
+			}
+
+			if !exited {
+				_ = proc.Signal(syscall.SIGKILL)
+				// Brief wait for SIGKILL to take effect.
+				time.Sleep(500 * time.Millisecond)
 			}
 
 			return "pv stopped", nil

--- a/internal/colima/colima.go
+++ b/internal/colima/colima.go
@@ -125,12 +125,37 @@ func IsRunning() bool {
 	return cmd.Run() == nil
 }
 
-// EnsureRunning starts Colima if it's not already running.
+// EnsureRunning starts Colima if it's not already running. If Start fails
+// (e.g. the VM is in a broken state after sleep or macOS update), it attempts
+// automatic recovery by force-stopping, deleting, and restarting the VM.
 func EnsureRunning() error {
 	if IsRunning() {
 		return nil
 	}
-	return Start()
+
+	err := Start()
+	if err == nil {
+		return nil
+	}
+
+	// VM may be in a broken state. Attempt recovery: force stop, delete, restart.
+	fmt.Fprintf(os.Stderr, "Warning: Colima start failed (%v), attempting VM recovery...\n", err)
+
+	_ = forceStop()
+	_ = Delete()
+
+	if retryErr := Start(); retryErr != nil {
+		return fmt.Errorf("cannot start Colima (recovery also failed): %w", retryErr)
+	}
+	return nil
+}
+
+// forceStop force-stops the Colima VM without graceful shutdown.
+func forceStop() error {
+	cmd := colimaCmd("stop", "--profile", "pv", "--force")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 // IsInstalled checks if the Colima binary exists at the expected path.

--- a/internal/colima/colima.go
+++ b/internal/colima/colima.go
@@ -149,21 +149,26 @@ func EnsureRunning(vm config.VMConfig) error {
 	// VM may be in a broken state. Attempt recovery: force stop, delete, restart.
 	fmt.Fprintf(os.Stderr, "Warning: Colima start failed (%v), attempting VM recovery...\n", err)
 
-	_ = forceStop()
-	_ = Delete()
+	stopErr := forceStop()
+	deleteErr := Delete()
 
 	if retryErr := Start(vm); retryErr != nil {
-		return fmt.Errorf("cannot start Colima (recovery also failed): %w", retryErr)
+		msg := fmt.Sprintf("cannot start Colima (recovery also failed): %v", retryErr)
+		if stopErr != nil {
+			msg += fmt.Sprintf("; force-stop error: %v", stopErr)
+		}
+		if deleteErr != nil {
+			msg += fmt.Sprintf("; delete error: %v", deleteErr)
+		}
+		return fmt.Errorf("%s", msg)
 	}
 	return nil
 }
 
 // forceStop force-stops the Colima VM without graceful shutdown.
+// Output is suppressed since this is called during automated recovery.
 func forceStop() error {
-	cmd := colimaCmd("stop", "--profile", "pv", "--force")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return colimaCmd("stop", "--profile", "pv", "--force").Run()
 }
 
 // IsInstalled checks if the Colima binary exists at the expected path.

--- a/internal/colima/colima.go
+++ b/internal/colima/colima.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/prvious/pv/internal/config"
@@ -88,13 +89,14 @@ func colimaCmd(args ...string) *exec.Cmd {
 	return cmd
 }
 
-// Start starts the Colima VM with the pv profile.
-func Start() error {
+// Start starts the Colima VM with the pv profile using the given resource config.
+func Start(vm config.VMConfig) error {
+	vm = vm.WithDefaults()
 	cmd := colimaCmd(
 		"start", "--profile", "pv",
-		"--cpu", "2",
-		"--memory", "2",
-		"--disk", "60",
+		"--cpu", strconv.Itoa(vm.CPU),
+		"--memory", strconv.Itoa(vm.Memory),
+		"--disk", strconv.Itoa(vm.Disk),
 		"--vm-type", "vz",
 		"--mount-type", "virtiofs",
 	)
@@ -128,12 +130,12 @@ func IsRunning() bool {
 // EnsureRunning starts Colima if it's not already running. If Start fails
 // (e.g. the VM is in a broken state after sleep or macOS update), it attempts
 // automatic recovery by force-stopping, deleting, and restarting the VM.
-func EnsureRunning() error {
+func EnsureRunning(vm config.VMConfig) error {
 	if IsRunning() {
 		return nil
 	}
 
-	err := Start()
+	err := Start(vm)
 	if err == nil {
 		return nil
 	}
@@ -144,7 +146,7 @@ func EnsureRunning() error {
 	_ = forceStop()
 	_ = Delete()
 
-	if retryErr := Start(); retryErr != nil {
+	if retryErr := Start(vm); retryErr != nil {
 		return fmt.Errorf("cannot start Colima (recovery also failed): %w", retryErr)
 	}
 	return nil

--- a/internal/colima/colima.go
+++ b/internal/colima/colima.go
@@ -91,6 +91,10 @@ func colimaCmd(args ...string) *exec.Cmd {
 
 // Start starts the Colima VM with the pv profile using the given resource config.
 func Start(vm config.VMConfig) error {
+	if err := checkVZCompat(); err != nil {
+		return err
+	}
+
 	vm = vm.WithDefaults()
 	cmd := colimaCmd(
 		"start", "--profile", "pv",

--- a/internal/colima/colima.go
+++ b/internal/colima/colima.go
@@ -80,11 +80,13 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// colimaCmd creates an exec.Command for the Colima binary with Lima on PATH.
+// colimaCmd creates an exec.Command for the Colima binary with Lima on PATH
+// and COLIMA_HOME set so all state lives under ~/.pv/.
 func colimaCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command(config.ColimaPath(), args...)
 	cmd.Env = append(os.Environ(),
 		"PATH="+config.LimaBinDir()+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"COLIMA_HOME="+config.ColimaHomeDir(),
 	)
 	return cmd
 }

--- a/internal/colima/compat.go
+++ b/internal/colima/compat.go
@@ -2,6 +2,7 @@ package colima
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -20,16 +21,18 @@ func checkVZCompat() error {
 
 	ver, err := syscall.Sysctl("kern.osproductversion")
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not detect macOS version for VZ compatibility check: %v\n", err)
 		return nil
 	}
 
 	major, err := parseMajorVersion(ver)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not parse macOS version %q for VZ compatibility check: %v\n", ver, err)
 		return nil
 	}
 
 	if major < minMacOSMajor {
-		return fmt.Errorf("Colima requires macOS %d+ (Ventura) for the Virtualization framework, detected macOS %s", minMacOSMajor, ver)
+		return fmt.Errorf("colima requires macOS %d+ (Ventura) for the Virtualization framework, detected macOS %s", minMacOSMajor, ver)
 	}
 	return nil
 }

--- a/internal/colima/compat.go
+++ b/internal/colima/compat.go
@@ -1,0 +1,43 @@
+package colima
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const minMacOSMajor = 13 // Ventura, required for --vm-type vz and --mount-type virtiofs
+
+// checkVZCompat verifies the system meets the minimum macOS version for the
+// Virtualization framework (vz) backend. Returns nil on non-Darwin platforms
+// or if the version cannot be determined (fail open).
+func checkVZCompat() error {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+
+	ver, err := syscall.Sysctl("kern.osproductversion")
+	if err != nil {
+		return nil
+	}
+
+	major, err := parseMajorVersion(ver)
+	if err != nil {
+		return nil
+	}
+
+	if major < minMacOSMajor {
+		return fmt.Errorf("Colima requires macOS %d+ (Ventura) for the Virtualization framework, detected macOS %s", minMacOSMajor, ver)
+	}
+	return nil
+}
+
+func parseMajorVersion(ver string) (int, error) {
+	parts := strings.SplitN(ver, ".", 2)
+	if len(parts) == 0 {
+		return 0, fmt.Errorf("empty version string")
+	}
+	return strconv.Atoi(parts[0])
+}

--- a/internal/colima/compat_test.go
+++ b/internal/colima/compat_test.go
@@ -1,0 +1,35 @@
+package colima
+
+import "testing"
+
+func TestParseMajorVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"14.5", 14},
+		{"13.0.1", 13},
+		{"15", 15},
+		{"12.6.7", 12},
+	}
+
+	for _, tt := range tests {
+		got, err := parseMajorVersion(tt.input)
+		if err != nil {
+			t.Errorf("parseMajorVersion(%q) error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("parseMajorVersion(%q) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCheckVZCompat_CurrentMachine(t *testing.T) {
+	// On any macOS CI or dev machine running this test, the check should pass
+	// (we require 13+ and all modern dev/CI machines meet this).
+	err := checkVZCompat()
+	if err != nil {
+		t.Logf("checkVZCompat returned: %v (expected on older macOS)", err)
+	}
+}

--- a/internal/commands/service/add.go
+++ b/internal/commands/service/add.go
@@ -69,7 +69,12 @@ pv service:add postgres 16`,
 			}
 		}
 
-		if err := colima.EnsureRunning(); err != nil {
+		settings, err := config.LoadSettings()
+		if err != nil {
+			return fmt.Errorf("cannot load settings: %w", err)
+		}
+
+		if err := colima.EnsureRunning(settings.Defaults.VM); err != nil {
 			ui.Subtle(fmt.Sprintf("Container runtime unavailable: %v", err))
 			ui.Subtle("Service registered — container will start when runtime is available.")
 		} else {

--- a/internal/commands/service/start.go
+++ b/internal/commands/service/start.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/prvious/pv/internal/colima"
+	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/registry"
 	"github.com/prvious/pv/internal/services"
 	"github.com/prvious/pv/internal/ui"
@@ -23,7 +24,11 @@ var startCmd = &cobra.Command{
 		}
 
 		if colima.IsInstalled() {
-			if err := colima.EnsureRunning(); err != nil {
+			settings, settingsErr := config.LoadSettings()
+			if settingsErr != nil {
+				return fmt.Errorf("cannot load settings: %w", settingsErr)
+			}
+			if err := colima.EnsureRunning(settings.Defaults.VM); err != nil {
 				fmt.Fprintln(os.Stderr)
 				ui.Subtle(fmt.Sprintf("Container runtime unavailable: %v", err))
 			}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -164,6 +164,12 @@ func ColimaPath() string {
 	return filepath.Join(InternalBinDir(), "colima")
 }
 
+// ColimaHomeDir returns the directory used as COLIMA_HOME, keeping all Colima
+// and Lima state under ~/.pv/ instead of the default ~/.colima/.
+func ColimaHomeDir() string {
+	return filepath.Join(PvDir(), "internal", "colima")
+}
+
 func LimaDir() string {
 	return filepath.Join(PvDir(), "internal", "lima")
 }
@@ -173,8 +179,7 @@ func LimaBinDir() string {
 }
 
 func ColimaSocketPath() string {
-	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".colima", "pv", "docker.sock")
+	return filepath.Join(ColimaHomeDir(), "pv", "docker.sock")
 }
 
 func EnsureDirs() error {
@@ -190,6 +195,7 @@ func EnsureDirs() error {
 		ServicesDir(),
 		InternalBinDir(),
 		PackagesDir(),
+		ColimaHomeDir(),
 	}
 	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0755); err != nil {

--- a/internal/config/paths_test.go
+++ b/internal/config/paths_test.go
@@ -352,8 +352,18 @@ func TestColimaSocketPath(t *testing.T) {
 	t.Setenv("HOME", home)
 
 	got := ColimaSocketPath()
-	if !strings.HasSuffix(got, filepath.Join(".colima", "pv", "docker.sock")) {
-		t.Errorf("ColimaSocketPath() = %q, want suffix .colima/pv/docker.sock", got)
+	if !strings.HasSuffix(got, filepath.Join(".pv", "internal", "colima", "pv", "docker.sock")) {
+		t.Errorf("ColimaSocketPath() = %q, want suffix .pv/internal/colima/pv/docker.sock", got)
+	}
+}
+
+func TestColimaHomeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := ColimaHomeDir()
+	if !strings.HasSuffix(got, filepath.Join(".pv", "internal", "colima")) {
+		t.Errorf("ColimaHomeDir() = %q, want suffix .pv/internal/colima", got)
 	}
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -17,10 +17,38 @@ const (
 	AutoAsk AutoMode = "ask"
 )
 
+// VMConfig holds Colima VM resource allocation settings.
+type VMConfig struct {
+	CPU    int `yaml:"cpu,omitempty"`
+	Memory int `yaml:"memory,omitempty"`
+	Disk   int `yaml:"disk,omitempty"`
+}
+
+// DefaultVMConfig returns sensible defaults for the Colima VM.
+func DefaultVMConfig() VMConfig {
+	return VMConfig{CPU: 2, Memory: 2, Disk: 60}
+}
+
+// WithDefaults returns a copy with zero values replaced by defaults.
+func (vm VMConfig) WithDefaults() VMConfig {
+	d := DefaultVMConfig()
+	if vm.CPU <= 0 {
+		vm.CPU = d.CPU
+	}
+	if vm.Memory <= 0 {
+		vm.Memory = d.Memory
+	}
+	if vm.Disk <= 0 {
+		vm.Disk = d.Disk
+	}
+	return vm
+}
+
 type Defaults struct {
-	PHP    string `yaml:"php,omitempty"`
-	TLD    string `yaml:"tld"`
-	Daemon *bool  `yaml:"daemon,omitempty"`
+	PHP    string   `yaml:"php,omitempty"`
+	TLD    string   `yaml:"tld"`
+	Daemon *bool    `yaml:"daemon,omitempty"`
+	VM     VMConfig `yaml:"vm,omitempty"`
 }
 
 // Automation controls which link-time steps run automatically.

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -388,3 +388,53 @@ func TestValidateTLD(t *testing.T) {
 		})
 	}
 }
+
+func TestVMConfig_WithDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		in   VMConfig
+		want VMConfig
+	}{
+		{
+			name: "zero value gets all defaults",
+			in:   VMConfig{},
+			want: VMConfig{CPU: 2, Memory: 2, Disk: 60},
+		},
+		{
+			name: "partial sets preserve explicit values",
+			in:   VMConfig{CPU: 4, Memory: 0, Disk: 0},
+			want: VMConfig{CPU: 4, Memory: 2, Disk: 60},
+		},
+		{
+			name: "negative values get defaults",
+			in:   VMConfig{CPU: -1, Memory: -5, Disk: -10},
+			want: VMConfig{CPU: 2, Memory: 2, Disk: 60},
+		},
+		{
+			name: "all valid values preserved",
+			in:   VMConfig{CPU: 8, Memory: 16, Disk: 200},
+			want: VMConfig{CPU: 8, Memory: 16, Disk: 200},
+		},
+		{
+			name: "default config is identity",
+			in:   DefaultVMConfig(),
+			want: DefaultVMConfig(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.in.WithDefaults()
+			if got != tt.want {
+				t.Errorf("VMConfig%+v.WithDefaults() = %+v, want %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultVMConfig(t *testing.T) {
+	d := DefaultVMConfig()
+	if d.CPU <= 0 || d.Memory <= 0 || d.Disk <= 0 {
+		t.Errorf("DefaultVMConfig() has non-positive values: %+v", d)
+	}
+}

--- a/internal/daemon/launchctl.go
+++ b/internal/daemon/launchctl.go
@@ -29,8 +29,16 @@ func Uninstall() error {
 }
 
 // Load tells launchd to load the pv service.
+// Uses the modern bootstrap API with a fallback to the legacy load command.
 func Load() error {
-	out, err := exec.Command("launchctl", "load", PlistPath()).CombinedOutput()
+	// Modern API (macOS 10.10+): launchctl bootstrap gui/<uid> <plist>
+	out, err := exec.Command("launchctl", "bootstrap", domainTarget(), PlistPath()).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	// Fallback to legacy API for older macOS.
+	out, err = exec.Command("launchctl", "load", PlistPath()).CombinedOutput()
 	if err != nil {
 		output := strings.TrimSpace(string(out))
 		if output != "" {
@@ -42,8 +50,16 @@ func Load() error {
 }
 
 // Unload tells launchd to unload the pv service.
+// Uses the modern bootout API with a fallback to the legacy unload command.
 func Unload() error {
-	out, err := exec.Command("launchctl", "unload", PlistPath()).CombinedOutput()
+	// Modern API: launchctl bootout gui/<uid>/dev.prvious.pv
+	out, err := exec.Command("launchctl", "bootout", serviceTarget()).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	// Fallback to legacy API for older macOS.
+	out, err = exec.Command("launchctl", "unload", PlistPath()).CombinedOutput()
 	if err != nil {
 		output := strings.TrimSpace(string(out))
 		if output != "" {

--- a/internal/server/dns.go
+++ b/internal/server/dns.go
@@ -14,14 +14,21 @@ type DNSServer struct {
 	tld    string
 	Addr   string // listen address, default "127.0.0.1:{DNSPort}"
 	server *dns.Server
+	ready  chan struct{}
 }
 
 // NewDNSServer creates a DNS server for the given TLD.
 func NewDNSServer(tld string) *DNSServer {
 	return &DNSServer{
-		tld:  tld,
-		Addr: fmt.Sprintf("127.0.0.1:%d", config.DNSPort),
+		tld:   tld,
+		Addr:  fmt.Sprintf("127.0.0.1:%d", config.DNSPort),
+		ready: make(chan struct{}),
 	}
+}
+
+// Ready returns a channel that is closed when the server has bound its port.
+func (d *DNSServer) Ready() <-chan struct{} {
+	return d.ready
 }
 
 // Start begins serving DNS queries. It blocks until Shutdown is called.
@@ -33,6 +40,7 @@ func (d *DNSServer) Start() error {
 		Addr:    d.Addr,
 		Net:     "udp",
 		Handler: mux,
+		NotifyStartedFunc: func() { close(d.ready) },
 	}
 	return d.server.ListenAndServe()
 }

--- a/internal/server/dns.go
+++ b/internal/server/dns.go
@@ -51,7 +51,8 @@ func (d *DNSServer) handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 	msg.Authoritative = true
 
 	for _, q := range r.Question {
-		if q.Qtype == dns.TypeA {
+		switch q.Qtype {
+		case dns.TypeA:
 			msg.Answer = append(msg.Answer, &dns.A{
 				Hdr: dns.RR_Header{
 					Name:   q.Name,
@@ -60,6 +61,16 @@ func (d *DNSServer) handleQuery(w dns.ResponseWriter, r *dns.Msg) {
 					Ttl:    60,
 				},
 				A: net.ParseIP("127.0.0.1"),
+			})
+		case dns.TypeAAAA:
+			msg.Answer = append(msg.Answer, &dns.AAAA{
+				Hdr: dns.RR_Header{
+					Name:   q.Name,
+					Rrtype: dns.TypeAAAA,
+					Class:  dns.ClassINET,
+					Ttl:    60,
+				},
+				AAAA: net.ParseIP("::1"),
 			})
 		}
 	}

--- a/internal/server/dns_test.go
+++ b/internal/server/dns_test.go
@@ -114,7 +114,7 @@ func TestDNSServer_CustomTLD(t *testing.T) {
 	}
 }
 
-func TestDNSServer_IgnoresNonAQuery(t *testing.T) {
+func TestDNSServer_ResolvesAAAAQuery(t *testing.T) {
 	_, addr := startTestDNS(t, "test")
 
 	c := new(dns.Client)
@@ -126,8 +126,33 @@ func TestDNSServer_IgnoresNonAQuery(t *testing.T) {
 		t.Fatalf("DNS query failed: %v", err)
 	}
 
+	if len(r.Answer) != 1 {
+		t.Fatalf("expected 1 answer for AAAA query, got %d", len(r.Answer))
+	}
+
+	aaaa, ok := r.Answer[0].(*dns.AAAA)
+	if !ok {
+		t.Fatal("expected AAAA record")
+	}
+	if aaaa.AAAA.String() != "::1" {
+		t.Errorf("got %s, want ::1", aaaa.AAAA.String())
+	}
+}
+
+func TestDNSServer_EmptyAnswerForUnsupportedType(t *testing.T) {
+	_, addr := startTestDNS(t, "test")
+
+	c := new(dns.Client)
+	m := new(dns.Msg)
+	m.SetQuestion("myapp.test.", dns.TypeMX)
+
+	r, _, err := c.Exchange(m, addr)
+	if err != nil {
+		t.Fatalf("DNS query failed: %v", err)
+	}
+
 	if len(r.Answer) != 0 {
-		t.Errorf("expected 0 answers for AAAA query, got %d", len(r.Answer))
+		t.Errorf("expected 0 answers for MX query, got %d", len(r.Answer))
 	}
 }
 

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -61,6 +61,16 @@ func Start(tld string) error {
 		}
 	}()
 
+	// Wait for DNS server to bind before proceeding.
+	select {
+	case <-dnsServer.Ready():
+		// Port bound successfully.
+	case err := <-dnsErr:
+		return fmt.Errorf("DNS server failed to start: %w", err)
+	case <-time.After(5 * time.Second):
+		return fmt.Errorf("DNS server did not start within 5s")
+	}
+
 	fmt.Fprintf(os.Stderr, "DNS server listening on %s\n", dnsServer.Addr)
 
 	// Start main FrankenPHP.

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -225,7 +225,7 @@ func ReadPID() (int, error) {
 }
 
 func writePID() error {
-	return os.WriteFile(config.PidFilePath(), []byte(strconv.Itoa(os.Getpid())), 0644)
+	return os.WriteFile(config.PidFilePath(), []byte(strconv.Itoa(os.Getpid())), 0600)
 }
 
 func removePID() {

--- a/internal/server/process_test.go
+++ b/internal/server/process_test.go
@@ -97,7 +97,7 @@ func TestIsRunning_DeadProcess(t *testing.T) {
 	// Write a PID that almost certainly doesn't exist.
 	fakePID := 99999
 	pidPath := filepath.Join(config.DataDir(), "pv.pid")
-	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(fakePID)), 0644); err != nil {
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(fakePID)), 0600); err != nil {
 		t.Fatalf("write fake PID error = %v", err)
 	}
 

--- a/internal/setup/resolver.go
+++ b/internal/setup/resolver.go
@@ -26,7 +26,7 @@ const (
 func SudoSetupScript(tld string) string {
 	resolverFile := filepath.Join(resolverDir, tld)
 	return fmt.Sprintf(
-		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s`,
+		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s && dscacheutil -flushcache && killall -HUP mDNSResponder 2>/dev/null || true`,
 		resolverDir, resolverFile,
 	)
 }
@@ -44,7 +44,7 @@ func RunSudoSetup(tld string) error {
 func ResolverSetupScript(tld string) string {
 	resolverFile := filepath.Join(resolverDir, tld)
 	return fmt.Sprintf(
-		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s`,
+		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s && dscacheutil -flushcache && killall -HUP mDNSResponder 2>/dev/null || true`,
 		resolverDir, resolverFile,
 	)
 }

--- a/internal/setup/resolver.go
+++ b/internal/setup/resolver.go
@@ -26,7 +26,7 @@ const (
 func SudoSetupScript(tld string) string {
 	resolverFile := filepath.Join(resolverDir, tld)
 	return fmt.Sprintf(
-		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s && dscacheutil -flushcache && killall -HUP mDNSResponder 2>/dev/null || true`,
+		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s && (dscacheutil -flushcache; killall -HUP mDNSResponder 2>/dev/null || true)`,
 		resolverDir, resolverFile,
 	)
 }
@@ -44,7 +44,7 @@ func RunSudoSetup(tld string) error {
 func ResolverSetupScript(tld string) string {
 	resolverFile := filepath.Join(resolverDir, tld)
 	return fmt.Sprintf(
-		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s && dscacheutil -flushcache && killall -HUP mDNSResponder 2>/dev/null || true`,
+		`mkdir -p %s && printf 'nameserver 127.0.0.1\nport 10053\n' > %s && (dscacheutil -flushcache; killall -HUP mDNSResponder 2>/dev/null || true)`,
 		resolverDir, resolverFile,
 	)
 }

--- a/internal/tools/shims.go
+++ b/internal/tools/shims.go
@@ -31,19 +31,21 @@ exec "$BINARY" "$@"
 `
 
 const colimaShimScript = `#!/bin/sh
-# pv Colima shim — ensures Lima (limactl) is on PATH.
+# pv Colima shim — ensures Lima (limactl) is on PATH and state stays under ~/.pv/.
 export PATH="%s:$PATH"
+export COLIMA_HOME="%s"
 exec "%s" "$@"
 `
 
 // writeColimaShim writes the Colima wrapper shim to ~/.pv/bin/colima.
 func writeColimaShim() error {
 	limaBinDir := config.LimaBinDir()
+	colimaHomeDir := config.ColimaHomeDir()
 	colimaPath := config.ColimaPath()
 	binDir := config.BinDir()
 
 	shimPath := filepath.Join(binDir, "colima")
-	content := fmt.Sprintf(colimaShimScript, limaBinDir, colimaPath)
+	content := fmt.Sprintf(colimaShimScript, limaBinDir, colimaHomeDir, colimaPath)
 	if err := os.WriteFile(shimPath, []byte(content), 0755); err != nil {
 		return fmt.Errorf("cannot write colima shim: %w", err)
 	}


### PR DESCRIPTION
## Summary

- **Fix DNS doctor health check**: Replace no-op UDP `Dial()` with a real DNS A query using `miekg/dns` client to actually verify the server responds
- **Add AAAA/IPv6 DNS response**: Return `::1` for AAAA queries to eliminate Safari "Happy Eyeballs" latency (matches Laravel Valet's approach)
- **Flush DNS cache after resolver setup**: Append `dscacheutil -flushcache` and `killall -HUP mDNSResponder` to the sudo resolver script so changes take effect immediately
- **Add Colima VM auto-recovery**: If `Start()` fails (broken VM after sleep/update), automatically attempt force-stop + delete + restart before giving up
- **Make VM resources configurable**: Add `vm` section to `pv.yml` with `cpu`, `memory`, `disk` fields (defaults: 2/2/60)
- **Add SIGKILL fallback to `pv stop`**: Escalate to SIGKILL after 5s SIGTERM timeout to prevent zombie supervisor processes
- **Add macOS version pre-flight check**: Verify macOS >= 13 (Ventura) before starting Colima with `--vm-type vz`, returning a clear error instead of a cryptic Colima failure
- **Fix DNS startup race**: Use `NotifyStartedFunc` callback to wait for the UDP socket to bind before logging "DNS server listening" and starting FrankenPHP
- **Migrate launchctl to bootstrap/bootout**: Use modern API with automatic fallback to legacy `load`/`unload` for older macOS
- **Restrict PID file permissions**: Change from `0644` to `0600` (principle of least privilege)
- **Redirect Colima state to `~/.pv/`**: Set `COLIMA_HOME=~/.pv/internal/colima` so all VM state, Docker sockets, and Lima data live under the managed tree instead of `~/.colima/`

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New tests added for AAAA DNS queries, MX empty response, macOS version parsing, `ColimaHomeDir`, updated `ColimaSocketPath`
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] Manual: run `pv install` on a fresh machine, verify DNS resolves `.test` domains
- [x] Manual: run `pv doctor`, verify DNS health check sends a real query
- [x] Manual: run `pv service:add redis`, verify Colima state appears under `~/.pv/internal/colima/`
- [x] Manual: configure `vm:` section in `pv.yml`, verify Colima respects the values
- [x] Manual: verify `pv stop` terminates cleanly (SIGTERM path) and force-kills after timeout (SIGKILL path)