### PR TITLE
Auto-install PHP versions on pv.yml change, fix daemon log visibility

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -16,7 +16,6 @@ import (
 var (
 	logFollow bool
 	logLines  int
-	logError  bool
 	logDaemon bool
 )
 
@@ -35,10 +34,8 @@ pv log myapp -n 50`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logPath := config.CaddyLogPath()
-		if logError {
+		if logDaemon {
 			logPath = config.DaemonErrLogPath()
-		} else if logDaemon {
-			logPath = config.DaemonLogPath()
 		}
 		f, err := os.Open(logPath)
 		if err != nil {
@@ -143,7 +140,6 @@ func getInode(info os.FileInfo) uint64 {
 func init() {
 	logCmd.Flags().BoolVarP(&logFollow, "follow", "f", false, "Follow log output")
 	logCmd.Flags().IntVarP(&logLines, "lines", "n", 50, "Number of lines to show")
-	logCmd.Flags().BoolVar(&logError, "error", false, "Show daemon stderr log")
-	logCmd.Flags().BoolVar(&logDaemon, "daemon", false, "Show daemon stdout log")
+	logCmd.Flags().BoolVar(&logDaemon, "daemon", false, "Show daemon log (watcher events, Colima boot, recovery)")
 	rootCmd.AddCommand(logCmd)
 }

--- a/internal/phpenv/phpenv.go
+++ b/internal/phpenv/phpenv.go
@@ -73,7 +73,10 @@ func EnsureInstalled(version string) error {
 		return nil
 	}
 	client := &http.Client{Timeout: 5 * time.Minute}
-	return InstallProgress(client, version, nil)
+	if err := InstallProgress(client, version, nil); err != nil {
+		return fmt.Errorf("install PHP %s: %w", version, err)
+	}
+	return nil
 }
 
 // SetGlobal updates the global PHP version in settings and repoints symlinks.

--- a/internal/phpenv/phpenv.go
+++ b/internal/phpenv/phpenv.go
@@ -2,6 +2,7 @@ package phpenv
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -60,6 +61,18 @@ func FrankenPHPPath(version string) string {
 // PHPPath returns the path to the PHP CLI binary for a version.
 func PHPPath(version string) string {
 	return filepath.Join(config.PhpVersionDir(version), "php")
+}
+
+// EnsureInstalled checks if a PHP version is installed, and if not, downloads
+// and installs it. This is the single entry point for ensuring a PHP version
+// is available — used by the watcher, link automation, and anywhere that
+// needs a version to be ready before proceeding.
+func EnsureInstalled(version string) error {
+	if IsInstalled(version) {
+		return nil
+	}
+	client := &http.Client{}
+	return InstallProgress(client, version, nil)
 }
 
 // SetGlobal updates the global PHP version in settings and repoints symlinks.

--- a/internal/phpenv/phpenv.go
+++ b/internal/phpenv/phpenv.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/prvious/pv/internal/config"
 )
@@ -71,7 +72,7 @@ func EnsureInstalled(version string) error {
 	if IsInstalled(version) {
 		return nil
 	}
-	client := &http.Client{}
+	client := &http.Client{Timeout: 5 * time.Minute}
 	return InstallProgress(client, version, nil)
 }
 

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -274,6 +274,16 @@ func handleWatcherEvents(w *watcher.Watcher, globalPHP string) {
 		}
 
 		if newPHP != "" && newPHP != project.PHP {
+			// Ensure the version is installed before applying the change.
+			if !phpenv.IsInstalled(newPHP) {
+				fmt.Fprintf(os.Stderr, "Watcher: PHP %s not installed, downloading...\n", newPHP)
+				if err := phpenv.EnsureInstalled(newPHP); err != nil {
+					fmt.Fprintf(os.Stderr, "Watcher: cannot install PHP %s: %v (keeping %s)\n", newPHP, err, project.PHP)
+					continue
+				}
+				fmt.Fprintf(os.Stderr, "Watcher: PHP %s installed\n", newPHP)
+			}
+
 			fmt.Fprintf(os.Stderr, "Watcher: %s PHP version changed %s -> %s\n", event.ProjectName, project.PHP, newPHP)
 			for i := range reg.Projects {
 				if reg.Projects[i].Name == event.ProjectName {

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -275,12 +275,12 @@ func handleWatcherEvents(w *watcher.Watcher, globalPHP string) {
 
 		if newPHP != "" && newPHP != project.PHP {
 			// Ensure the version is installed before applying the change.
-			if !phpenv.IsInstalled(newPHP) {
-				fmt.Fprintf(os.Stderr, "Watcher: PHP %s not installed, downloading...\n", newPHP)
-				if err := phpenv.EnsureInstalled(newPHP); err != nil {
-					fmt.Fprintf(os.Stderr, "Watcher: cannot install PHP %s: %v (keeping %s)\n", newPHP, err, project.PHP)
-					continue
-				}
+			wasInstalled := phpenv.IsInstalled(newPHP)
+			if err := phpenv.EnsureInstalled(newPHP); err != nil {
+				fmt.Fprintf(os.Stderr, "Watcher: cannot install PHP %s: %v (keeping %s)\n", newPHP, err, project.PHP)
+				continue
+			}
+			if !wasInstalled {
 				fmt.Fprintf(os.Stderr, "Watcher: PHP %s installed\n", newPHP)
 			}
 


### PR DESCRIPTION
## Summary

- **Auto-install uninstalled PHP versions:** When the watcher detects a `pv.yml` change to a PHP version that isn't installed, it now auto-downloads and installs it before applying the change. If the install fails, the old version is kept — no more 502 errors from switching to an uninstalled version.
- **`phpenv.EnsureInstalled`:** New single entry point for ensuring a PHP version is available. Checks if installed, downloads if not.
- **Fix `pv log --daemon`:** Was reading `pv.log` (stdout, always empty) instead of `pv.err.log` (stderr, where all daemon output goes). Now reads the correct file. Removed the redundant `--error` flag.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Manual: change `pv.yml` to an uninstalled PHP version, verify it auto-installs
- [ ] Manual: change `pv.yml` to a bogus version, verify old version is kept (no 502)
- [ ] Manual: `pv log --daemon -f` shows watcher events