### PR TITLE
Build and distribute standalone PHP CLI alongside FrankenPHP

### DIFF
--- a/.github/workflows/build-frankenphp.yml
+++ b/.github/workflows/build-frankenphp.yml
@@ -68,6 +68,20 @@ jobs:
         id: arch
         run: echo "arch=$(uname -m)" >> "$GITHUB_OUTPUT"
 
+      # Clone static-php-cli BEFORE restoring the downloads cache. The cache
+      # restores dist/static-php-cli/downloads/, which creates a parent
+      # dist/static-php-cli/ directory without src/. build-static.sh checks
+      # for static-php-cli/src to decide whether to clone; without this
+      # pre-clone, the cache-created directory wins and its fallback
+      # `git clone ... static-php-cli` fails with "destination path already
+      # exists". Pre-cloning ensures src/ is present, so build-static.sh
+      # takes the `cd static-php-cli/ && git pull` branch instead.
+      - name: Pre-clone static-php-cli
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          git clone --depth 1 https://github.com/crazywhalecc/static-php-cli dist/static-php-cli
+
       - name: Cache spc downloads
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build-frankenphp.yml
+++ b/.github/workflows/build-frankenphp.yml
@@ -82,6 +82,9 @@ jobs:
           FRANKENPHP_VERSION: ${{ needs.resolve-version.outputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPC_OPT_DOWNLOAD_ARGS: "--ignore-cache-sources=php-src --retry 5 --prefer-pre-built"
+          # Also build the standalone PHP CLI so it shares the exact same
+          # extension set as the FrankenPHP binary.
+          SPC_OPT_BUILD_ARGS: "--build-cli"
           CI: ""
           # xlswriter removed: its bundled minizip uses K&R function definitions
           # that C23 rejects (autoconf 2.73 enables -std=gnu23 by default).
@@ -116,6 +119,26 @@ jobs:
           path: dist/frankenphp-mac-${{ steps.arch.outputs.arch }}-php${{ matrix.php }}
           compression-level: 0
 
+      - name: Package PHP CLI
+        run: |
+          set -euo pipefail
+          ARCH="${{ steps.arch.outputs.arch }}"
+          PHP_BIN="dist/static-php-cli/buildroot/bin/php"
+          chmod +x "$PHP_BIN"
+          "$PHP_BIN" -v
+          "$PHP_BIN" -m
+          mkdir -p dist/cli-staging
+          cp "$PHP_BIN" dist/cli-staging/php
+          tar -C dist/cli-staging -czf "dist/php-mac-${ARCH}-php${{ matrix.php }}.tar.gz" php
+          rm -rf dist/cli-staging
+
+      - name: Upload PHP CLI
+        uses: actions/upload-artifact@v4
+        with:
+          name: php-mac-${{ steps.arch.outputs.arch }}-php${{ matrix.php }}
+          path: dist/php-mac-${{ steps.arch.outputs.arch }}-php${{ matrix.php }}.tar.gz
+          compression-level: 0
+
   release:
     needs: [resolve-version, build]
     runs-on: ubuntu-latest
@@ -127,13 +150,25 @@ jobs:
           pattern: frankenphp-mac-*
           path: artifacts
 
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: php-mac-*
+          path: artifacts
+
       - name: Prepare release assets
         run: |
           mkdir -p release
+          # FrankenPHP binaries: artifact dir name matches the binary name.
           for dir in artifacts/frankenphp-mac-*; do
+            [ -d "$dir" ] || continue
             name=$(basename "$dir")
             cp "$dir"/* "release/"
             chmod +x "release/${name}"
+          done
+          # PHP CLI tarballs: just copy as-is (no chmod needed).
+          for dir in artifacts/php-mac-*; do
+            [ -d "$dir" ] || continue
+            cp "$dir"/* "release/"
           done
           ls -la release/
 
@@ -152,9 +187,9 @@ jobs:
             exit 1
           fi
 
-          echo "Uploading FrankenPHP assets to $LATEST_TAG"
+          echo "Uploading FrankenPHP + PHP CLI assets to $LATEST_TAG"
           gh release upload "$LATEST_TAG" release/* \
             --repo "${{ github.repository }}" \
             --clobber
 
-          echo "FrankenPHP assets uploaded to $LATEST_TAG"
+          echo "Assets uploaded to $LATEST_TAG"

--- a/.github/workflows/build-frankenphp.yml
+++ b/.github/workflows/build-frankenphp.yml
@@ -141,6 +141,10 @@ jobs:
 
   release:
     needs: [resolve-version, build]
+    # Only publish from main. Dispatching from a feature branch runs the build
+    # matrix as a test of the PHP/FrankenPHP binary builds without touching
+    # the published release.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -157,17 +161,43 @@ jobs:
 
       - name: Prepare release assets
         run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          fp_dirs=(artifacts/frankenphp-mac-*)
+          php_dirs=(artifacts/php-mac-*)
+
+          # Never publish an incomplete release. Every FrankenPHP binary must
+          # ship with a matching PHP CLI tarball for the same arch+version.
+          if [ ${#fp_dirs[@]} -eq 0 ]; then
+            echo "::error::No FrankenPHP artifacts were downloaded"
+            exit 1
+          fi
+          if [ ${#php_dirs[@]} -eq 0 ]; then
+            echo "::error::No PHP CLI artifacts were downloaded"
+            exit 1
+          fi
+          if [ ${#fp_dirs[@]} -ne ${#php_dirs[@]} ]; then
+            echo "::error::Artifact count mismatch: ${#fp_dirs[@]} FrankenPHP vs ${#php_dirs[@]} PHP CLI"
+            exit 1
+          fi
+          for dir in "${fp_dirs[@]}"; do
+            suffix="${dir#artifacts/frankenphp-}"
+            if [ ! -d "artifacts/php-${suffix}" ]; then
+              echo "::error::Missing PHP CLI artifact for frankenphp-${suffix}"
+              exit 1
+            fi
+          done
+
           mkdir -p release
           # FrankenPHP binaries: artifact dir name matches the binary name.
-          for dir in artifacts/frankenphp-mac-*; do
-            [ -d "$dir" ] || continue
+          for dir in "${fp_dirs[@]}"; do
             name=$(basename "$dir")
             cp "$dir"/* "release/"
             chmod +x "release/${name}"
           done
           # PHP CLI tarballs: just copy as-is (no chmod needed).
-          for dir in artifacts/php-mac-*; do
-            [ -d "$dir" ] || continue
+          for dir in "${php_dirs[@]}"; do
             cp "$dir"/* "release/"
           done
           ls -la release/

--- a/internal/binaries/versions.go
+++ b/internal/binaries/versions.go
@@ -6,9 +6,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/prvious/pv/internal/config"
@@ -120,26 +117,4 @@ func SetGitHubHeaders(req *http.Request) {
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-}
-
-// ParseFrankenPHPPhpVersion extracts the PHP version from `frankenphp version` output.
-// Example input: "FrankenPHP v1.11.3 PHP 8.5.3 Caddy/v2.9.1 h1:..."
-// Returns: "8.5.3"
-func ParseFrankenPHPPhpVersion(output string) (string, error) {
-	re := regexp.MustCompile(`PHP (\d+\.\d+\.\d+)`)
-	matches := re.FindStringSubmatch(output)
-	if len(matches) < 2 {
-		return "", fmt.Errorf("could not parse PHP version from FrankenPHP output: %s", output)
-	}
-	return matches[1], nil
-}
-
-// DetectPHPVersion runs `frankenphp version` and parses the embedded PHP version.
-func DetectPHPVersion(binDir string) (string, error) {
-	frankenphpPath := filepath.Join(binDir, "frankenphp")
-	out, err := exec.Command(frankenphpPath, "version").Output()
-	if err != nil {
-		return "", fmt.Errorf("run frankenphp version: %w", err)
-	}
-	return ParseFrankenPHPPhpVersion(string(out))
 }

--- a/internal/binaries/versions_test.go
+++ b/internal/binaries/versions_test.go
@@ -114,59 +114,6 @@ func TestFetchLatestVersion_GitHub(t *testing.T) {
 	}
 }
 
-func TestParseFrankenPHPPhpVersion(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		want    string
-		wantErr bool
-	}{
-		{
-			name:  "standard output",
-			input: "FrankenPHP v1.11.3 PHP 8.5.3 Caddy/v2.9.1 h1:abc",
-			want:  "8.5.3",
-		},
-		{
-			name:  "different version",
-			input: "FrankenPHP v1.4.0 PHP 8.4.2 Caddy/v2.8.4 h1:xyz",
-			want:  "8.4.2",
-		},
-		{
-			name:  "multiline output",
-			input: "FrankenPHP v1.11.3 PHP 8.5.3 Caddy/v2.9.1 h1:abc\nsome other line",
-			want:  "8.5.3",
-		},
-		{
-			name:    "no PHP version",
-			input:   "FrankenPHP v1.11.3 Caddy/v2.9.1",
-			wantErr: true,
-		},
-		{
-			name:    "empty input",
-			input:   "",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseFrankenPHPPhpVersion(tt.input)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("ParseFrankenPHPPhpVersion() error = nil, want error")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("ParseFrankenPHPPhpVersion() error = %v", err)
-			}
-			if got != tt.want {
-				t.Errorf("ParseFrankenPHPPhpVersion() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
 // urlRewriteTransport redirects all requests to a test server URL.
 type urlRewriteTransport struct {
 	base    http.RoundTripper

--- a/internal/phpenv/install.go
+++ b/internal/phpenv/install.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	// releaseRepo is the GitHub repository hosting custom FrankenPHP builds.
+	// releaseRepo is the GitHub repository hosting custom FrankenPHP + PHP CLI builds.
 	releaseRepo = "prvious/pv"
 )
 
@@ -52,14 +52,9 @@ func InstallProgress(client *http.Client, phpVersion string, progress binaries.P
 		return err
 	}
 
-	// 3. Detect the full PHP version from the binary.
-	fullVersion, err := binaries.DetectPHPVersion(versionDir)
-	if err != nil {
-		fullVersion = phpVersion + ".0"
-	}
-
-	// 4. Download PHP CLI from static-php.dev.
-	phpURL, err := phpCLIURL(fullVersion)
+	// 3. Download PHP CLI from the same release. Built alongside FrankenPHP
+	// so both binaries share an identical extension set.
+	phpURL, err := phpCLIURL(tag, phpVersion)
 	if err != nil {
 		return err
 	}
@@ -149,24 +144,12 @@ func platformName() (string, error) {
 	return name, nil
 }
 
-var phpArchNames = map[string]string{
-	"arm64": "aarch64",
-	"amd64": "x86_64",
-}
-
-var phpOSNames = map[string]string{
-	"darwin": "macos",
-	"linux":  "linux",
-}
-
-func phpCLIURL(fullVersion string) (string, error) {
-	arch, ok := phpArchNames[runtime.GOARCH]
-	if !ok {
-		return "", fmt.Errorf("unsupported architecture for PHP CLI: %s", runtime.GOARCH)
+// phpCLIURL returns the release asset URL for the static PHP CLI tarball.
+// Format: php-{platform}-php{version}.tar.gz (containing a `php` binary).
+func phpCLIURL(tag, phpVersion string) (string, error) {
+	platform, err := platformName()
+	if err != nil {
+		return "", err
 	}
-	osName, ok := phpOSNames[runtime.GOOS]
-	if !ok {
-		return "", fmt.Errorf("unsupported OS for PHP CLI: %s", runtime.GOOS)
-	}
-	return fmt.Sprintf("https://dl.static-php.dev/static-php-cli/common/php-%s-cli-%s-%s.tar.gz", fullVersion, osName, arch), nil
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s/php-%s-php%s.tar.gz", releaseRepo, tag, platform, phpVersion), nil
 }

--- a/internal/phpenv/install.go
+++ b/internal/phpenv/install.go
@@ -133,13 +133,17 @@ var platformNames = map[string]map[string]string{
 }
 
 func platformName() (string, error) {
-	archMap, ok := platformNames[runtime.GOOS]
+	return platformNameFor(runtime.GOOS, runtime.GOARCH)
+}
+
+func platformNameFor(goos, goarch string) (string, error) {
+	archMap, ok := platformNames[goos]
 	if !ok {
-		return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+		return "", fmt.Errorf("unsupported OS: %s", goos)
 	}
-	name, ok := archMap[runtime.GOARCH]
+	name, ok := archMap[goarch]
 	if !ok {
-		return "", fmt.Errorf("unsupported architecture: %s/%s", runtime.GOOS, runtime.GOARCH)
+		return "", fmt.Errorf("unsupported architecture: %s/%s", goos, goarch)
 	}
 	return name, nil
 }

--- a/internal/phpenv/install_test.go
+++ b/internal/phpenv/install_test.go
@@ -1,0 +1,71 @@
+package phpenv
+
+import (
+	"testing"
+)
+
+func TestPlatformNameFor(t *testing.T) {
+	tests := []struct {
+		goos, goarch string
+		want         string
+		wantErr      bool
+	}{
+		{"darwin", "arm64", "mac-arm64", false},
+		{"darwin", "amd64", "mac-x86_64", false},
+		{"linux", "amd64", "linux-x86_64", false},
+		{"linux", "arm64", "linux-aarch64", false},
+		{"windows", "amd64", "", true},
+		{"darwin", "riscv64", "", true},
+	}
+
+	for _, tt := range tests {
+		name := tt.goos + "/" + tt.goarch
+		t.Run(name, func(t *testing.T) {
+			got, err := platformNameFor(tt.goos, tt.goarch)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("platformNameFor(%q, %q) error = nil, want error", tt.goos, tt.goarch)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("platformNameFor(%q, %q) error = %v", tt.goos, tt.goarch, err)
+			}
+			if got != tt.want {
+				t.Errorf("platformNameFor(%q, %q) = %q, want %q", tt.goos, tt.goarch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFrankenPHPAssetName(t *testing.T) {
+	platform, err := platformName()
+	if err != nil {
+		t.Skipf("unsupported platform: %v", err)
+	}
+
+	got, err := frankenphpAssetName("8.4")
+	if err != nil {
+		t.Fatalf("frankenphpAssetName() error = %v", err)
+	}
+	want := "frankenphp-" + platform + "-php8.4"
+	if got != want {
+		t.Errorf("frankenphpAssetName() = %q, want %q", got, want)
+	}
+}
+
+func TestPHPCLIURL(t *testing.T) {
+	platform, err := platformName()
+	if err != nil {
+		t.Skipf("unsupported platform: %v", err)
+	}
+
+	got, err := phpCLIURL("v1.2.3", "8.4")
+	if err != nil {
+		t.Fatalf("phpCLIURL() error = %v", err)
+	}
+	want := "https://github.com/prvious/pv/releases/download/v1.2.3/php-" + platform + "-php8.4.tar.gz"
+	if got != want {
+		t.Errorf("phpCLIURL() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds support for building and distributing a standalone PHP CLI binary that shares the exact same extension set as the FrankenPHP binary. Previously, the PHP CLI was downloaded from static-php.dev, which could have different extensions. Now both binaries are built together and distributed from the same release.

## Key Changes

- **Build Configuration**: Added `SPC_OPT_BUILD_ARGS: "--build-cli"` to the build workflow to compile the standalone PHP CLI alongside FrankenPHP
- **Artifact Packaging**: Added new workflow steps to package the compiled PHP CLI binary into a tarball (`php-mac-{arch}-php{version}.tar.gz`)
- **Release Management**: Updated the release job to download and upload both FrankenPHP and PHP CLI artifacts
- **Installation Logic**: Modified `phpCLIURL()` to download the PHP CLI from the same GitHub release as FrankenPHP instead of from static-php.dev, ensuring version consistency and identical extension sets
- **Documentation**: Updated comments to reflect that both FrankenPHP and PHP CLI are now built and distributed together

## Implementation Details

- The PHP CLI is built using the same static-php-cli build process with the `--build-cli` flag
- The binary is packaged as a gzipped tarball containing a single `php` executable
- The download URL now uses the release tag and version to fetch from the custom build repository (`prvious/pv`)
- Removed the previous logic that attempted to detect the full PHP version from the binary and map architecture/OS names, as the new approach uses the release tag directly

https://claude.ai/code/session_012F7YzeARQRFMj3SbKDRpic