### PR TITLE
Replace Valet cert path with Vite env vars

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -136,6 +136,7 @@ pv link --name=myapp ~/Code/myapp`,
 			&steps.DetectServicesStep{},
 			&laravel.DetectServicesStep{},
 			&laravel.SetAppURLStep{},
+			&laravel.SetViteTLSStep{},
 			&laravel.CreateDatabaseStep{},
 			&laravel.RunMigrationsStep{},
 		}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -9,7 +9,6 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/prvious/pv/internal/binaries"
-	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/commands/composer"
 	daemoncmds "github.com/prvious/pv/internal/commands/daemon"
 	"github.com/prvious/pv/internal/commands/mago"
@@ -144,11 +143,6 @@ var setupCmd = &cobra.Command{
 			}
 			if err := s.Save(); err != nil {
 				return "", fmt.Errorf("cannot save settings: %w", err)
-			}
-
-			// Write Valet-compatible config for Vite TLS auto-detection.
-			if err := certs.EnsureValetConfig(tld); err != nil {
-				ui.Subtle(fmt.Sprintf("Vite TLS config: %v", err))
 			}
 
 			return "Settings saved", nil

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -236,9 +236,6 @@ var uninstallCmd = &cobra.Command{
 				ui.Subtle(fmt.Sprintf("Could not remove some Vite TLS certs: %v", err))
 			}
 		}
-		if err := certs.RemoveConfig(); err != nil {
-			ui.Subtle(fmt.Sprintf("Could not remove Valet config: %v", err))
-		}
 
 		// Remove ~/.pv directory.
 		if err := ui.Step("Removing ~/.pv...", func() (string, error) {

--- a/docs/superpowers/plans/2026-04-02-vite-tls-env-vars.md
+++ b/docs/superpowers/plans/2026-04-02-vite-tls-env-vars.md
@@ -1,0 +1,559 @@
+# Vite TLS Env Vars Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace Valet cert directory with pv-native cert storage at `~/.pv/data/certs/` and use `VITE_DEV_SERVER_*` env vars instead of Valet auto-detection.
+
+**Architecture:** Rewrite `internal/certs/valet.go` to use pv-owned cert storage, add `SetViteTLSStep` automation step, wire up the gate in settings/pipeline, remove all Valet config code from callers.
+
+**Tech Stack:** Go, x509 certificates, cobra CLI
+
+**Spec:** `docs/superpowers/specs/2026-04-02-vite-tls-env-vars-design.md`
+
+---
+
+### Task 1: Rewrite cert storage to use `~/.pv/data/certs/`
+
+**Files:**
+- Modify: `internal/certs/valet.go`
+- Modify: `internal/certs/valet_test.go`
+
+- [ ] **Step 1: Write tests for new cert storage functions**
+
+Replace the entire contents of `internal/certs/valet_test.go` with:
+
+```go
+package certs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCertsDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := CertsDir()
+	expected := filepath.Join(home, ".pv", "data", "certs")
+	if dir != expected {
+		t.Errorf("CertsDir() = %q, want %q", dir, expected)
+	}
+}
+
+func TestCertPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := CertPath("myapp.test")
+	expected := filepath.Join(home, ".pv", "data", "certs", "myapp.test.crt")
+	if p != expected {
+		t.Errorf("CertPath() = %q, want %q", p, expected)
+	}
+}
+
+func TestKeyPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	p := KeyPath("myapp.test")
+	expected := filepath.Join(home, ".pv", "data", "certs", "myapp.test.key")
+	if p != expected {
+		t.Errorf("KeyPath() = %q, want %q", p, expected)
+	}
+}
+
+func TestGenerateSiteTLS(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// GenerateSiteTLS requires Caddy CA — test that it returns an error
+	// when no CA exists (same behavior as before).
+	err := GenerateSiteTLS("myapp.test")
+	if err == nil {
+		t.Fatal("expected error when CA doesn't exist")
+	}
+}
+
+func TestRemoveSiteTLS(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	certsDir := CertsDir()
+	os.MkdirAll(certsDir, 0755)
+
+	certPath := filepath.Join(certsDir, "myapp.test.crt")
+	keyPath := filepath.Join(certsDir, "myapp.test.key")
+	os.WriteFile(certPath, []byte("cert"), 0644)
+	os.WriteFile(keyPath, []byte("key"), 0600)
+
+	if err := RemoveSiteTLS("myapp.test"); err != nil {
+		t.Fatalf("RemoveSiteTLS() error = %v", err)
+	}
+
+	if _, err := os.Stat(certPath); !os.IsNotExist(err) {
+		t.Error("cert file should be removed")
+	}
+	if _, err := os.Stat(keyPath); !os.IsNotExist(err) {
+		t.Error("key file should be removed")
+	}
+}
+
+func TestRemoveSiteTLS_NonExistent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := RemoveSiteTLS("nonexistent.test"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRemoveLinkedCerts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	certsDir := CertsDir()
+	os.MkdirAll(certsDir, 0755)
+
+	for _, name := range []string{"app1.test", "app2.test", "other.test"} {
+		os.WriteFile(filepath.Join(certsDir, name+".crt"), []byte("cert"), 0644)
+		os.WriteFile(filepath.Join(certsDir, name+".key"), []byte("key"), 0600)
+	}
+
+	if err := RemoveLinkedCerts([]string{"app1.test", "app2.test"}); err != nil {
+		t.Fatalf("RemoveLinkedCerts() error = %v", err)
+	}
+
+	for _, name := range []string{"app1.test", "app2.test"} {
+		if _, err := os.Stat(filepath.Join(certsDir, name+".crt")); !os.IsNotExist(err) {
+			t.Errorf("%s.crt should be removed", name)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(certsDir, "other.test.crt")); err != nil {
+		t.Error("other.test.crt should NOT be removed")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/certs/ -run "TestCertsDir|TestCertPath|TestKeyPath|TestRemoveSiteTLS$|TestRemoveLinkedCerts$" -v`
+Expected: FAIL — functions don't exist yet.
+
+- [ ] **Step 3: Rewrite `internal/certs/valet.go`**
+
+Replace the entire contents of `internal/certs/valet.go` with:
+
+```go
+package certs
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+// CertsDir returns ~/.pv/data/certs/.
+func CertsDir() string {
+	return filepath.Join(config.DataDir(), "certs")
+}
+
+// CertPath returns the full path to a site certificate.
+func CertPath(hostname string) string {
+	return filepath.Join(CertsDir(), hostname+".crt")
+}
+
+// KeyPath returns the full path to a site private key.
+func KeyPath(hostname string) string {
+	return filepath.Join(CertsDir(), hostname+".key")
+}
+
+// GenerateSiteTLS generates a TLS cert/key pair for hostname and places them
+// in the pv certs directory. Uses Caddy's local CA to sign the certificate.
+func GenerateSiteTLS(hostname string) error {
+	caCertPath := config.CACertPath()
+	caKeyPath := config.CAKeyPath()
+
+	if _, err := os.Stat(caCertPath); err != nil {
+		return fmt.Errorf("Caddy CA not found at %s (run pv start first to generate it)", caCertPath)
+	}
+	if _, err := os.Stat(caKeyPath); err != nil {
+		return fmt.Errorf("Caddy CA key not found at %s", caKeyPath)
+	}
+
+	certsDir := CertsDir()
+	if err := os.MkdirAll(certsDir, 0755); err != nil {
+		return fmt.Errorf("cannot create certs dir: %w", err)
+	}
+
+	certPath := CertPath(hostname)
+	keyPath := KeyPath(hostname)
+
+	return GenerateSiteCert(hostname, caCertPath, caKeyPath, certPath, keyPath)
+}
+
+// RemoveSiteTLS removes the TLS cert/key pair for hostname.
+// Returns nil if the files do not exist.
+func RemoveSiteTLS(hostname string) error {
+	var errs []error
+	for _, ext := range []string{".crt", ".key"} {
+		if err := os.Remove(filepath.Join(CertsDir(), hostname+ext)); err != nil && !os.IsNotExist(err) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// RemoveLinkedCerts removes TLS cert/key pairs for the given hostnames.
+func RemoveLinkedCerts(hostnames []string) error {
+	var errs []error
+	for _, h := range hostnames {
+		for _, ext := range []string{".crt", ".key"} {
+			if err := os.Remove(filepath.Join(CertsDir(), h+ext)); err != nil && !os.IsNotExist(err) {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/certs/ -v`
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/certs/valet.go internal/certs/valet_test.go
+git commit -m "Move cert storage from ~/.config/valet/ to ~/.pv/data/certs/
+
+Replace Valet-specific cert functions with pv-native storage.
+Remove EnsureValetConfig, ValetConfigDir, ValetCertsDir,
+RemoveConfig, and all config.json management."
+```
+
+### Task 2: Update callers that reference removed Valet functions
+
+**Files:**
+- Modify: `internal/automation/steps/generate_tls_cert.go`
+- Modify: `cmd/setup.go`
+- Modify: `cmd/uninstall.go`
+
+- [ ] **Step 1: Update `generate_tls_cert.go` — remove `EnsureValetConfig` call**
+
+Replace the entire `Run` method in `internal/automation/steps/generate_tls_cert.go` with:
+
+```go
+func (s *GenerateTLSCertStep) Run(ctx *automation.Context) (string, error) {
+	hostname := fmt.Sprintf("%s.%s", ctx.ProjectName, ctx.TLD)
+	if err := certs.GenerateSiteTLS(hostname); err != nil {
+		return "", fmt.Errorf("TLS cert not generated for %s: %w", hostname, err)
+	}
+	return hostname, nil
+}
+```
+
+- [ ] **Step 2: Update `cmd/setup.go` — remove `EnsureValetConfig` call**
+
+In `cmd/setup.go`, remove these lines (around lines 149-152):
+
+```go
+			// Write Valet-compatible config for Vite TLS auto-detection.
+			if err := certs.EnsureValetConfig(tld); err != nil {
+				ui.Subtle(fmt.Sprintf("Vite TLS config: %v", err))
+			}
+```
+
+Also remove the `certs` import from `cmd/setup.go` if it becomes unused (check if any other certs function is still called in the file).
+
+- [ ] **Step 3: Update `cmd/uninstall.go` — remove `RemoveConfig` call**
+
+In `cmd/uninstall.go`, remove these lines (around lines 239-241):
+
+```go
+		if err := certs.RemoveConfig(); err != nil {
+			ui.Subtle(fmt.Sprintf("Could not remove Valet config: %v", err))
+		}
+```
+
+Keep the `certs.RemoveLinkedCerts(hostnames)` call — it still works (now removes from `~/.pv/data/certs/`).
+
+- [ ] **Step 4: Verify build and tests**
+
+Run: `go build ./... && go test ./... && go vet ./...`
+Expected: All clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/automation/steps/generate_tls_cert.go cmd/setup.go cmd/uninstall.go
+git commit -m "Remove Valet config calls from callers
+
+EnsureValetConfig and RemoveConfig are gone. GenerateTLSCertStep
+now calls GenerateSiteTLS directly. RemoveLinkedCerts still used
+in uninstall (points to new cert dir)."
+```
+
+### Task 3: Add `SetViteTLSStep` automation step
+
+**Files:**
+- Modify: `internal/laravel/steps.go`
+- Modify: `internal/laravel/steps_test.go`
+
+- [ ] **Step 1: Write tests for `SetViteTLSStep`**
+
+Add these tests to `internal/laravel/steps_test.go` (after the existing `SetAppURLStep` tests):
+
+```go
+// --- SetViteTLSStep tests ---
+
+func TestSetViteTLSStep_ShouldRun_TrueForLaravel(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_URL=http://localhost"), 0644)
+
+	step := &SetViteTLSStep{}
+	ctx := &automation.Context{ProjectType: "laravel", ProjectPath: dir}
+	if !step.ShouldRun(ctx) {
+		t.Error("expected ShouldRun=true for laravel with .env")
+	}
+}
+
+func TestSetViteTLSStep_ShouldRun_FalseWhenNoEnv(t *testing.T) {
+	dir := t.TempDir()
+	step := &SetViteTLSStep{}
+	ctx := &automation.Context{ProjectType: "laravel", ProjectPath: dir}
+	if step.ShouldRun(ctx) {
+		t.Error("expected ShouldRun=false when no .env")
+	}
+}
+
+func TestSetViteTLSStep_ShouldRun_FalseForPHP(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte(""), 0644)
+	step := &SetViteTLSStep{}
+	ctx := &automation.Context{ProjectType: "php", ProjectPath: dir}
+	if step.ShouldRun(ctx) {
+		t.Error("expected ShouldRun=false for php")
+	}
+}
+
+func TestSetViteTLSStep_Run(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_URL=https://myapp.test\n"), 0644)
+
+	step := &SetViteTLSStep{}
+	ctx := &automation.Context{
+		ProjectPath: dir,
+		ProjectName: "myapp",
+		TLD:         "test",
+	}
+
+	result, err := step.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result == "" {
+		t.Error("expected non-empty result")
+	}
+
+	env, err := services.ReadDotEnv(filepath.Join(dir, ".env"))
+	if err != nil {
+		t.Fatalf("ReadDotEnv: %v", err)
+	}
+
+	certPath := certs.CertPath("myapp.test")
+	keyPath := certs.KeyPath("myapp.test")
+
+	if env["VITE_DEV_SERVER_CERT"] != certPath {
+		t.Errorf("VITE_DEV_SERVER_CERT = %q, want %q", env["VITE_DEV_SERVER_CERT"], certPath)
+	}
+	if env["VITE_DEV_SERVER_KEY"] != keyPath {
+		t.Errorf("VITE_DEV_SERVER_KEY = %q, want %q", env["VITE_DEV_SERVER_KEY"], keyPath)
+	}
+}
+```
+
+Note: You will need to add `"github.com/prvious/pv/internal/certs"` to the test file imports. Check existing imports first — `services` should already be imported.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/laravel/ -run "TestSetViteTLSStep" -v`
+Expected: FAIL — `SetViteTLSStep` not defined.
+
+- [ ] **Step 3: Implement `SetViteTLSStep`**
+
+Add this to `internal/laravel/steps.go`, after `SetAppURLStep` (after line 111):
+
+```go
+// --- SetViteTLSStep ---
+
+// SetViteTLSStep sets VITE_DEV_SERVER_KEY and VITE_DEV_SERVER_CERT in .env
+// so laravel-vite-plugin can find the TLS certificate for the dev server.
+type SetViteTLSStep struct{}
+
+var _ automation.Step = (*SetViteTLSStep)(nil)
+
+func (s *SetViteTLSStep) Label() string  { return "Set Vite TLS" }
+func (s *SetViteTLSStep) Gate() string   { return "set_vite_tls" }
+func (s *SetViteTLSStep) Critical() bool { return false }
+
+func (s *SetViteTLSStep) ShouldRun(ctx *automation.Context) bool {
+	return isLaravel(ctx.ProjectType) && HasEnvFile(ctx.ProjectPath)
+}
+
+func (s *SetViteTLSStep) Run(ctx *automation.Context) (string, error) {
+	tld := ctx.TLD
+	if tld == "" {
+		tld = "test"
+	}
+	hostname := fmt.Sprintf("%s.%s", ctx.ProjectName, tld)
+	envPath := filepath.Join(ctx.ProjectPath, ".env")
+	vars := map[string]string{
+		"VITE_DEV_SERVER_CERT": certs.CertPath(hostname),
+		"VITE_DEV_SERVER_KEY":  certs.KeyPath(hostname),
+	}
+	if err := services.MergeDotEnv(envPath, "", vars); err != nil {
+		return "", fmt.Errorf("set Vite TLS: %w", err)
+	}
+	return hostname, nil
+}
+```
+
+You will need to add `"github.com/prvious/pv/internal/certs"` to the imports in `steps.go`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/laravel/ -v`
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/laravel/steps.go internal/laravel/steps_test.go
+git commit -m "Add SetViteTLSStep automation step
+
+Writes VITE_DEV_SERVER_KEY and VITE_DEV_SERVER_CERT to .env
+pointing to pv's cert storage. Runs for Laravel projects with
+.env files."
+```
+
+### Task 4: Wire up settings gate and pipeline
+
+**Files:**
+- Modify: `internal/config/settings.go`
+- Modify: `internal/automation/pipeline.go`
+- Modify: `cmd/link.go`
+
+- [ ] **Step 1: Add `SetViteTLS` field to `Automation` struct**
+
+In `internal/config/settings.go`, add after the `SetAppURL` field (line 60):
+
+```go
+	SetViteTLS        AutoMode `yaml:"set_vite_tls,omitempty"`
+```
+
+- [ ] **Step 2: Add default value**
+
+In the `DefaultAutomation()` function, add after `SetAppURL: AutoOn,` (line 88):
+
+```go
+		SetViteTLS:         AutoOn,
+```
+
+- [ ] **Step 3: Add validation in `applyAutomationDefaults`**
+
+In `applyAutomationDefaults`, add after the `SetAppURL` validation block (after line 123):
+
+```go
+	if !validAutoMode(a.SetViteTLS) {
+		a.SetViteTLS = d.SetViteTLS
+	}
+```
+
+- [ ] **Step 4: Add gate case in pipeline**
+
+In `internal/automation/pipeline.go`, add a case in the `automationMode` switch after the `set_app_url` case (after line 124):
+
+```go
+	case "set_vite_tls":
+		return a.SetViteTLS
+```
+
+- [ ] **Step 5: Add step to pipeline in `cmd/link.go`**
+
+In `cmd/link.go`, add `&laravel.SetViteTLSStep{}` after `&laravel.SetAppURLStep{}` in the `allSteps` slice:
+
+```go
+			&laravel.SetAppURLStep{},
+			&laravel.SetViteTLSStep{},
+```
+
+- [ ] **Step 6: Verify build and full test suite**
+
+Run: `go build ./... && go test ./... && gofmt -l . && go vet ./...`
+Expected: All clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/config/settings.go internal/automation/pipeline.go cmd/link.go
+git commit -m "Wire SetViteTLS gate into settings, pipeline, and link command
+
+New automation gate 'set_vite_tls' defaults to on. Step runs
+after SetAppURLStep in the link pipeline."
+```
+
+### Task 5: Update settings tests
+
+**Files:**
+- Modify: `internal/config/settings_test.go`
+- Modify: `internal/automation/pipeline_test.go`
+
+- [ ] **Step 1: Check existing settings tests for the new field**
+
+Read `internal/config/settings_test.go` and `internal/automation/pipeline_test.go` to find where automation fields are asserted. Add `SetViteTLS` assertions alongside the existing `SetAppURL` assertions.
+
+Search for patterns like `a.SetAppURL` in the test files and add matching `a.SetViteTLS` checks. Also search for `{"set_app_url"` in pipeline tests and add `{"set_vite_tls", a.SetViteTLS}`.
+
+- [ ] **Step 2: Run tests**
+
+Run: `go test ./internal/config/ ./internal/automation/ -v`
+Expected: All PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/config/settings_test.go internal/automation/pipeline_test.go
+git commit -m "Add SetViteTLS to settings and pipeline tests"
+```
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./...`
+Expected: All PASS.
+
+- [ ] **Step 2: Run lint**
+
+Run: `gofmt -l internal/certs/ internal/laravel/ internal/config/ internal/automation/ cmd/ && go vet ./...`
+Expected: Clean.
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build -o /dev/null .`
+Expected: Builds successfully.
+
+- [ ] **Step 4: Verify no remaining Valet references in source**
+
+Run: `grep -r "ValetConfig\|ValetCerts\|config/valet\|RemoveConfig" internal/ cmd/ --include="*.go" | grep -v _test.go | grep -v plans/ | grep -v specs/`
+Expected: No matches (all Valet references removed from non-test source files).

--- a/docs/superpowers/specs/2026-04-02-vite-tls-env-vars-design.md
+++ b/docs/superpowers/specs/2026-04-02-vite-tls-env-vars-design.md
@@ -1,0 +1,79 @@
+# Replace Valet Cert Path with Vite Env Vars
+
+**Date:** 2026-04-02
+**Status:** Approved
+
+## Problem
+
+pv stores TLS certs in `~/.config/valet/Certificates/` and maintains a `config.json` to mimic Valet, solely for `laravel-vite-plugin` auto-detection. This has issues:
+
+1. **`--name` flag mismatch**: The Vite plugin resolves hostname from `basename(cwd)`, not the link name. When `--name` differs from the directory name, Vite can't find the cert.
+2. **Unnecessary Valet coupling**: pv pretends to be Valet by maintaining `~/.config/valet/` — a directory owned by another tool.
+3. **Conflict risk**: If real Valet/Herd is installed, pv's writes to `~/.config/valet/` can interfere.
+
+The Vite plugin has a second detection path: `VITE_DEV_SERVER_KEY` and `VITE_DEV_SERVER_CERT` env vars in `.env`. This path uses explicit file paths and is immune to the basename mismatch.
+
+## Design
+
+### Approach
+
+1. Move cert storage from `~/.config/valet/Certificates/` to `~/.pv/data/certs/`
+2. Write `VITE_DEV_SERVER_KEY` and `VITE_DEV_SERVER_CERT` to the project's `.env` during link
+3. Remove all Valet config directory code
+
+### Changes
+
+#### 1. Cert storage (`internal/certs/valet.go` → rewrite)
+
+Replace Valet-specific functions with pv-native cert storage:
+
+- `CertsDir() string` — returns `~/.pv/data/certs/`
+- `CertPath(hostname) string` — returns `~/.pv/data/certs/{hostname}.crt`
+- `KeyPath(hostname) string` — returns `~/.pv/data/certs/{hostname}.key`
+- `GenerateSiteTLS(hostname)` — writes cert/key to `CertsDir()` using `GenerateSiteCert` (same low-level cert generation)
+- `RemoveSiteTLS(hostname)` — removes cert/key from `CertsDir()`
+- `RemoveLinkedCerts(hostnames)` — removes cert/key pairs for given hostnames from `CertsDir()`
+
+**Delete:** `EnsureValetConfig`, `ValetConfigDir`, `ValetCertsDir`, `RemoveConfig`. All `config.json` management is gone.
+
+#### 2. New automation step (`internal/laravel/steps.go`)
+
+`SetViteTLSStep` writes `VITE_DEV_SERVER_KEY` and `VITE_DEV_SERVER_CERT` to `.env`:
+
+- `ShouldRun`: `isLaravel(ctx.ProjectType) && HasEnvFile(ctx.ProjectPath)`
+- `Run`: builds cert/key paths from `certs.CertPath(hostname)` and `certs.KeyPath(hostname)` where hostname is `ctx.ProjectName + "." + ctx.TLD`, then writes via `services.MergeDotEnv`
+- `Gate`: `"set_vite_tls"`
+- `Label`: `"Set Vite TLS"`
+
+#### 3. Settings (`internal/config/settings.go`)
+
+Add `SetViteTLS AutoMode` field to the `Automation` struct, defaulting to `AutoOn`.
+
+#### 4. Pipeline order (`cmd/link.go`)
+
+Add `&laravel.SetViteTLSStep{}` after `&laravel.SetAppURLStep{}` in the pipeline.
+
+#### 5. Update callers
+
+- `cmd/setup.go` — remove `certs.EnsureValetConfig(tld)` call
+- `cmd/uninstall.go` — remove `certs.RemoveConfig()` call; keep `certs.RemoveLinkedCerts(hostnames)` (it now removes from `~/.pv/data/certs/`)
+- `cmd/unlink.go` — `certs.RemoveSiteTLS` already called, internal path changes only
+- `cmd/link.go` — relink path already calls `certs.RemoveSiteTLS`, no change needed
+- `internal/automation/steps/generate_tls_cert.go` — remove `certs.EnsureValetConfig` call, just call `certs.GenerateSiteTLS(hostname)`
+
+#### 6. No changes required
+
+- `internal/certs/certs.go` — `GenerateSiteCert` (low-level cert generation) is unchanged
+- DNS, Caddy templates, registry — unaffected
+- `internal/server/` — unaffected
+
+### Hostname resolution
+
+Certs always use the link name (`ctx.ProjectName`), which respects the `--name` flag. The env vars point to `~/.pv/data/certs/{projectName}.{tld}.crt`. This eliminates the basename mismatch entirely.
+
+### Testing
+
+- Update `internal/certs/valet_test.go` for new cert paths
+- Add tests for `SetViteTLSStep` (ShouldRun + Run)
+- Add automation gate test for `set_vite_tls`
+- Existing `GenerateSiteCert` tests in `certs_test.go` are unaffected

--- a/internal/automation/pipeline.go
+++ b/internal/automation/pipeline.go
@@ -122,6 +122,8 @@ func LookupGate(a *config.Automation, gate string) config.AutoMode {
 		return a.GenerateKey
 	case "set_app_url":
 		return a.SetAppURL
+	case "set_vite_tls":
+		return a.SetViteTLS
 	case "install_octane":
 		return a.InstallOctane
 	case "create_database":

--- a/internal/automation/pipeline_test.go
+++ b/internal/automation/pipeline_test.go
@@ -230,6 +230,7 @@ func TestLookupGate(t *testing.T) {
 		{"copy_env", a.CopyEnv},
 		{"generate_key", a.GenerateKey},
 		{"set_app_url", a.SetAppURL},
+		{"set_vite_tls", a.SetViteTLS},
 		{"install_octane", a.InstallOctane},
 		{"create_database", a.CreateDatabase},
 		{"run_migrations", a.RunMigrations},

--- a/internal/automation/steps/generate_tls_cert.go
+++ b/internal/automation/steps/generate_tls_cert.go
@@ -22,9 +22,6 @@ func (s *GenerateTLSCertStep) ShouldRun(_ *automation.Context) bool {
 
 func (s *GenerateTLSCertStep) Run(ctx *automation.Context) (string, error) {
 	hostname := fmt.Sprintf("%s.%s", ctx.ProjectName, ctx.TLD)
-	if err := certs.EnsureValetConfig(ctx.TLD); err != nil {
-		return "", fmt.Errorf("TLS cert setup skipped: %w", err)
-	}
 	if err := certs.GenerateSiteTLS(hostname); err != nil {
 		return "", fmt.Errorf("TLS cert not generated for %s: %w", hostname, err)
 	}

--- a/internal/certs/storage.go
+++ b/internal/certs/storage.go
@@ -31,10 +31,16 @@ func GenerateSiteTLS(hostname string) error {
 	caKeyPath := config.CAKeyPath()
 
 	if _, err := os.Stat(caCertPath); err != nil {
-		return fmt.Errorf("Caddy CA not found at %s (run pv start first to generate it)", caCertPath)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("Caddy CA not found at %s (run pv start first to generate it)", caCertPath)
+		}
+		return fmt.Errorf("cannot access Caddy CA at %s: %w", caCertPath, err)
 	}
 	if _, err := os.Stat(caKeyPath); err != nil {
-		return fmt.Errorf("Caddy CA key not found at %s", caKeyPath)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("Caddy CA key not found at %s", caKeyPath)
+		}
+		return fmt.Errorf("cannot access Caddy CA key at %s: %w", caKeyPath, err)
 	}
 
 	certsDir := CertsDir()

--- a/internal/certs/storage_test.go
+++ b/internal/certs/storage_test.go
@@ -99,12 +99,16 @@ func TestRemoveLinkedCerts(t *testing.T) {
 	}
 
 	for _, name := range []string{"app1.test", "app2.test"} {
-		if _, err := os.Stat(filepath.Join(certsDir, name+".crt")); !os.IsNotExist(err) {
-			t.Errorf("%s.crt should be removed", name)
+		for _, ext := range []string{".crt", ".key"} {
+			if _, err := os.Stat(filepath.Join(certsDir, name+ext)); !os.IsNotExist(err) {
+				t.Errorf("%s%s should be removed", name, ext)
+			}
 		}
 	}
 
-	if _, err := os.Stat(filepath.Join(certsDir, "other.test.crt")); err != nil {
-		t.Error("other.test.crt should NOT be removed")
+	for _, ext := range []string{".crt", ".key"} {
+		if _, err := os.Stat(filepath.Join(certsDir, "other.test"+ext)); err != nil {
+			t.Errorf("other.test%s should NOT be removed", ext)
+		}
 	}
 }

--- a/internal/certs/valet.go
+++ b/internal/certs/valet.go
@@ -1,7 +1,6 @@
 package certs
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -10,60 +9,23 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-// ValetConfigDir returns ~/.config/valet (where laravel-vite-plugin looks for
-// Valet on macOS). pv populates this so Vite auto-detects TLS certificates.
-func ValetConfigDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("cannot determine home directory: %w", err)
-	}
-	return filepath.Join(home, ".config", "valet"), nil
+// CertsDir returns ~/.pv/data/certs/.
+func CertsDir() string {
+	return filepath.Join(config.DataDir(), "certs")
 }
 
-// ValetCertsDir returns ~/.config/valet/Certificates.
-func ValetCertsDir() (string, error) {
-	dir, err := ValetConfigDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "Certificates"), nil
+// CertPath returns the full path to a site certificate.
+func CertPath(hostname string) string {
+	return filepath.Join(CertsDir(), hostname+".crt")
 }
 
-// EnsureValetConfig writes the TLD to ~/.config/valet/config.json for
-// laravel-vite-plugin's TLS certificate discovery. Merges with any existing
-// config.json to avoid destroying real Valet settings.
-func EnsureValetConfig(tld string) error {
-	dir, err := ValetConfigDir()
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Join(dir, "Certificates"), 0755); err != nil {
-		return fmt.Errorf("cannot create valet config dir: %w", err)
-	}
-
-	configPath := filepath.Join(dir, "config.json")
-
-	// Read existing config to preserve other fields (e.g., real Valet settings).
-	cfg := make(map[string]any)
-	if data, err := os.ReadFile(configPath); err == nil {
-		_ = json.Unmarshal(data, &cfg) // ignore parse errors, overwrite corrupt file
-	}
-
-	cfg["tld"] = tld
-
-	data, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		return fmt.Errorf("cannot marshal valet config: %w", err)
-	}
-	if err := os.WriteFile(configPath, data, 0644); err != nil {
-		return fmt.Errorf("cannot write valet config: %w", err)
-	}
-	return nil
+// KeyPath returns the full path to a site private key.
+func KeyPath(hostname string) string {
+	return filepath.Join(CertsDir(), hostname+".key")
 }
 
 // GenerateSiteTLS generates a TLS cert/key pair for hostname and places them
-// in the Valet Certificates directory where laravel-vite-plugin expects them.
-// Uses Caddy's local CA to sign the certificate.
+// in the pv certs directory. Uses Caddy's local CA to sign the certificate.
 func GenerateSiteTLS(hostname string) error {
 	caCertPath := config.CACertPath()
 	caKeyPath := config.CAKeyPath()
@@ -75,65 +37,38 @@ func GenerateSiteTLS(hostname string) error {
 		return fmt.Errorf("Caddy CA key not found at %s", caKeyPath)
 	}
 
-	certsDir, err := ValetCertsDir()
-	if err != nil {
-		return err
-	}
+	certsDir := CertsDir()
 	if err := os.MkdirAll(certsDir, 0755); err != nil {
-		return fmt.Errorf("cannot create certificates dir: %w", err)
+		return fmt.Errorf("cannot create certs dir: %w", err)
 	}
 
-	certPath := filepath.Join(certsDir, hostname+".crt")
-	keyPath := filepath.Join(certsDir, hostname+".key")
+	certPath := CertPath(hostname)
+	keyPath := KeyPath(hostname)
 
 	return GenerateSiteCert(hostname, caCertPath, caKeyPath, certPath, keyPath)
 }
 
-// RemoveSiteTLS removes the TLS cert/key pair for hostname from the Valet
-// Certificates directory. Returns nil if the files do not exist.
+// RemoveSiteTLS removes the TLS cert/key pair for hostname.
+// Returns nil if the files do not exist.
 func RemoveSiteTLS(hostname string) error {
-	certsDir, err := ValetCertsDir()
-	if err != nil {
-		return err
-	}
-
 	var errs []error
 	for _, ext := range []string{".crt", ".key"} {
-		if err := os.Remove(filepath.Join(certsDir, hostname+ext)); err != nil && !os.IsNotExist(err) {
+		if err := os.Remove(filepath.Join(CertsDir(), hostname+ext)); err != nil && !os.IsNotExist(err) {
 			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
 }
 
-// RemoveLinkedCerts removes TLS cert/key pairs for the given hostnames only.
-// Does not touch any other files in ~/.config/valet.
+// RemoveLinkedCerts removes TLS cert/key pairs for the given hostnames.
 func RemoveLinkedCerts(hostnames []string) error {
-	certsDir, err := ValetCertsDir()
-	if err != nil {
-		return err
-	}
-
 	var errs []error
 	for _, h := range hostnames {
 		for _, ext := range []string{".crt", ".key"} {
-			if err := os.Remove(filepath.Join(certsDir, h+ext)); err != nil && !os.IsNotExist(err) {
+			if err := os.Remove(filepath.Join(CertsDir(), h+ext)); err != nil && !os.IsNotExist(err) {
 				errs = append(errs, err)
 			}
 		}
 	}
 	return errors.Join(errs...)
-}
-
-// RemoveConfig removes the config.json file from ~/.config/valet.
-// Does not remove the directory itself or any other files.
-func RemoveConfig() error {
-	dir, err := ValetConfigDir()
-	if err != nil {
-		return err
-	}
-	if err := os.Remove(filepath.Join(dir, "config.json")); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
 }

--- a/internal/certs/valet_test.go
+++ b/internal/certs/valet_test.go
@@ -1,98 +1,51 @@
 package certs
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-func TestEnsureValetConfig(t *testing.T) {
+func TestCertsDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	if err := EnsureValetConfig("test"); err != nil {
-		t.Fatalf("EnsureValetConfig() error = %v", err)
-	}
-
-	// Verify config.json.
-	configPath := filepath.Join(home, ".config", "valet", "config.json")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("read config.json: %v", err)
-	}
-
-	var cfg map[string]any
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("parse config.json: %v", err)
-	}
-	if cfg["tld"] != "test" {
-		t.Errorf("TLD = %q, want %q", cfg["tld"], "test")
-	}
-
-	// Verify Certificates directory exists.
-	certsDir := filepath.Join(home, ".config", "valet", "Certificates")
-	info, err := os.Stat(certsDir)
-	if err != nil {
-		t.Fatalf("Certificates dir: %v", err)
-	}
-	if !info.IsDir() {
-		t.Error("Certificates is not a directory")
+	dir := CertsDir()
+	expected := filepath.Join(home, ".pv", "data", "certs")
+	if dir != expected {
+		t.Errorf("CertsDir() = %q, want %q", dir, expected)
 	}
 }
 
-func TestEnsureValetConfig_UpdatesTLD(t *testing.T) {
+func TestCertPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	if err := EnsureValetConfig("test"); err != nil {
-		t.Fatal(err)
-	}
-	if err := EnsureValetConfig("dev"); err != nil {
-		t.Fatal(err)
-	}
-
-	configPath := filepath.Join(home, ".config", "valet", "config.json")
-	data, _ := os.ReadFile(configPath)
-	var cfg map[string]any
-	json.Unmarshal(data, &cfg)
-
-	if cfg["tld"] != "dev" {
-		t.Errorf("TLD = %q, want %q after update", cfg["tld"], "dev")
+	p := CertPath("myapp.test")
+	expected := filepath.Join(home, ".pv", "data", "certs", "myapp.test.crt")
+	if p != expected {
+		t.Errorf("CertPath() = %q, want %q", p, expected)
 	}
 }
 
-func TestEnsureValetConfig_PreservesExistingFields(t *testing.T) {
+func TestKeyPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// Write a pre-existing config with extra fields (e.g., real Valet config).
-	configDir := filepath.Join(home, ".config", "valet")
-	os.MkdirAll(configDir, 0755)
-	existing := map[string]any{
-		"tld":      "local",
-		"loopback": "127.0.0.1",
-		"paths":    []string{"/home/user/Sites"},
+	p := KeyPath("myapp.test")
+	expected := filepath.Join(home, ".pv", "data", "certs", "myapp.test.key")
+	if p != expected {
+		t.Errorf("KeyPath() = %q, want %q", p, expected)
 	}
-	data, _ := json.Marshal(existing)
-	os.WriteFile(filepath.Join(configDir, "config.json"), data, 0644)
+}
 
-	if err := EnsureValetConfig("test"); err != nil {
-		t.Fatal(err)
-	}
+func TestGenerateSiteTLS(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
-	result, _ := os.ReadFile(filepath.Join(configDir, "config.json"))
-	var cfg map[string]any
-	json.Unmarshal(result, &cfg)
-
-	if cfg["tld"] != "test" {
-		t.Errorf("TLD = %q, want %q", cfg["tld"], "test")
-	}
-	if cfg["loopback"] != "127.0.0.1" {
-		t.Error("existing loopback field was lost")
-	}
-	if cfg["paths"] == nil {
-		t.Error("existing paths field was lost")
+	err := GenerateSiteTLS("myapp.test")
+	if err == nil {
+		t.Fatal("expected error when CA doesn't exist")
 	}
 }
 
@@ -100,10 +53,9 @@ func TestRemoveSiteTLS(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	certsDir := filepath.Join(home, ".config", "valet", "Certificates")
+	certsDir := CertsDir()
 	os.MkdirAll(certsDir, 0755)
 
-	// Create dummy cert files.
 	certPath := filepath.Join(certsDir, "myapp.test.crt")
 	keyPath := filepath.Join(certsDir, "myapp.test.key")
 	os.WriteFile(certPath, []byte("cert"), 0644)
@@ -125,7 +77,6 @@ func TestRemoveSiteTLS_NonExistent(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	// Should not error on non-existent files.
 	if err := RemoveSiteTLS("nonexistent.test"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -135,82 +86,25 @@ func TestRemoveLinkedCerts(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	certsDir := filepath.Join(home, ".config", "valet", "Certificates")
+	certsDir := CertsDir()
 	os.MkdirAll(certsDir, 0755)
 
-	// Create certs for two "linked" apps and one "other" app.
 	for _, name := range []string{"app1.test", "app2.test", "other.test"} {
 		os.WriteFile(filepath.Join(certsDir, name+".crt"), []byte("cert"), 0644)
 		os.WriteFile(filepath.Join(certsDir, name+".key"), []byte("key"), 0600)
 	}
 
-	// Only remove linked apps.
 	if err := RemoveLinkedCerts([]string{"app1.test", "app2.test"}); err != nil {
 		t.Fatalf("RemoveLinkedCerts() error = %v", err)
 	}
 
-	// Linked certs should be gone.
 	for _, name := range []string{"app1.test", "app2.test"} {
 		if _, err := os.Stat(filepath.Join(certsDir, name+".crt")); !os.IsNotExist(err) {
 			t.Errorf("%s.crt should be removed", name)
 		}
-		if _, err := os.Stat(filepath.Join(certsDir, name+".key")); !os.IsNotExist(err) {
-			t.Errorf("%s.key should be removed", name)
-		}
 	}
 
-	// Other cert should still exist.
 	if _, err := os.Stat(filepath.Join(certsDir, "other.test.crt")); err != nil {
 		t.Error("other.test.crt should NOT be removed")
-	}
-	if _, err := os.Stat(filepath.Join(certsDir, "other.test.key")); err != nil {
-		t.Error("other.test.key should NOT be removed")
-	}
-}
-
-func TestRemoveConfig(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	if err := EnsureValetConfig("test"); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := RemoveConfig(); err != nil {
-		t.Fatalf("RemoveConfig() error = %v", err)
-	}
-
-	configPath := filepath.Join(home, ".config", "valet", "config.json")
-	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
-		t.Error("config.json should be removed")
-	}
-
-	// Certificates directory should still exist.
-	certsDir := filepath.Join(home, ".config", "valet", "Certificates")
-	if _, err := os.Stat(certsDir); err != nil {
-		t.Error("Certificates dir should NOT be removed")
-	}
-}
-
-func TestRemoveConfig_NonExistent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	// Should not error when config doesn't exist.
-	if err := RemoveConfig(); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-func TestValetConfigDir_ReturnsAbsolutePath(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	dir, err := ValetConfigDir()
-	if err != nil {
-		t.Fatalf("ValetConfigDir() error = %v", err)
-	}
-	if !filepath.IsAbs(dir) {
-		t.Errorf("ValetConfigDir() = %q, want absolute path", dir)
 	}
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -58,6 +58,7 @@ type Automation struct {
 	CopyEnv           AutoMode `yaml:"copy_env,omitempty"`
 	GenerateKey       AutoMode `yaml:"generate_key,omitempty"`
 	SetAppURL         AutoMode `yaml:"set_app_url,omitempty"`
+	SetViteTLS        AutoMode `yaml:"set_vite_tls,omitempty"`
 	InstallOctane     AutoMode `yaml:"install_octane,omitempty"`
 	CreateDatabase    AutoMode `yaml:"create_database,omitempty"`
 	RunMigrations     AutoMode `yaml:"run_migrations,omitempty"`
@@ -86,6 +87,7 @@ func DefaultAutomation() Automation {
 		CopyEnv:            AutoOn,
 		GenerateKey:        AutoOn,
 		SetAppURL:          AutoOn,
+		SetViteTLS:         AutoOn,
 		InstallOctane:      AutoAsk,
 		CreateDatabase:     AutoOn,
 		RunMigrations:      AutoAsk,
@@ -120,6 +122,9 @@ func applyAutomationDefaults(a *Automation) {
 	}
 	if !validAutoMode(a.SetAppURL) {
 		a.SetAppURL = d.SetAppURL
+	}
+	if !validAutoMode(a.SetViteTLS) {
+		a.SetViteTLS = d.SetViteTLS
 	}
 	if !validAutoMode(a.InstallOctane) {
 		a.InstallOctane = d.InstallOctane

--- a/internal/config/settings_test.go
+++ b/internal/config/settings_test.go
@@ -212,6 +212,9 @@ func TestDefaultSettings_HasAutomationDefaults(t *testing.T) {
 	if a.SetAppURL != AutoOn {
 		t.Errorf("SetAppURL = %q, want %q", a.SetAppURL, AutoOn)
 	}
+	if a.SetViteTLS != AutoOn {
+		t.Errorf("SetViteTLS = %q, want %q", a.SetViteTLS, AutoOn)
+	}
 	if a.InstallOctane != AutoAsk {
 		t.Errorf("InstallOctane = %q, want %q", a.InstallOctane, AutoAsk)
 	}
@@ -304,6 +307,9 @@ func TestLoadSettings_MissingAutomationGetsDefaults(t *testing.T) {
 	}
 	if a.SetAppURL != AutoOn {
 		t.Errorf("SetAppURL = %q, want %q", a.SetAppURL, AutoOn)
+	}
+	if a.SetViteTLS != AutoOn {
+		t.Errorf("SetViteTLS = %q, want %q", a.SetViteTLS, AutoOn)
 	}
 	if a.InstallOctane != AutoAsk {
 		t.Errorf("InstallOctane = %q, want %q", a.InstallOctane, AutoAsk)

--- a/internal/laravel/steps.go
+++ b/internal/laravel/steps.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/services"
 )
 
@@ -108,6 +109,39 @@ func (s *SetAppURLStep) Run(ctx *automation.Context) (string, error) {
 		return "", fmt.Errorf("set APP_URL: %w", err)
 	}
 	return appURL, nil
+}
+
+// --- SetViteTLSStep ---
+
+// SetViteTLSStep sets VITE_DEV_SERVER_KEY and VITE_DEV_SERVER_CERT in .env
+// so laravel-vite-plugin can find the TLS certificate for the dev server.
+type SetViteTLSStep struct{}
+
+var _ automation.Step = (*SetViteTLSStep)(nil)
+
+func (s *SetViteTLSStep) Label() string  { return "Set Vite TLS" }
+func (s *SetViteTLSStep) Gate() string   { return "set_vite_tls" }
+func (s *SetViteTLSStep) Critical() bool { return false }
+
+func (s *SetViteTLSStep) ShouldRun(ctx *automation.Context) bool {
+	return isLaravel(ctx.ProjectType) && HasEnvFile(ctx.ProjectPath)
+}
+
+func (s *SetViteTLSStep) Run(ctx *automation.Context) (string, error) {
+	tld := ctx.TLD
+	if tld == "" {
+		tld = "test"
+	}
+	hostname := fmt.Sprintf("%s.%s", ctx.ProjectName, tld)
+	envPath := filepath.Join(ctx.ProjectPath, ".env")
+	vars := map[string]string{
+		"VITE_DEV_SERVER_CERT": certs.CertPath(hostname),
+		"VITE_DEV_SERVER_KEY":  certs.KeyPath(hostname),
+	}
+	if err := services.MergeDotEnv(envPath, "", vars); err != nil {
+		return "", fmt.Errorf("set Vite TLS: %w", err)
+	}
+	return hostname, nil
 }
 
 // --- InstallOctaneStep ---

--- a/internal/laravel/steps_test.go
+++ b/internal/laravel/steps_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/certs"
 	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/registry"
 	"github.com/prvious/pv/internal/services"
@@ -174,6 +175,75 @@ func TestSetAppURLStep_Run(t *testing.T) {
 	}
 	if env["APP_URL"] != "https://test-project.test" {
 		t.Errorf("APP_URL = %q, want %q", env["APP_URL"], "https://test-project.test")
+	}
+}
+
+// --- SetViteTLSStep tests ---
+
+func TestSetViteTLSStep_ShouldRun_TrueForLaravel(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_URL=http://localhost"), 0644)
+
+	step := &SetViteTLSStep{}
+	ctx := &automation.Context{ProjectType: "laravel", ProjectPath: dir}
+	if !step.ShouldRun(ctx) {
+		t.Error("expected ShouldRun=true for laravel with .env")
+	}
+}
+
+func TestSetViteTLSStep_ShouldRun_FalseWhenNoEnv(t *testing.T) {
+	dir := t.TempDir()
+	step := &SetViteTLSStep{}
+	ctx := &automation.Context{ProjectType: "laravel", ProjectPath: dir}
+	if step.ShouldRun(ctx) {
+		t.Error("expected ShouldRun=false when no .env")
+	}
+}
+
+func TestSetViteTLSStep_ShouldRun_FalseForPHP(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte(""), 0644)
+	step := &SetViteTLSStep{}
+	ctx := &automation.Context{ProjectType: "php", ProjectPath: dir}
+	if step.ShouldRun(ctx) {
+		t.Error("expected ShouldRun=false for php")
+	}
+}
+
+func TestSetViteTLSStep_Run(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_URL=https://myapp.test\n"), 0644)
+
+	step := &SetViteTLSStep{}
+	ctx := &automation.Context{
+		ProjectPath: dir,
+		ProjectName: "myapp",
+		TLD:         "test",
+	}
+
+	result, err := step.Run(ctx)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result == "" {
+		t.Error("expected non-empty result")
+	}
+
+	env, err := services.ReadDotEnv(filepath.Join(dir, ".env"))
+	if err != nil {
+		t.Fatalf("ReadDotEnv: %v", err)
+	}
+
+	certPath := certs.CertPath("myapp.test")
+	keyPath := certs.KeyPath("myapp.test")
+
+	if env["VITE_DEV_SERVER_CERT"] != certPath {
+		t.Errorf("VITE_DEV_SERVER_CERT = %q, want %q", env["VITE_DEV_SERVER_CERT"], certPath)
+	}
+	if env["VITE_DEV_SERVER_KEY"] != keyPath {
+		t.Errorf("VITE_DEV_SERVER_KEY = %q, want %q", env["VITE_DEV_SERVER_KEY"], keyPath)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move TLS cert storage from `~/.config/valet/Certificates/` to `~/.pv/data/certs/`
- Write `VITE_DEV_SERVER_KEY` and `VITE_DEV_SERVER_CERT` to `.env` during `pv link` (new `SetViteTLSStep`)
- Remove all Valet config directory code (`EnsureValetConfig`, `RemoveConfig`, `config.json` management)
- Fixes `--name` flag mismatch: Vite plugin's `basename(cwd)` detection is bypassed entirely — env vars point directly to the correct cert

## Why

The Vite plugin resolves hostnames from `basename(cwd)`, not the link name. When `pv link --name=custom` is used, the old Valet auto-detection couldn't find certs. The plugin's second detection path (`VITE_DEV_SERVER_*` env vars) is explicit and immune to this mismatch.

Also: pv no longer pretends to be Valet by maintaining `~/.config/valet/`.

## Changes

- `internal/certs/valet.go` — Rewritten: `CertsDir()`, `CertPath()`, `KeyPath()`, `GenerateSiteTLS()`, `RemoveSiteTLS()`, `RemoveLinkedCerts()`
- `internal/laravel/steps.go` — New `SetViteTLSStep` automation step
- `internal/config/settings.go` — New `SetViteTLS` automation gate
- `internal/automation/pipeline.go` — New `"set_vite_tls"` gate case
- `cmd/link.go` — `SetViteTLSStep` added to pipeline
- `internal/automation/steps/generate_tls_cert.go` — Removed `EnsureValetConfig` call
- `cmd/setup.go` — Removed `EnsureValetConfig` call
- `cmd/uninstall.go` — Removed `RemoveConfig` call

## Test plan

- [x] New cert storage path tests (CertsDir, CertPath, KeyPath, RemoveSiteTLS, RemoveLinkedCerts)
- [x] SetViteTLSStep tests (ShouldRun + Run with .env verification)
- [x] Settings default and pipeline gate tests updated
- [x] Full test suite passes
- [x] Zero Valet references remaining in source
- [x] `gofmt` and `go vet` clean