### PR TITLE
Add automatic wildcard subdomain support

### DIFF
--- a/docs/superpowers/plans/2026-04-01-wildcard-subdomains.md
+++ b/docs/superpowers/plans/2026-04-01-wildcard-subdomains.md
@@ -1,0 +1,300 @@
+# Wildcard Subdomain Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every linked project automatically responds to `*.name.tld` in addition to `name.tld`, matching Valet/Herd behavior.
+
+**Architecture:** Add wildcard to all 8 Caddy site address templates and add a wildcard SAN to the Valet cert generator. DNS and registry are already wildcard-capable.
+
+**Tech Stack:** Go, Caddy templates, x509 certificates
+
+**Spec:** `docs/superpowers/specs/2026-04-01-wildcard-subdomains-design.md`
+
+---
+
+### Task 1: Update Caddy site template tests to expect wildcards
+
+**Files:**
+- Modify: `internal/caddy/caddy_test.go`
+
+- [ ] **Step 1: Update `TestGenerateSiteConfig_LaravelOctane` assertion**
+
+Change line 58 from:
+```go
+	if !strings.Contains(content, "octane-app.test {") {
+		t.Error("expected domain octane-app.test")
+	}
+```
+to:
+```go
+	if !strings.Contains(content, "octane-app.test, *.octane-app.test {") {
+		t.Error("expected domain octane-app.test with wildcard")
+	}
+```
+
+- [ ] **Step 2: Update `TestGenerateSiteConfig_Laravel` assertion**
+
+Change line 121 from:
+```go
+	if !strings.Contains(content, "lara-app.test {") {
+		t.Error("expected domain lara-app.test")
+	}
+```
+to:
+```go
+	if !strings.Contains(content, "lara-app.test, *.lara-app.test {") {
+		t.Error("expected domain lara-app.test with wildcard")
+	}
+```
+
+- [ ] **Step 3: Update `TestGenerateSiteConfig_DomainName` assertion**
+
+Change line 218 from:
+```go
+	if !strings.Contains(content, "my-app.test {") {
+		t.Errorf("expected 'my-app.test {' in output, got:\n%s", content)
+	}
+```
+to:
+```go
+	if !strings.Contains(content, "my-app.test, *.my-app.test {") {
+		t.Errorf("expected 'my-app.test, *.my-app.test {' in output, got:\n%s", content)
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `go test ./internal/caddy/ -run "TestGenerateSiteConfig_LaravelOctane|TestGenerateSiteConfig_Laravel|TestGenerateSiteConfig_DomainName" -v`
+Expected: 3 FAIL — templates still produce `name.test {` without wildcard.
+
+### Task 2: Add wildcard to main Caddy site templates
+
+**Files:**
+- Modify: `internal/caddy/caddy.go`
+
+- [ ] **Step 1: Update `laravelOctaneTmpl`**
+
+Change line 26 from:
+```go
+const laravelOctaneTmpl = `{{.Name}}.{{.TLD}} {
+```
+to:
+```go
+const laravelOctaneTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
+```
+
+- [ ] **Step 2: Update `laravelTmpl`**
+
+Change line 43 from:
+```go
+const laravelTmpl = `{{.Name}}.{{.TLD}} {
+```
+to:
+```go
+const laravelTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
+```
+
+- [ ] **Step 3: Update `phpTmpl`**
+
+Change line 54 from:
+```go
+const phpTmpl = `{{.Name}}.{{.TLD}} {
+```
+to:
+```go
+const phpTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
+```
+
+- [ ] **Step 4: Update `staticTmpl`**
+
+Change line 65 from:
+```go
+const staticTmpl = `{{.Name}}.{{.TLD}} {
+```
+to:
+```go
+const staticTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
+```
+
+- [ ] **Step 5: Update `proxyTmpl`**
+
+Change line 74 from:
+```go
+const proxyTmpl = `{{.Name}}.{{.TLD}} {
+```
+to:
+```go
+const proxyTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/caddy/ -run "TestGenerateSiteConfig_LaravelOctane|TestGenerateSiteConfig_Laravel|TestGenerateSiteConfig_DomainName" -v`
+Expected: 3 PASS
+
+- [ ] **Step 7: Run full caddy test suite**
+
+Run: `go test ./internal/caddy/ -v`
+Expected: All PASS. The service console tests (`TestGenerateServiceSiteConfigs`) should still pass since those templates are not changed (they use `serviceConsoleTmpl` which is `subdomain.pv.tld`, not a project wildcard).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/caddy/caddy.go internal/caddy/caddy_test.go
+git commit -m "Add wildcard subdomain to main Caddy site templates
+
+Every linked project now responds to *.name.tld in addition to
+name.tld. Covers laravel, laravel-octane, php, static, and proxy
+templates."
+```
+
+### Task 3: Add wildcard to secondary (version) Caddy templates and test
+
+**Files:**
+- Modify: `internal/caddy/caddy.go`
+- Modify: `internal/caddy/caddy_test.go`
+
+- [ ] **Step 1: Add test for wildcard in version-specific config**
+
+Add this test after `TestOctaneTemplate_WatchesAutoload_VersionSpecific`:
+
+```go
+func TestVersionSiteConfig_HasWildcard(t *testing.T) {
+	scaffold(t)
+
+	projDir := t.TempDir()
+	p := registry.Project{Name: "ver-app", Path: projDir, Type: "laravel", PHP: "8.3"}
+
+	if err := GenerateSiteConfig(p, "8.4"); err != nil {
+		t.Fatalf("GenerateSiteConfig() error = %v", err)
+	}
+
+	content := readVersionSiteConfig(t, "8.3", "ver-app")
+
+	if !strings.Contains(content, "ver-app.test, *.ver-app.test {") {
+		t.Errorf("expected wildcard in version site config, got:\n%s", content)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/caddy/ -run TestVersionSiteConfig_HasWildcard -v`
+Expected: FAIL — version templates still produce `http://name.tld {` without wildcard.
+
+- [ ] **Step 3: Update `versionLaravelOctaneTmpl`**
+
+Change line 82 from:
+```go
+const versionLaravelOctaneTmpl = `http://{{.Name}}.{{.TLD}} {
+```
+to:
+```go
+const versionLaravelOctaneTmpl = `http://{{.Name}}.{{.TLD}}, http://*.{{.Name}}.{{.TLD}} {
+```
+
+- [ ] **Step 4: Update `versionLaravelTmpl`**
+
+Change line 98 from:
+```go
+const versionLaravelTmpl = `http://{{.Name}}.{{.TLD}} {
+```
+to:
+```go
+const versionLaravelTmpl = `http://{{.Name}}.{{.TLD}}, http://*.{{.Name}}.{{.TLD}} {
+```
+
+- [ ] **Step 5: Update `versionPhpTmpl`**
+
+Change line 108 from:
+```go
+const versionPhpTmpl = `http://{{.Name}}.{{.TLD}} {
+```
+to:
+```go
+const versionPhpTmpl = `http://{{.Name}}.{{.TLD}}, http://*.{{.Name}}.{{.TLD}} {
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/caddy/ -v`
+Expected: All PASS (including the new `TestVersionSiteConfig_HasWildcard`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/caddy/caddy.go internal/caddy/caddy_test.go
+git commit -m "Add wildcard subdomain to secondary version Caddy templates
+
+Version-specific FrankenPHP instances now also match *.name.tld
+requests proxied from the main process."
+```
+
+### Task 4: Update cert generation to include wildcard SAN and test
+
+**Files:**
+- Modify: `internal/certs/certs.go`
+- Modify: `internal/certs/certs_test.go`
+
+- [ ] **Step 1: Update `TestGenerateSiteCert` to expect wildcard SAN**
+
+In `internal/certs/certs_test.go`, change line 87 from:
+```go
+	if len(cert.DNSNames) != 1 || cert.DNSNames[0] != "myapp.test" {
+		t.Errorf("DNSNames = %v, want [myapp.test]", cert.DNSNames)
+	}
+```
+to:
+```go
+	if len(cert.DNSNames) != 2 || cert.DNSNames[0] != "myapp.test" || cert.DNSNames[1] != "*.myapp.test" {
+		t.Errorf("DNSNames = %v, want [myapp.test *.myapp.test]", cert.DNSNames)
+	}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/certs/ -run TestGenerateSiteCert -v`
+Expected: FAIL — `DNSNames = [myapp.test], want [myapp.test *.myapp.test]`
+
+- [ ] **Step 3: Add wildcard SAN to `GenerateSiteCert`**
+
+In `internal/certs/certs.go`, change line 37 from:
+```go
+		DNSNames:     []string{hostname},
+```
+to:
+```go
+		DNSNames:     []string{hostname, "*." + hostname},
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/certs/ -v`
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/certs/certs.go internal/certs/certs_test.go
+git commit -m "Add wildcard SAN to Valet TLS certificates
+
+Certs now include *.hostname in DNSNames so the Vite dev server
+cert covers subdomain requests."
+```
+
+### Task 5: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./...`
+Expected: All PASS.
+
+- [ ] **Step 2: Run lint checks**
+
+Run: `gofmt -l . && go vet ./...`
+Expected: No output (all clean).
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build -o pv .`
+Expected: Builds successfully.

--- a/docs/superpowers/specs/2026-04-01-wildcard-subdomains-design.md
+++ b/docs/superpowers/specs/2026-04-01-wildcard-subdomains-design.md
@@ -57,10 +57,6 @@ This ensures the Valet/Vite-compatible cert (used by `laravel-vite-plugin` for t
 - **TLS cert automation step** (`internal/automation/steps/generate_tls_cert.go`): Passes `hostname` as before; the SAN change is internal to `GenerateSiteCert`.
 - **Unlink/cleanup**: Same files to remove, no new artifacts.
 
-### Existing sites
-
-Sites linked before this change get wildcard routing on next `pv start` (daemon regenerates all Caddy configs via `GenerateAllConfigs`). Valet/Vite certs would need `pv unlink && pv link` to regenerate with the wildcard SAN — acceptable since the Valet cert only affects the Vite dev server, not browser TLS to the actual site (Caddy handles that).
-
 ### Testing
 
 - Update existing Caddy template tests to verify wildcard addresses appear in generated configs.

--- a/docs/superpowers/specs/2026-04-01-wildcard-subdomains-design.md
+++ b/docs/superpowers/specs/2026-04-01-wildcard-subdomains-design.md
@@ -1,0 +1,72 @@
+# Wildcard Subdomain Support
+
+**Date:** 2026-04-01
+**Status:** Approved
+
+## Problem
+
+`pv link` creates a single top-level domain (e.g., `project.test`). Applications that use subdomain-based routing (multi-tenant apps, locale prefixes like `us.project.test` / `ca.project.test`) cannot be developed locally without manual workarounds.
+
+Laravel Valet and Herd both support wildcard subdomains automatically — every linked site responds to `*.site.test` with no extra configuration. pv should match this behavior.
+
+## Design
+
+### Approach
+
+Automatic wildcard subdomain support for all linked sites. No flags, no per-project config. Every linked project responds to both `name.tld` and `*.name.tld`.
+
+### Scope
+
+Single-level wildcard only. `*.project.test` covers `us.project.test` and `ca.project.test` but not `api.us.project.test`. This is an X.509/DNS spec limitation shared by Valet and Herd.
+
+### Changes
+
+#### 1. Caddy site templates (`internal/caddy/caddy.go`)
+
+Every site address changes from `{{.Name}}.{{.TLD}}` to `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}}`.
+
+Affected templates (8 total):
+- **Main process**: `laravelOctaneTmpl`, `laravelTmpl`, `phpTmpl`, `staticTmpl`
+- **Proxy**: `proxyTmpl`
+- **Secondary version**: `versionLaravelOctaneTmpl`, `versionLaravelTmpl`, `versionPhpTmpl`
+
+Caddy's `tls internal` directive automatically generates valid certs covering all listed site addresses, so wildcard TLS for browser-facing HTTPS is handled by Caddy with no additional cert work.
+
+No changes to `siteData` struct, `writeConfig`, template helpers, or generation logic.
+
+#### 2. Valet TLS cert SAN (`internal/certs/certs.go`)
+
+In `GenerateSiteCert`, change:
+```go
+DNSNames: []string{hostname}
+```
+to:
+```go
+DNSNames: []string{hostname, "*." + hostname}
+```
+
+This ensures the Valet/Vite-compatible cert (used by `laravel-vite-plugin` for the dev server) also covers wildcard subdomains. The cert filename (`{hostname}.crt`/`.key`) and the `GenerateSiteTLS` function signature remain unchanged.
+
+#### 3. No changes required
+
+- **DNS server** (`internal/server/dns.go`): Already resolves all `*.test` queries to `127.0.0.1` at any subdomain depth.
+- **macOS resolver** (`internal/setup/resolver.go`): `/etc/resolver/test` already applies to all subdomains.
+- **Registry** (`internal/registry/`): No new fields needed.
+- **Link command** (`cmd/link.go`): No new flags.
+- **Valet config** (`internal/certs/valet.go`): Cert filenames stay as `{name}.{tld}.crt` — Vite plugin looks up by `basename(cwd) + "." + tld`, not by subdomain.
+- **TLS cert automation step** (`internal/automation/steps/generate_tls_cert.go`): Passes `hostname` as before; the SAN change is internal to `GenerateSiteCert`.
+- **Unlink/cleanup**: Same files to remove, no new artifacts.
+
+### Existing sites
+
+Sites linked before this change get wildcard routing on next `pv start` (daemon regenerates all Caddy configs via `GenerateAllConfigs`). Valet/Vite certs would need `pv unlink && pv link` to regenerate with the wildcard SAN — acceptable since the Valet cert only affects the Vite dev server, not browser TLS to the actual site (Caddy handles that).
+
+### Testing
+
+- Update existing Caddy template tests to verify wildcard addresses appear in generated configs.
+- Update cert generation tests to verify `*.hostname` appears in the cert's SAN list.
+
+### Limitations
+
+- **Single-level wildcards only**: `*.project.test` matches `sub.project.test` but not `deep.sub.project.test`. This is an X.509 and DNS standard limitation.
+- **Firefox cert trust**: Firefox uses its own cert store, not the macOS Keychain. This is a pre-existing issue unrelated to this change.

--- a/internal/caddy/caddy.go
+++ b/internal/caddy/caddy.go
@@ -23,7 +23,7 @@ const serviceConsoleTmpl = `{{.Subdomain}}.pv.{{.TLD}} {
 
 // --- Templates for the main process (direct serving) ---
 
-const laravelOctaneTmpl = `{{.Name}}.{{.TLD}} {
+const laravelOctaneTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
     tls internal
     root * {{.RootPath}}
     encode zstd gzip
@@ -40,7 +40,7 @@ const laravelOctaneTmpl = `{{.Name}}.{{.TLD}} {
 }
 `
 
-const laravelTmpl = `{{.Name}}.{{.TLD}} {
+const laravelTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
     tls internal
     root * {{.RootPath}}
     encode zstd gzip
@@ -51,7 +51,7 @@ const laravelTmpl = `{{.Name}}.{{.TLD}} {
 }
 `
 
-const phpTmpl = `{{.Name}}.{{.TLD}} {
+const phpTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
     tls internal
     root * {{.RootPath}}
     encode zstd gzip
@@ -62,7 +62,7 @@ const phpTmpl = `{{.Name}}.{{.TLD}} {
 }
 `
 
-const staticTmpl = `{{.Name}}.{{.TLD}} {
+const staticTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
     tls internal
     root * {{.RootPath}}
     file_server
@@ -71,7 +71,7 @@ const staticTmpl = `{{.Name}}.{{.TLD}} {
 
 // --- Template for reverse proxy (main process proxies to secondary) ---
 
-const proxyTmpl = `{{.Name}}.{{.TLD}} {
+const proxyTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
     tls internal
     reverse_proxy 127.0.0.1:{{.Port}}
 }

--- a/internal/caddy/caddy.go
+++ b/internal/caddy/caddy.go
@@ -79,7 +79,7 @@ const proxyTmpl = `{{.Name}}.{{.TLD}}, *.{{.Name}}.{{.TLD}} {
 
 // --- Templates for secondary FrankenPHP instances ---
 
-const versionLaravelOctaneTmpl = `http://{{.Name}}.{{.TLD}} {
+const versionLaravelOctaneTmpl = `http://{{.Name}}.{{.TLD}}, http://*.{{.Name}}.{{.TLD}} {
     root * {{.RootPath}}
     encode zstd gzip
 
@@ -95,7 +95,7 @@ const versionLaravelOctaneTmpl = `http://{{.Name}}.{{.TLD}} {
 }
 `
 
-const versionLaravelTmpl = `http://{{.Name}}.{{.TLD}} {
+const versionLaravelTmpl = `http://{{.Name}}.{{.TLD}}, http://*.{{.Name}}.{{.TLD}} {
     root * {{.RootPath}}
     encode zstd gzip
 
@@ -105,7 +105,7 @@ const versionLaravelTmpl = `http://{{.Name}}.{{.TLD}} {
 }
 `
 
-const versionPhpTmpl = `http://{{.Name}}.{{.TLD}} {
+const versionPhpTmpl = `http://{{.Name}}.{{.TLD}}, http://*.{{.Name}}.{{.TLD}} {
     root * {{.RootPath}}
     encode zstd gzip
 

--- a/internal/caddy/caddy_test.go
+++ b/internal/caddy/caddy_test.go
@@ -106,6 +106,23 @@ func TestOctaneTemplate_WatchesAutoload_VersionSpecific(t *testing.T) {
 	}
 }
 
+func TestVersionSiteConfig_HasWildcard(t *testing.T) {
+	scaffold(t)
+
+	projDir := t.TempDir()
+	p := registry.Project{Name: "ver-app", Path: projDir, Type: "laravel", PHP: "8.3"}
+
+	if err := GenerateSiteConfig(p, "8.4"); err != nil {
+		t.Fatalf("GenerateSiteConfig() error = %v", err)
+	}
+
+	content := readVersionSiteConfig(t, "8.3", "ver-app")
+
+	if !strings.Contains(content, "http://ver-app.test, http://*.ver-app.test {") {
+		t.Errorf("expected wildcard in version site config, got:\n%s", content)
+	}
+}
+
 func TestGenerateSiteConfig_Laravel(t *testing.T) {
 	scaffold(t)
 

--- a/internal/caddy/caddy_test.go
+++ b/internal/caddy/caddy_test.go
@@ -55,8 +55,8 @@ func TestGenerateSiteConfig_LaravelOctane(t *testing.T) {
 
 	content := readSiteConfig(t, "octane-app")
 
-	if !strings.Contains(content, "octane-app.test {") {
-		t.Error("expected domain octane-app.test")
+	if !strings.Contains(content, "octane-app.test, *.octane-app.test {") {
+		t.Error("expected domain octane-app.test with wildcard")
 	}
 	if !strings.Contains(content, "worker {") {
 		t.Error("expected worker block")
@@ -118,8 +118,8 @@ func TestGenerateSiteConfig_Laravel(t *testing.T) {
 
 	content := readSiteConfig(t, "lara-app")
 
-	if !strings.Contains(content, "lara-app.test {") {
-		t.Error("expected domain lara-app.test")
+	if !strings.Contains(content, "lara-app.test, *.lara-app.test {") {
+		t.Error("expected domain lara-app.test with wildcard")
 	}
 	if !strings.Contains(content, "php_server") {
 		t.Error("expected php_server")
@@ -215,8 +215,8 @@ func TestGenerateSiteConfig_DomainName(t *testing.T) {
 
 	content := readSiteConfig(t, "my-app")
 
-	if !strings.Contains(content, "my-app.test {") {
-		t.Errorf("expected 'my-app.test {' in output, got:\n%s", content)
+	if !strings.Contains(content, "my-app.test, *.my-app.test {") {
+		t.Errorf("expected 'my-app.test, *.my-app.test {' in output, got:\n%s", content)
 	}
 }
 

--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -34,7 +34,7 @@ func GenerateSiteCert(hostname, caCertPath, caKeyPath, certPath, keyPath string)
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject:      pkix.Name{CommonName: hostname},
-		DNSNames:     []string{hostname},
+		DNSNames:     []string{hostname, "*." + hostname},
 		NotBefore:    time.Now().Add(-time.Hour),
 		NotAfter:     time.Now().Add(825 * 24 * time.Hour), // 825 days (macOS max for trusted TLS certs)
 		KeyUsage:     x509.KeyUsageDigitalSignature,

--- a/internal/certs/certs_test.go
+++ b/internal/certs/certs_test.go
@@ -84,8 +84,8 @@ func TestGenerateSiteCert(t *testing.T) {
 	if cert.Subject.CommonName != "myapp.test" {
 		t.Errorf("CommonName = %q, want %q", cert.Subject.CommonName, "myapp.test")
 	}
-	if len(cert.DNSNames) != 1 || cert.DNSNames[0] != "myapp.test" {
-		t.Errorf("DNSNames = %v, want [myapp.test]", cert.DNSNames)
+	if len(cert.DNSNames) != 2 || cert.DNSNames[0] != "myapp.test" || cert.DNSNames[1] != "*.myapp.test" {
+		t.Errorf("DNSNames = %v, want [myapp.test *.myapp.test]", cert.DNSNames)
 	}
 	if cert.NotAfter.Before(time.Now().Add(800 * 24 * time.Hour)) {
 		t.Error("cert expires too soon")


### PR DESCRIPTION
## Summary

- Every linked project now responds to `*.name.tld` (e.g., `us.project.test`) in addition to `name.tld`, matching Laravel Valet/Herd behavior
- All 8 Caddy site templates (main + proxy + secondary version) include wildcard site addresses
- Valet TLS certs include `*.hostname` SAN for Vite dev server compatibility
- No new flags, no registry changes, no DNS changes — fully automatic

## Changes

- `internal/caddy/caddy.go` — Add `*.{{.Name}}.{{.TLD}}` to all 8 site address templates
- `internal/certs/certs.go` — Add `"*." + hostname` to cert `DNSNames` slice
- Tests updated to verify wildcard addresses and SANs

## Test plan

- [x] All caddy template tests pass with wildcard assertions
- [x] Cert generation test verifies wildcard SAN present
- [x] Full test suite passes (`go test ./...`)
- [x] `gofmt` and `go vet` clean
- [x] Build succeeds