### PR TITLE
Make pv link idempotent

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/prvious/pv/internal/automation"
 	"github.com/prvious/pv/internal/automation/steps"
+	"github.com/prvious/pv/internal/caddy"
+	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/detection"
 	"github.com/prvious/pv/internal/laravel"
@@ -62,27 +64,46 @@ pv link --name=myapp ~/Code/myapp`,
 			return fmt.Errorf("cannot load registry: %w", err)
 		}
 
-		if existing := reg.Find(name); existing != nil {
-			return fmt.Errorf("%s is already linked at %s\nTo re-link, run: pv unlink %s && pv link %s", name, existing.Path, name, path)
-		}
-
-		projectType := detection.Detect(absPath)
-
 		settings, err := config.LoadSettings()
 		if err != nil {
 			return fmt.Errorf("cannot load settings: %w", err)
 		}
 		globalPHP := settings.Defaults.PHP
 
+		// Check if project is already linked — if so, update in place.
+		var relink bool
+		var preservedServices *registry.ProjectServices
+		var preservedDatabases []string
+		if existing := reg.Find(name); existing != nil {
+			relink = true
+			preservedServices = existing.Services
+			preservedDatabases = existing.Databases
+
+			// Clean up old configs before pipeline regenerates them.
+			_ = caddy.RemoveSiteConfig(name)
+			hostname := name + "." + settings.Defaults.TLD
+			_ = certs.RemoveSiteTLS(hostname)
+		}
+
+		projectType := detection.Detect(absPath)
+
 		phpVersion := globalPHP
 		if v, err := phpenv.ResolveVersion(absPath); err == nil && v != "" {
 			phpVersion = v
 		}
 
-		// Register project.
+		// Register or update project.
 		project := registry.Project{Name: name, Path: absPath, Type: projectType, PHP: phpVersion}
-		if err := reg.Add(project); err != nil {
-			return err
+		if relink {
+			project.Services = preservedServices
+			project.Databases = preservedDatabases
+			if err := reg.Update(project); err != nil {
+				return err
+			}
+		} else {
+			if err := reg.Add(project); err != nil {
+				return err
+			}
 		}
 
 		// Build automation context.
@@ -129,10 +150,15 @@ pv link --name=myapp ~/Code/myapp`,
 			typeLabel = "unknown"
 		}
 
+		action := "Linked"
+		if relink {
+			action = "Relinked"
+		}
+
 		domain := "https://" + name + "." + settings.Defaults.TLD
 
 		fmt.Fprintln(os.Stderr)
-		ui.Success(fmt.Sprintf("Linked %s", ui.Accent.Bold(true).Render(domain)))
+		ui.Success(fmt.Sprintf("%s %s", action, ui.Accent.Bold(true).Render(domain)))
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintf(os.Stderr, "  %s  %s\n", ui.Muted.Render("Path"), absPath)
 		fmt.Fprintf(os.Stderr, "  %s  %s\n", ui.Muted.Render("Type"), typeLabel)

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -71,18 +71,16 @@ pv link --name=myapp ~/Code/myapp`,
 		globalPHP := settings.Defaults.PHP
 
 		// Check if project is already linked — if so, update in place.
-		var relink bool
-		var preservedServices *registry.ProjectServices
-		var preservedDatabases []string
-		if existing := reg.Find(name); existing != nil {
-			relink = true
-			preservedServices = existing.Services
-			preservedDatabases = existing.Databases
-
+		relink := reg.Find(name) != nil
+		if relink {
 			// Clean up old configs before pipeline regenerates them.
-			_ = caddy.RemoveSiteConfig(name)
+			if err := caddy.RemoveSiteConfig(name); err != nil {
+				return fmt.Errorf("cannot remove old site config: %w", err)
+			}
 			hostname := name + "." + settings.Defaults.TLD
-			_ = certs.RemoveSiteTLS(hostname)
+			if err := certs.RemoveSiteTLS(hostname); err != nil {
+				ui.Subtle(fmt.Sprintf("Could not remove old TLS certs: %v", err))
+			}
 		}
 
 		projectType := detection.Detect(absPath)
@@ -93,15 +91,16 @@ pv link --name=myapp ~/Code/myapp`,
 		}
 
 		// Register or update project.
-		project := registry.Project{Name: name, Path: absPath, Type: projectType, PHP: phpVersion}
 		if relink {
-			project.Services = preservedServices
-			project.Databases = preservedDatabases
-			if err := reg.Update(project); err != nil {
+			if err := reg.UpdateWith(name, func(p *registry.Project) {
+				p.Path = absPath
+				p.Type = projectType
+				p.PHP = phpVersion
+			}); err != nil {
 				return err
 			}
 		} else {
-			if err := reg.Add(project); err != nil {
+			if err := reg.Add(registry.Project{Name: name, Path: absPath, Type: projectType, PHP: phpVersion}); err != nil {
 				return err
 			}
 		}

--- a/cmd/link_test.go
+++ b/cmd/link_test.go
@@ -96,23 +96,56 @@ func TestLink_FileNotDir(t *testing.T) {
 	}
 }
 
-func TestLink_DuplicateName(t *testing.T) {
+func TestLink_RelinkPreservesServices(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	writeDefaultSettings(t)
 
 	projDir := t.TempDir()
 
+	// First link.
 	cmd1 := newLinkCmd()
-	cmd1.SetArgs([]string{"link", projDir, "--name", "dup"})
+	cmd1.SetArgs([]string{"link", projDir, "--name", "myapp"})
 	if err := cmd1.Execute(); err != nil {
 		t.Fatalf("first link error = %v", err)
 	}
 
-	projDir2 := t.TempDir()
+	// Manually add services to the registry entry to simulate bound services.
+	reg, err := registry.Load()
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	p := reg.Find("myapp")
+	if p == nil {
+		t.Fatal("expected project myapp in registry")
+	}
+	p.Services = &registry.ProjectServices{MySQL: "mysql:8.0"}
+	p.Databases = []string{"myapp"}
+	if err := reg.Save(); err != nil {
+		t.Fatalf("save registry: %v", err)
+	}
+
+	// Re-link the same project — should succeed, not error.
 	cmd2 := newLinkCmd()
-	cmd2.SetArgs([]string{"link", projDir2, "--name", "dup"})
-	if err := cmd2.Execute(); err == nil {
-		t.Fatal("expected error for duplicate name, got nil")
+	cmd2.SetArgs([]string{"link", projDir, "--name", "myapp"})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("re-link should succeed, got error: %v", err)
+	}
+
+	// Verify services and databases were preserved.
+	reg2, err := registry.Load()
+	if err != nil {
+		t.Fatalf("load registry after relink: %v", err)
+	}
+	p2 := reg2.Find("myapp")
+	if p2 == nil {
+		t.Fatal("expected project myapp in registry after relink")
+	}
+	if p2.Services == nil || p2.Services.MySQL != "mysql:8.0" {
+		t.Errorf("expected MySQL service preserved, got services=%v", p2.Services)
+	}
+	if len(p2.Databases) != 1 || p2.Databases[0] != "myapp" {
+		t.Errorf("expected databases preserved, got %v", p2.Databases)
 	}
 }
 

--- a/cmd/link_test.go
+++ b/cmd/link_test.go
@@ -137,6 +137,9 @@ func TestLink_RelinkPreservesServices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load registry after relink: %v", err)
 	}
+	if len(reg2.List()) != 1 {
+		t.Fatalf("expected 1 project after relink, got %d", len(reg2.List()))
+	}
 	p2 := reg2.Find("myapp")
 	if p2 == nil {
 		t.Fatal("expected project myapp in registry after relink")
@@ -146,6 +149,46 @@ func TestLink_RelinkPreservesServices(t *testing.T) {
 	}
 	if len(p2.Databases) != 1 || p2.Databases[0] != "myapp" {
 		t.Errorf("expected databases preserved, got %v", p2.Databases)
+	}
+}
+
+func TestLink_RelinkUpdatesPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeDefaultSettings(t)
+
+	projDir1 := t.TempDir()
+	projDir2 := t.TempDir()
+
+	// First link to projDir1.
+	cmd1 := newLinkCmd()
+	cmd1.SetArgs([]string{"link", projDir1, "--name", "myapp"})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first link error = %v", err)
+	}
+
+	// Re-link to projDir2.
+	cmd2 := newLinkCmd()
+	cmd2.SetArgs([]string{"link", projDir2, "--name", "myapp"})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("re-link error = %v", err)
+	}
+
+	reg, err := registry.Load()
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	if len(reg.List()) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(reg.List()))
+	}
+	p := reg.Find("myapp")
+	if p == nil {
+		t.Fatal("expected project myapp in registry")
+	}
+
+	absPath2, _ := filepath.Abs(projDir2)
+	if p.Path != absPath2 {
+		t.Errorf("path = %q, want %q", p.Path, absPath2)
 	}
 }
 

--- a/docs/superpowers/plans/2026-04-02-idempotent-link.md
+++ b/docs/superpowers/plans/2026-04-02-idempotent-link.md
@@ -1,0 +1,270 @@
+# Idempotent `pv link` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `pv link` idempotent — re-linking an already-linked project updates it in place (preserving services/databases) instead of erroring.
+
+**Architecture:** Add `Registry.Update()` method, then replace the "already linked" error in `cmd/link.go` with an update-in-place flow that preserves service bindings and re-runs the automation pipeline.
+
+**Tech Stack:** Go, cobra CLI
+
+**Spec:** `docs/superpowers/specs/2026-04-02-idempotent-link-design.md`
+
+---
+
+### Task 1: Add `Registry.Update()` method with tests
+
+**Files:**
+- Modify: `internal/registry/registry.go:71-77`
+- Modify: `internal/registry/registry_test.go`
+
+- [ ] **Step 1: Write failing tests for `Update`**
+
+Add these tests after the existing `TestRemove_Last` test in `internal/registry/registry_test.go`:
+
+```go
+func TestUpdate_Existing(t *testing.T) {
+	r := &Registry{}
+	_ = r.Add(Project{Name: "foo", Path: "/tmp/foo", Type: "php"})
+
+	err := r.Update(Project{Name: "foo", Path: "/tmp/foo2", Type: "laravel"})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if len(r.Projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(r.Projects))
+	}
+	if r.Projects[0].Path != "/tmp/foo2" {
+		t.Errorf("expected path %q, got %q", "/tmp/foo2", r.Projects[0].Path)
+	}
+	if r.Projects[0].Type != "laravel" {
+		t.Errorf("expected type %q, got %q", "laravel", r.Projects[0].Type)
+	}
+}
+
+func TestUpdate_NonExistent(t *testing.T) {
+	r := &Registry{}
+	err := r.Update(Project{Name: "foo", Path: "/tmp/foo"})
+	if err == nil {
+		t.Fatal("expected error for non-existent project, got nil")
+	}
+}
+
+func TestUpdate_PreservesOrder(t *testing.T) {
+	r := &Registry{}
+	_ = r.Add(Project{Name: "a", Path: "/tmp/a"})
+	_ = r.Add(Project{Name: "b", Path: "/tmp/b"})
+	_ = r.Add(Project{Name: "c", Path: "/tmp/c"})
+
+	err := r.Update(Project{Name: "b", Path: "/tmp/b2", Type: "laravel"})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if r.Projects[0].Name != "a" || r.Projects[1].Name != "b" || r.Projects[2].Name != "c" {
+		t.Errorf("expected order [a b c], got [%s %s %s]", r.Projects[0].Name, r.Projects[1].Name, r.Projects[2].Name)
+	}
+	if r.Projects[1].Path != "/tmp/b2" {
+		t.Errorf("expected updated path, got %q", r.Projects[1].Path)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/registry/ -run "TestUpdate" -v`
+Expected: FAIL — `Update` method not defined.
+
+- [ ] **Step 3: Implement `Update` method**
+
+In `internal/registry/registry.go`, add this method after the `Add` method (after line 77):
+
+```go
+func (r *Registry) Update(p Project) error {
+	for i, existing := range r.Projects {
+		if existing.Name == p.Name {
+			r.Projects[i] = p
+			return nil
+		}
+	}
+	return fmt.Errorf("project %q not found", p.Name)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/registry/ -v`
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/registry/registry.go internal/registry/registry_test.go
+git commit -m "Add Registry.Update() method for in-place project updates
+
+Replaces an existing project entry by name, preserving array order.
+Returns error if project not found."
+```
+
+### Task 2: Make `pv link` idempotent
+
+**Files:**
+- Modify: `cmd/link.go:64-67`
+
+- [ ] **Step 1: Write failing test for re-link behavior**
+
+In `cmd/link_test.go`, replace the existing `TestLink_DuplicateName` test (lines 99-117) with:
+
+```go
+func TestLink_RelinkPreservesServices(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeDefaultSettings(t)
+
+	projDir := t.TempDir()
+
+	// First link.
+	cmd1 := newLinkCmd()
+	cmd1.SetArgs([]string{"link", projDir, "--name", "myapp"})
+	if err := cmd1.Execute(); err != nil {
+		t.Fatalf("first link error = %v", err)
+	}
+
+	// Manually add services to the registry entry to simulate bound services.
+	reg, err := registry.Load()
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	p := reg.Find("myapp")
+	if p == nil {
+		t.Fatal("expected project myapp in registry")
+	}
+	p.Services = &registry.ProjectServices{MySQL: "mysql:8.0"}
+	p.Databases = []string{"myapp"}
+	if err := reg.Save(); err != nil {
+		t.Fatalf("save registry: %v", err)
+	}
+
+	// Re-link the same project — should succeed, not error.
+	cmd2 := newLinkCmd()
+	cmd2.SetArgs([]string{"link", projDir, "--name", "myapp"})
+	if err := cmd2.Execute(); err != nil {
+		t.Fatalf("re-link should succeed, got error: %v", err)
+	}
+
+	// Verify services and databases were preserved.
+	reg2, err := registry.Load()
+	if err != nil {
+		t.Fatalf("load registry after relink: %v", err)
+	}
+	p2 := reg2.Find("myapp")
+	if p2 == nil {
+		t.Fatal("expected project myapp in registry after relink")
+	}
+	if p2.Services == nil || p2.Services.MySQL != "mysql:8.0" {
+		t.Errorf("expected MySQL service preserved, got services=%v", p2.Services)
+	}
+	if len(p2.Databases) != 1 || p2.Databases[0] != "myapp" {
+		t.Errorf("expected databases preserved, got %v", p2.Databases)
+	}
+}
+```
+
+Note: You need to check what `ProjectServices` fields are available. Read `internal/registry/registry.go` for the struct definition.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/ -run TestLink_RelinkPreservesServices -v`
+Expected: FAIL — re-link still errors with "already linked".
+
+- [ ] **Step 3: Update `cmd/link.go` to handle re-link**
+
+In `cmd/link.go`, replace the existing duplicate-check block (lines 65-67):
+
+```go
+		if existing := reg.Find(name); existing != nil {
+			return fmt.Errorf("%s is already linked at %s\nTo re-link, run: pv unlink %s && pv link %s", name, existing.Path, name, path)
+		}
+```
+
+with:
+
+```go
+		// Check if project is already linked — if so, update in place.
+		var relink bool
+		var preservedServices *registry.ProjectServices
+		var preservedDatabases []string
+		if existing := reg.Find(name); existing != nil {
+			relink = true
+			preservedServices = existing.Services
+			preservedDatabases = existing.Databases
+
+			// Clean up old configs before pipeline regenerates them.
+			_ = caddy.RemoveSiteConfig(name)
+			hostname := name + "." + settings.Defaults.TLD
+			_ = certs.RemoveSiteTLS(hostname)
+		}
+```
+
+You will need to add `"github.com/prvious/pv/internal/caddy"` and `"github.com/prvious/pv/internal/certs"` to the imports (if not already present).
+
+Then, move the settings load above this block (it currently happens at line 71-75, but we need `settings.Defaults.TLD` for the cert cleanup). Read the current file to find the exact placement.
+
+- [ ] **Step 4: Update the registry operation**
+
+Replace the current `reg.Add(project)` call (around line 84) with:
+
+```go
+		// Register or update project.
+		project := registry.Project{Name: name, Path: absPath, Type: projectType, PHP: phpVersion}
+		if relink {
+			project.Services = preservedServices
+			project.Databases = preservedDatabases
+			if err := reg.Update(project); err != nil {
+				return err
+			}
+		} else {
+			if err := reg.Add(project); err != nil {
+				return err
+			}
+		}
+```
+
+- [ ] **Step 5: Update success output**
+
+Replace the success output line that prints "Linked" (around line 135):
+
+```go
+		action := "Linked"
+		if relink {
+			action = "Relinked"
+		}
+
+		fmt.Fprintln(os.Stderr)
+		ui.Success(fmt.Sprintf("%s %s", action, ui.Accent.Bold(true).Render(domain)))
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./cmd/ -run TestLink -v`
+Expected: All PASS, including the new `TestLink_RelinkPreservesServices`.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `go test ./...`
+Expected: All PASS.
+
+- [ ] **Step 8: Run lint checks**
+
+Run: `gofmt -l . && go vet ./...`
+Expected: Clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cmd/link.go cmd/link_test.go
+git commit -m "Make pv link idempotent — update in place if already linked
+
+Re-linking preserves service bindings and databases, re-detects
+project type and PHP version, and re-runs the full automation
+pipeline. Shows 'Relinked' in success output."
+```

--- a/docs/superpowers/specs/2026-04-02-idempotent-link-design.md
+++ b/docs/superpowers/specs/2026-04-02-idempotent-link-design.md
@@ -1,0 +1,65 @@
+# Idempotent `pv link`
+
+**Date:** 2026-04-02
+**Status:** Approved
+
+## Problem
+
+Running `pv link` on an already-linked project errors with "already linked, run unlink then link". This is annoying for the common case of re-linking a project to refresh its config (e.g., after changing PHP version, project type, or moving directories).
+
+## Design
+
+### Approach
+
+Make `pv link` idempotent. If the project name is already registered, update it in place instead of erroring. Preserve service bindings and databases from the existing entry; re-detect type and PHP version.
+
+### Changes
+
+#### 1. Registry: add `Update` method (`internal/registry/registry.go`)
+
+New method that replaces an existing project entry by name:
+
+```go
+func (r *Registry) Update(p Project) error {
+    for i, existing := range r.Projects {
+        if existing.Name == p.Name {
+            r.Projects[i] = p
+            return nil
+        }
+    }
+    return fmt.Errorf("project %q not found", p.Name)
+}
+```
+
+#### 2. Link command: update path (`cmd/link.go`)
+
+Replace the "already linked" error with an update flow:
+
+1. When `reg.Find(name)` finds an existing project:
+   - Save `Services` and `Databases` from the existing entry
+   - Re-detect `Type` and resolve `PHP` version (same logic as fresh link)
+   - Build new `Project` with preserved `Services`/`Databases` + fresh `Path`/`Type`/`PHP`
+   - Remove old Caddy site config and TLS cert (cleanup before pipeline regenerates)
+   - Call `reg.Update(project)` then `reg.Save()`
+2. When not found: proceed as today with `reg.Add(project)` then `reg.Save()`
+3. The full automation pipeline runs in both cases — same steps, same order
+4. Success output says "Relinked" instead of "Linked" when updating an existing entry
+
+#### 3. No changes required
+
+- **Automation pipeline** — same steps run for both fresh and re-link
+- **`cmd/unlink.go`** — unchanged
+- **Caddy/certs/DNS** — pipeline handles regeneration
+- **Registry `Add`/`Remove`** — unchanged, `Update` is additive
+
+### Edge cases
+
+- **Name collision with different path**: `pv link --name=myapp ~/new-path` when `myapp` is linked to `~/old-path` — updates the path. User explicitly chose the name. Old configs cleaned up, new ones generated.
+- **Same path, same name**: Pure refresh — re-detects type/PHP, regenerates configs, re-runs automation.
+- **Services/databases preserved**: Existing service bindings (MySQL, Redis, etc.) and database list carry over to the updated entry.
+
+### Testing
+
+- Add unit test for `Registry.Update()` — updates existing entry, returns error for non-existent
+- Add test in `cmd/` that links, then re-links the same project — verify no error, verify services preserved
+- Existing link/unlink tests should continue to pass unchanged

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -76,6 +76,16 @@ func (r *Registry) Add(p Project) error {
 	return nil
 }
 
+func (r *Registry) Update(p Project) error {
+	for i, existing := range r.Projects {
+		if existing.Name == p.Name {
+			r.Projects[i] = p
+			return nil
+		}
+	}
+	return fmt.Errorf("project %q not found", p.Name)
+}
+
 func (r *Registry) Remove(name string) error {
 	for i, p := range r.Projects {
 		if p.Name == name {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -76,14 +76,14 @@ func (r *Registry) Add(p Project) error {
 	return nil
 }
 
-func (r *Registry) Update(p Project) error {
-	for i, existing := range r.Projects {
-		if existing.Name == p.Name {
-			r.Projects[i] = p
+func (r *Registry) UpdateWith(name string, fn func(*Project)) error {
+	for i := range r.Projects {
+		if r.Projects[i].Name == name {
+			fn(&r.Projects[i])
 			return nil
 		}
 	}
-	return fmt.Errorf("project %q not found", p.Name)
+	return fmt.Errorf("project %q not found", name)
 }
 
 func (r *Registry) Remove(name string) error {

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -122,13 +122,16 @@ func TestRemove_Last(t *testing.T) {
 	}
 }
 
-func TestUpdate_Existing(t *testing.T) {
+func TestUpdateWith_Existing(t *testing.T) {
 	r := &Registry{}
 	_ = r.Add(Project{Name: "foo", Path: "/tmp/foo", Type: "php"})
 
-	err := r.Update(Project{Name: "foo", Path: "/tmp/foo2", Type: "laravel"})
+	err := r.UpdateWith("foo", func(p *Project) {
+		p.Path = "/tmp/foo2"
+		p.Type = "laravel"
+	})
 	if err != nil {
-		t.Fatalf("Update() error = %v", err)
+		t.Fatalf("UpdateWith() error = %v", err)
 	}
 	if len(r.Projects) != 1 {
 		t.Fatalf("expected 1 project, got %d", len(r.Projects))
@@ -141,29 +144,59 @@ func TestUpdate_Existing(t *testing.T) {
 	}
 }
 
-func TestUpdate_NonExistent(t *testing.T) {
+func TestUpdateWith_NonExistent(t *testing.T) {
 	r := &Registry{}
-	err := r.Update(Project{Name: "foo", Path: "/tmp/foo"})
+	err := r.UpdateWith("foo", func(p *Project) {
+		p.Path = "/tmp/foo"
+	})
 	if err == nil {
 		t.Fatal("expected error for non-existent project, got nil")
 	}
 }
 
-func TestUpdate_PreservesOrder(t *testing.T) {
+func TestUpdateWith_PreservesOrder(t *testing.T) {
 	r := &Registry{}
 	_ = r.Add(Project{Name: "a", Path: "/tmp/a"})
 	_ = r.Add(Project{Name: "b", Path: "/tmp/b"})
 	_ = r.Add(Project{Name: "c", Path: "/tmp/c"})
 
-	err := r.Update(Project{Name: "b", Path: "/tmp/b2", Type: "laravel"})
+	err := r.UpdateWith("b", func(p *Project) {
+		p.Path = "/tmp/b2"
+		p.Type = "laravel"
+	})
 	if err != nil {
-		t.Fatalf("Update() error = %v", err)
+		t.Fatalf("UpdateWith() error = %v", err)
 	}
 	if r.Projects[0].Name != "a" || r.Projects[1].Name != "b" || r.Projects[2].Name != "c" {
 		t.Errorf("expected order [a b c], got [%s %s %s]", r.Projects[0].Name, r.Projects[1].Name, r.Projects[2].Name)
 	}
 	if r.Projects[1].Path != "/tmp/b2" {
 		t.Errorf("expected updated path, got %q", r.Projects[1].Path)
+	}
+}
+
+func TestUpdateWith_PreservesUntouchedFields(t *testing.T) {
+	r := &Registry{}
+	_ = r.Add(Project{
+		Name:      "foo",
+		Path:      "/tmp/foo",
+		Type:      "php",
+		Services:  &ProjectServices{MySQL: "mysql:8.0"},
+		Databases: []string{"foo_db"},
+	})
+
+	err := r.UpdateWith("foo", func(p *Project) {
+		p.Path = "/tmp/foo2"
+		p.Type = "laravel"
+	})
+	if err != nil {
+		t.Fatalf("UpdateWith() error = %v", err)
+	}
+	if r.Projects[0].Services == nil || r.Projects[0].Services.MySQL != "mysql:8.0" {
+		t.Errorf("expected Services preserved, got %v", r.Projects[0].Services)
+	}
+	if len(r.Projects[0].Databases) != 1 || r.Projects[0].Databases[0] != "foo_db" {
+		t.Errorf("expected Databases preserved, got %v", r.Projects[0].Databases)
 	}
 }
 

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -122,6 +122,51 @@ func TestRemove_Last(t *testing.T) {
 	}
 }
 
+func TestUpdate_Existing(t *testing.T) {
+	r := &Registry{}
+	_ = r.Add(Project{Name: "foo", Path: "/tmp/foo", Type: "php"})
+
+	err := r.Update(Project{Name: "foo", Path: "/tmp/foo2", Type: "laravel"})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if len(r.Projects) != 1 {
+		t.Fatalf("expected 1 project, got %d", len(r.Projects))
+	}
+	if r.Projects[0].Path != "/tmp/foo2" {
+		t.Errorf("expected path %q, got %q", "/tmp/foo2", r.Projects[0].Path)
+	}
+	if r.Projects[0].Type != "laravel" {
+		t.Errorf("expected type %q, got %q", "laravel", r.Projects[0].Type)
+	}
+}
+
+func TestUpdate_NonExistent(t *testing.T) {
+	r := &Registry{}
+	err := r.Update(Project{Name: "foo", Path: "/tmp/foo"})
+	if err == nil {
+		t.Fatal("expected error for non-existent project, got nil")
+	}
+}
+
+func TestUpdate_PreservesOrder(t *testing.T) {
+	r := &Registry{}
+	_ = r.Add(Project{Name: "a", Path: "/tmp/a"})
+	_ = r.Add(Project{Name: "b", Path: "/tmp/b"})
+	_ = r.Add(Project{Name: "c", Path: "/tmp/c"})
+
+	err := r.Update(Project{Name: "b", Path: "/tmp/b2", Type: "laravel"})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if r.Projects[0].Name != "a" || r.Projects[1].Name != "b" || r.Projects[2].Name != "c" {
+		t.Errorf("expected order [a b c], got [%s %s %s]", r.Projects[0].Name, r.Projects[1].Name, r.Projects[2].Name)
+	}
+	if r.Projects[1].Path != "/tmp/b2" {
+		t.Errorf("expected updated path, got %q", r.Projects[1].Path)
+	}
+}
+
 func TestFind_Existing(t *testing.T) {
 	r := &Registry{}
 	_ = r.Add(Project{Name: "foo", Path: "/tmp/foo"})


### PR DESCRIPTION
## Summary

- `pv link` now updates an already-linked project in place instead of erroring
- Preserves service bindings (MySQL, Postgres, Redis, etc.) and databases from the existing entry
- Re-detects project type and PHP version, re-runs the full automation pipeline
- Shows "Relinked" in success output when updating an existing project

## Changes

- `internal/registry/registry.go` — New `Update()` method that replaces an existing entry by name
- `cmd/link.go` — Replace "already linked" error with update-in-place flow
- Tests updated to verify re-link preserves services and databases

## Test plan

- [x] `Registry.Update()` unit tests (existing, non-existent, order preservation)
- [x] `TestLink_RelinkPreservesServices` verifies end-to-end re-link with service preservation
- [x] Full test suite passes
- [x] `gofmt` and `go vet` clean