### PR TITLE
Remove --background and --foreground flags from pv start

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,97 +2,30 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/prvious/pv/internal/config"
-	"github.com/prvious/pv/internal/daemon"
 	"github.com/prvious/pv/internal/server"
-	"github.com/prvious/pv/internal/ui"
 	"github.com/spf13/cobra"
 )
-
-var startBackground bool
 
 var startCmd = &cobra.Command{
 	Use:     "start",
 	GroupID: "server",
 	Short:   "Start the pv server (DNS + FrankenPHP)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if startBackground {
-			return startDaemon()
+		if server.IsRunning() {
+			return fmt.Errorf("pv is already running (PID file exists and process is alive)")
 		}
-		return startFG()
+
+		settings, err := config.LoadSettings()
+		if err != nil {
+			return fmt.Errorf("cannot load settings: %w", err)
+		}
+
+		return server.Start(settings.Defaults.TLD)
 	},
 }
 
-func startFG() error {
-	if server.IsRunning() {
-		return fmt.Errorf("pv is already running (PID file exists and process is alive)")
-	}
-
-	settings, err := config.LoadSettings()
-	if err != nil {
-		return fmt.Errorf("cannot load settings: %w", err)
-	}
-
-	return server.Start(settings.Defaults.TLD)
-}
-
-func startDaemon() error {
-	// Check if already running via launchd.
-	if daemon.IsLoaded() {
-		pid, err := daemon.GetPID()
-		if err == nil && pid > 0 {
-			ui.Success(fmt.Sprintf("pv is already running %s", ui.Muted.Render(fmt.Sprintf("(PID %d)", pid))))
-			return nil
-		}
-	}
-
-	// Also check foreground PID file.
-	if server.IsRunning() {
-		pid, _ := server.ReadPID()
-		ui.Success(fmt.Sprintf("pv is already running in foreground %s", ui.Muted.Render(fmt.Sprintf("(PID %d)", pid))))
-		return nil
-	}
-
-	if err := ui.Step("Starting pv daemon...", func() (string, error) {
-		// Generate and write plist.
-		cfg := daemon.DefaultPlistConfig()
-		if err := daemon.Install(cfg); err != nil {
-			return "", fmt.Errorf("cannot install plist: %w", err)
-		}
-
-		// Load the service.
-		if err := daemon.Load(); err != nil {
-			return "", fmt.Errorf("cannot start daemon: %w", err)
-		}
-
-		// Wait for the process to appear.
-		var pid int
-		for i := 0; i < 15; i++ {
-			time.Sleep(200 * time.Millisecond)
-			p, err := daemon.GetPID()
-			if err == nil && p > 0 {
-				pid = p
-				break
-			}
-		}
-
-		if pid > 0 {
-			return fmt.Sprintf("Running in background (PID %d)", pid), nil
-		}
-		return "Daemon started (waiting for process...)", nil
-	}); err != nil {
-		return err
-	}
-
-	ui.Subtle("Run pv log to view logs")
-
-	return nil
-}
-
 func init() {
-	startCmd.Flags().BoolVar(&startBackground, "background", false, "Run as a background daemon via launchd")
-	startCmd.Flags().Bool("foreground", false, "Run in the foreground (default, accepted for launchd plist compatibility)")
 	rootCmd.AddCommand(startCmd)
 }

--- a/internal/daemon/plist.go
+++ b/internal/daemon/plist.go
@@ -60,7 +60,6 @@ const plistTmpl = `<?xml version="1.0" encoding="UTF-8"?>
     <array>
         <string>{{.PvBinaryPath}}</string>
         <string>start</string>
-        <string>--foreground</string>
     </array>
 
     <key>RunAtLoad</key>

--- a/internal/daemon/plist_test.go
+++ b/internal/daemon/plist_test.go
@@ -48,9 +48,6 @@ func TestRenderPlist_ProgramArguments(t *testing.T) {
 	if !strings.Contains(xml, "<string>start</string>") {
 		t.Error("plist missing 'start' in ProgramArguments")
 	}
-	if !strings.Contains(xml, "<string>--foreground</string>") {
-		t.Error("plist missing '--foreground' in ProgramArguments")
-	}
 }
 
 func TestRenderPlist_KeepAlive(t *testing.T) {


### PR DESCRIPTION
## Summary

- Removes `--background` flag from `pv start` — background execution now exclusively uses `pv daemon:enable`
- Removes `--foreground` flag (was dead code — registered but never read)
- Removes `--foreground` from the launchd plist template
- Simplifies `cmd/start.go` from 99 to 32 lines

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] Existing daemon plists with `--foreground` still work (it was a no-op)
- [x] `pv daemon:enable` regenerates plist without `--foreground`