### PR TITLE
Add colima:stop command

### DIFF
--- a/cmd/colima.go
+++ b/cmd/colima.go
@@ -1,7 +1,11 @@
 package cmd
 
-import "github.com/prvious/pv/internal/commands/colima"
+import (
+	"github.com/prvious/pv/internal/commands/colima"
+	"github.com/prvious/pv/internal/commands/service"
+)
 
 func init() {
+	colima.StopServicesFunc = service.RunStop
 	colima.Register(rootCmd)
 }

--- a/internal/commands/colima/register.go
+++ b/internal/commands/colima/register.go
@@ -8,6 +8,7 @@ func Register(parent *cobra.Command) {
 	parent.AddCommand(pathCmd)
 	parent.AddCommand(updateCmd)
 	parent.AddCommand(uninstallCmd)
+	parent.AddCommand(stopCmd)
 }
 
 func RunInstall() error {
@@ -20,4 +21,8 @@ func RunUpdate() error {
 
 func RunUninstall() error {
 	return uninstallCmd.RunE(uninstallCmd, nil)
+}
+
+func RunStop() error {
+	return stopCmd.RunE(stopCmd, nil)
 }

--- a/internal/commands/colima/register_test.go
+++ b/internal/commands/colima/register_test.go
@@ -11,7 +11,7 @@ func TestRegister_AllCommandsPresent(t *testing.T) {
 	root.AddGroup(&cobra.Group{ID: "colima", Title: "Colima"})
 	Register(root)
 
-	expected := []string{"colima:install", "colima:download", "colima:path", "colima:update", "colima:uninstall"}
+	expected := []string{"colima:install", "colima:download", "colima:path", "colima:update", "colima:uninstall", "colima:stop"}
 	for _, name := range expected {
 		cmd, _, err := root.Find([]string{name})
 		if err != nil || cmd.Name() != name {

--- a/internal/commands/colima/stop.go
+++ b/internal/commands/colima/stop.go
@@ -1,0 +1,40 @@
+package colima
+
+import (
+	"fmt"
+
+	internalcolima "github.com/prvious/pv/internal/colima"
+	"github.com/prvious/pv/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+// StopServicesFunc is set at init time by the cmd layer to break the
+// import cycle between commands/colima and commands/service.
+var StopServicesFunc func() error
+
+var stopCmd = &cobra.Command{
+	Use:     "colima:stop",
+	GroupID: "colima",
+	Short:   "Stop all services and shut down the Colima VM",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if !internalcolima.IsRunning() {
+			ui.Subtle("Colima is not running")
+			return nil
+		}
+
+		// Stop all service containers first. Non-fatal — if Docker is
+		// unreachable the VM stop will still clean everything up.
+		if StopServicesFunc != nil {
+			if err := StopServicesFunc(); err != nil {
+				ui.Fail(fmt.Sprintf("Could not stop services: %v", err))
+			}
+		}
+
+		return ui.Step("Stopping Colima VM...", func() (string, error) {
+			if err := internalcolima.Stop(); err != nil {
+				return "", fmt.Errorf("cannot stop Colima VM: %w", err)
+			}
+			return "Colima stopped", nil
+		})
+	},
+}

--- a/internal/commands/colima/stop.go
+++ b/internal/commands/colima/stop.go
@@ -1,6 +1,7 @@
 package colima
 
 import (
+	"errors"
 	"fmt"
 
 	internalcolima "github.com/prvious/pv/internal/colima"
@@ -25,7 +26,7 @@ var stopCmd = &cobra.Command{
 		// Stop all service containers first. Non-fatal — if Docker is
 		// unreachable the VM stop will still clean everything up.
 		if StopServicesFunc != nil {
-			if err := StopServicesFunc(); err != nil {
+			if err := StopServicesFunc(); err != nil && !errors.Is(err, ui.ErrAlreadyPrinted) {
 				ui.Fail(fmt.Sprintf("Could not stop services: %v", err))
 			}
 		}

--- a/internal/commands/service/register.go
+++ b/internal/commands/service/register.go
@@ -17,3 +17,7 @@ func Register(parent *cobra.Command) {
 func RunAdd(args []string) error {
 	return addCmd.RunE(addCmd, args)
 }
+
+func RunStop() error {
+	return stopCmd.RunE(stopCmd, nil)
+}


### PR DESCRIPTION
## Summary

- Adds `pv colima:stop` — gracefully stops all service containers, then shuts down the Colima VM
- Exports `RunStop()` from both service and colima packages for cross-package composition
- Uses callback pattern (`StopServicesFunc`) to avoid import cycle between `commands/colima` and `commands/service`

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] Register test updated to expect `colima:stop`
- [x] `ErrAlreadyPrinted` checked before logging service stop failures