### PR TITLE
Fix .env fallback semantics for binary services

### DIFF
--- a/docs/superpowers/plans/2026-04-17-binary-service-fallbacks.md
+++ b/docs/superpowers/plans/2026-04-17-binary-service-fallbacks.md
@@ -1,0 +1,361 @@
+# Binary Service Fallback Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `.env` fallback application so binary services are skipped on transient stops but get proper fallback + unbind on permanent removal/destruction, matching Docker behavior.
+
+**Architecture:** Four surgical edits across three existing files. No new functions, no interface changes. Three new tests in the existing `hooks_test.go` file.
+
+**Tech Stack:** Go, existing `internal/commands/service/` package, existing `registry.UnbindService` and `laravel.FallbackMapping`.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-binary-service-fallbacks-design.md`
+
+**Branch:** `fix/binary-service-fallbacks` (already created). Three commits total.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|------|--------|---------------|
+| `internal/commands/service/hooks_test.go` | Modify | Add 3 new tests for mail fallback, stop-all skip, and unbind |
+| `internal/commands/service/stop.go` | Modify | Skip binary services in the no-args fallback loop (line 65) |
+| `internal/commands/service/remove.go` | Modify | Add fallback + unbind to the binary path (after line 71) |
+| `internal/commands/service/destroy.go` | Modify | Add fallback + unbind to the binary path (after line 75) + add fallback before unbind in Docker path (line 128) |
+
+---
+
+## Task 1: Add tests + fix stop.go
+
+**Files:**
+- Modify: `internal/commands/service/hooks_test.go`
+- Modify: `internal/commands/service/stop.go`
+
+Three new tests, plus the stop.go fix. All tests go in `hooks_test.go` alongside the existing `TestApplyFallbacksToLinkedProjects_Integration`.
+
+- [ ] **Step 1: Write the mail fallback integration test**
+
+Append to `internal/commands/service/hooks_test.go`:
+
+```go
+func TestApplyFallbacksToLinkedProjects_Mail(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	projectDir := t.TempDir()
+	envPath := filepath.Join(projectDir, ".env")
+	os.WriteFile(envPath, []byte("MAIL_MAILER=smtp\n"), 0644)
+
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{
+			"mail": {Kind: "binary", Port: 1025},
+		},
+		Projects: []registry.Project{
+			{Name: "test-app", Path: projectDir, Type: "laravel",
+				Services: &registry.ProjectServices{Mail: true}},
+		},
+	}
+
+	origConfirm := automation.ConfirmFunc
+	automation.ConfirmFunc = func(label string) (bool, error) { return true, nil }
+	defer func() { automation.ConfirmFunc = origConfirm }()
+
+	applyFallbacksToLinkedProjects(reg, "mail")
+
+	env, _ := services.ReadDotEnv(envPath)
+	if env["MAIL_MAILER"] != "log" {
+		t.Errorf("MAIL_MAILER = %q, want log", env["MAIL_MAILER"])
+	}
+}
+```
+
+- [ ] **Step 2: Write the stop-all skip test**
+
+Append to `internal/commands/service/hooks_test.go`:
+
+```go
+// TestStopAllFallbackLoop_SkipsBinaryServices simulates the stop-all fallback
+// loop from stop.go:64-68 and verifies that binary services are skipped while
+// Docker services still get fallbacks applied.
+func TestStopAllFallbackLoop_SkipsBinaryServices(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Two linked projects: one using redis (Docker), one using mail (binary).
+	redisProjectDir := t.TempDir()
+	os.WriteFile(filepath.Join(redisProjectDir, ".env"),
+		[]byte("CACHE_STORE=redis\n"), 0644)
+
+	mailProjectDir := t.TempDir()
+	os.WriteFile(filepath.Join(mailProjectDir, ".env"),
+		[]byte("MAIL_MAILER=smtp\n"), 0644)
+
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{
+			"redis": {Image: "redis:latest", Port: 6379},
+			"mail":  {Kind: "binary", Port: 1025},
+		},
+		Projects: []registry.Project{
+			{Name: "redis-app", Path: redisProjectDir, Type: "laravel",
+				Services: &registry.ProjectServices{Redis: true}},
+			{Name: "mail-app", Path: mailProjectDir, Type: "laravel",
+				Services: &registry.ProjectServices{Mail: true}},
+		},
+	}
+
+	origConfirm := automation.ConfirmFunc
+	automation.ConfirmFunc = func(label string) (bool, error) { return true, nil }
+	defer func() { automation.ConfirmFunc = origConfirm }()
+
+	// Simulate the stop-all fallback loop (same logic as stop.go:64-68).
+	for key, inst := range reg.ListServices() {
+		if inst.Kind == "binary" {
+			continue
+		}
+		svcName, _ := services.ParseServiceKey(key)
+		applyFallbacksToLinkedProjects(reg, svcName)
+	}
+
+	// Docker service (redis) should have fallback applied.
+	redisEnv, _ := services.ReadDotEnv(filepath.Join(redisProjectDir, ".env"))
+	if redisEnv["CACHE_STORE"] != "file" {
+		t.Errorf("redis CACHE_STORE = %q, want file", redisEnv["CACHE_STORE"])
+	}
+
+	// Binary service (mail) should NOT have fallback applied.
+	mailEnv, _ := services.ReadDotEnv(filepath.Join(mailProjectDir, ".env"))
+	if mailEnv["MAIL_MAILER"] != "smtp" {
+		t.Errorf("mail MAIL_MAILER = %q, want smtp (should NOT have been changed)",
+			mailEnv["MAIL_MAILER"])
+	}
+}
+```
+
+- [ ] **Step 3: Write the unbind test**
+
+Append to `internal/commands/service/hooks_test.go`:
+
+```go
+func TestUnbindService_ClearsMailBinding(t *testing.T) {
+	reg := &registry.Registry{
+		Projects: []registry.Project{
+			{Name: "test-app", Path: "/tmp/test",
+				Services: &registry.ProjectServices{Mail: true, Redis: true}},
+		},
+	}
+
+	reg.UnbindService("mail")
+
+	project := reg.Find("test-app")
+	if project.Services.Mail {
+		t.Error("ProjectServices.Mail should be false after UnbindService")
+	}
+	// Redis should be untouched.
+	if !project.Services.Redis {
+		t.Error("ProjectServices.Redis should still be true")
+	}
+}
+```
+
+- [ ] **Step 4: Run tests — mail + unbind should PASS, stop-all skip should FAIL**
+
+```bash
+go test ./internal/commands/service/ -run "TestApplyFallbacksToLinkedProjects_Mail|TestStopAllFallbackLoop_SkipsBinaryServices|TestUnbindService_ClearsMailBinding" -v
+```
+
+Expected:
+- `TestApplyFallbacksToLinkedProjects_Mail` — PASS (function already works for mail).
+- `TestUnbindService_ClearsMailBinding` — PASS (registry.UnbindService already handles "mail").
+- `TestStopAllFallbackLoop_SkipsBinaryServices` — PASS (the test simulates the FIXED loop logic with the skip — it doesn't exercise the production bug in stop.go, it exercises the correct loop pattern that we'll wire into stop.go in Step 5).
+
+All three tests should pass because they test the underlying functions (which work) and the correct loop logic (which the test itself implements). The production code in `stop.go` still has the bug, but that's an integration gap, not a unit test concern — the test pins the correct behavior so future regressions break it.
+
+**If all 3 PASS**, proceed to Step 5. If any FAIL, debug before continuing.
+
+- [ ] **Step 5: Fix `stop.go:64-68` — skip binary services in the fallback loop**
+
+Edit `internal/commands/service/stop.go`. Replace lines 64-68:
+
+Before:
+```go
+			// Apply fallbacks for each stopped service.
+			for key := range reg.ListServices() {
+				svcName, _ := services.ParseServiceKey(key)
+				applyFallbacksToLinkedProjects(reg, svcName)
+			}
+```
+
+After:
+```go
+			// Apply fallbacks for each stopped service.
+			for key, inst := range reg.ListServices() {
+				if inst.Kind == "binary" {
+					continue // binary services were not stopped above; no fallback needed.
+				}
+				svcName, _ := services.ParseServiceKey(key)
+				applyFallbacksToLinkedProjects(reg, svcName)
+			}
+```
+
+- [ ] **Step 6: Run tests + build**
+
+```bash
+gofmt -w internal/commands/service/
+go vet ./internal/commands/service/
+go test ./internal/commands/service/ -v
+go build ./...
+```
+
+Expected: PASS for all tests in the package (the 3 new ones + the existing `TestApplyFallbacksToLinkedProjects_Integration`). Build clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/commands/service/hooks_test.go internal/commands/service/stop.go
+git commit -m "stop: skip binary services in stop-all fallback loop
+
+The no-args stop command skips binary services in the container-stop
+loop (they're managed by the daemon) but then applied .env fallbacks
+to ALL registered services, including binaries that were never stopped.
+This rewrote e.g. MAIL_MAILER=smtp → log in linked projects' .env
+while mail was still supervised and listening.
+
+Fix: skip inst.Kind == \"binary\" entries in the fallback loop.
+
+Also adds three new tests:
+- mail fallback integration (pins FallbackMapping(\"mail\") wiring)
+- stop-all loop simulating the correct skip behavior
+- unbind clears ProjectServices.Mail"
+```
+
+---
+
+## Task 2: Add fallback + unbind to binary remove and destroy paths
+
+**Files:**
+- Modify: `internal/commands/service/remove.go`
+- Modify: `internal/commands/service/destroy.go`
+
+Two edits: binary `service:remove` and binary `service:destroy` both need `applyFallbacksToLinkedProjects` + `reg.UnbindService` + `reg.Save()` added to match their Docker counterparts.
+
+- [ ] **Step 1: Fix `remove.go` binary path — add fallback + unbind**
+
+Edit `internal/commands/service/remove.go`. After the daemon signal block and before the success message (between lines 71 and 72):
+
+Before:
+```go
+			if server.IsRunning() {
+				if err := server.SignalDaemon(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+				}
+			}
+			ui.Success(fmt.Sprintf("%s removed (data preserved)", binSvc.DisplayName()))
+```
+
+After:
+```go
+			if server.IsRunning() {
+				if err := server.SignalDaemon(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+				}
+			}
+			// Apply env fallbacks and unbind from linked projects — the binary
+			// is permanently gone. Mirrors the Docker path at remove.go:115-118.
+			applyFallbacksToLinkedProjects(reg, name)
+			reg.UnbindService(name)
+			if err := reg.Save(); err != nil {
+				return fmt.Errorf("cannot save registry: %w", err)
+			}
+			ui.Success(fmt.Sprintf("%s removed (data preserved)", binSvc.DisplayName()))
+```
+
+- [ ] **Step 2: Fix `destroy.go` binary path — add fallback + unbind**
+
+Edit `internal/commands/service/destroy.go`. After the daemon signal block and before the success message (between lines 75 and 76):
+
+Before:
+```go
+			if server.IsRunning() {
+				if err := server.SignalDaemon(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+				}
+			}
+			ui.Success(fmt.Sprintf("%s destroyed (binary + data gone)", binSvc.DisplayName()))
+```
+
+After:
+```go
+			if server.IsRunning() {
+				if err := server.SignalDaemon(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+				}
+			}
+			// Apply env fallbacks and unbind from linked projects — the binary
+			// is permanently gone. Mirrors the Docker path pattern.
+			applyFallbacksToLinkedProjects(reg, name)
+			reg.UnbindService(name)
+			if err := reg.Save(); err != nil {
+				return fmt.Errorf("cannot save registry: %w", err)
+			}
+			ui.Success(fmt.Sprintf("%s destroyed (binary + data gone)", binSvc.DisplayName()))
+```
+
+- [ ] **Step 3: Fix `destroy.go` Docker path — add fallback before existing unbind**
+
+Edit `internal/commands/service/destroy.go`. At lines 128-130, add the fallback call before the existing unbind:
+
+Before:
+```go
+		// Unbind from all projects.
+		projects := reg.ProjectsUsingService(svcName)
+		reg.UnbindService(svcName)
+```
+
+After:
+```go
+		// Apply fallbacks and unbind from all projects.
+		applyFallbacksToLinkedProjects(reg, svcName)
+		projects := reg.ProjectsUsingService(svcName)
+		reg.UnbindService(svcName)
+```
+
+- [ ] **Step 4: Run tests + build**
+
+```bash
+gofmt -w internal/commands/service/
+go vet ./internal/commands/service/
+go test ./internal/commands/service/ -v
+go build ./...
+```
+
+Expected: PASS for all tests. Build clean.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: every package passes. This is the last task — confirm the whole tree is clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/commands/service/remove.go internal/commands/service/destroy.go
+git commit -m "remove/destroy: apply fallback + unbind for binary services
+
+Binary service:remove and service:destroy now apply .env fallbacks
+(e.g. MAIL_MAILER=smtp → log) and call reg.UnbindService to clear
+ProjectServices.Mail/S3 flags on linked projects, matching the
+existing behavior of their Docker counterparts.
+
+Also fixes a pre-existing Docker bug: service:destroy did not call
+applyFallbacksToLinkedProjects before unbinding, unlike service:remove
+which does both. Docker destroy now applies fallbacks too."
+```
+
+---
+
+## Parallelization Guide
+
+Linear. Task 2 depends on Task 1 (tests must be in place before the stop.go fix lands). Task 2's remove/destroy edits are independent of Task 1's stop.go fix, but keeping them sequential avoids cross-task git conflicts in the same package.
+
+Total: 2 commits on branch `fix/binary-service-fallbacks`. Whole branch lands in one PR.

--- a/docs/superpowers/specs/2026-04-16-binary-service-fallbacks-design.md
+++ b/docs/superpowers/specs/2026-04-16-binary-service-fallbacks-design.md
@@ -1,0 +1,138 @@
+# Binary Service Fallback Semantics
+
+**Date:** 2026-04-16
+**Status:** Approved
+
+## Problem
+
+After the rustfs and mailpit binary-service migrations, the `.env` fallback system (`applyFallbacksToLinkedProjects`) has two bugs:
+
+1. **False positive (stop.go:65-68):** `pv service:stop` (no args) applies fallbacks to all registered services, including binary services it didn't actually stop. Binary services are skipped in the stop loop (line 38-42, "managed by the daemon") but NOT skipped in the fallback loop. Result: linked Laravel projects have `MAIL_MAILER=smtp → log` rewritten even though mail is still supervised and listening.
+
+2. **Missing fallback on removal (remove.go / destroy.go binary paths):** `pv service:remove mail` and `pv service:destroy mail` permanently delete the binary but do NOT apply `.env` fallbacks to linked projects. The Docker equivalents DO apply fallbacks. Result: linked projects keep `MAIL_MAILER=smtp` after mail is gone; the next mail send fails with no hint.
+
+## Correct semantics
+
+| Operation | Binary actually stopped? | Fallback? | Rationale |
+|---|---|---|---|
+| `pv service:stop` (no args) | No (skipped in loop) | No | Binary is still supervised |
+| `pv service:stop mail` (named) | Yes (Enabled=false + daemon signal) | No | Transient — may come back via `service:start` |
+| `pv service:remove mail` | Yes (binary deleted) | **Yes** | Permanent removal |
+| `pv service:destroy mail` | Yes (binary + data deleted) | **Yes** | Permanent removal |
+
+## Goals
+
+- Fix the false positive: skip binary services in `stop.go`'s no-args fallback loop.
+- Fix the missing fallback: add `applyFallbacksToLinkedProjects` calls to the binary paths of `remove.go` and `destroy.go`.
+
+## Non-goals
+
+- Do not change Docker stop behavior (line 135-137 in `stop.go`). Docker `service:stop` currently applies fallbacks; changing that is a bigger semantic shift not requested by the user.
+- Do not modify `applyFallbacksToLinkedProjects` itself — it's kind-agnostic and already works for binary service names (via `laravel.FallbackMapping`).
+- Do not add fallback to the named binary `service:stop` path — user confirmed transient stops should not trigger fallback.
+
+## Changes
+
+Three surgical edits across three files. No new functions, no interface changes.
+
+### Edit 1: `internal/commands/service/stop.go:65-68`
+
+Skip binary services in the post-stop fallback loop.
+
+Before:
+```go
+for key := range reg.ListServices() {
+    svcName, _ := services.ParseServiceKey(key)
+    applyFallbacksToLinkedProjects(reg, svcName)
+}
+```
+
+After:
+```go
+for key, inst := range reg.ListServices() {
+    if inst.Kind == "binary" {
+        continue // binary services were not stopped above; no fallback needed.
+    }
+    svcName, _ := services.ParseServiceKey(key)
+    applyFallbacksToLinkedProjects(reg, svcName)
+}
+```
+
+### Edit 2: `internal/commands/service/remove.go` binary path (~line 71)
+
+Add fallback call before the success message.
+
+Before:
+```go
+            if server.IsRunning() {
+                if err := server.SignalDaemon(); err != nil {
+                    ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+                }
+            }
+            ui.Success(fmt.Sprintf("%s removed (data preserved)", binSvc.DisplayName()))
+```
+
+After:
+```go
+            if server.IsRunning() {
+                if err := server.SignalDaemon(); err != nil {
+                    ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+                }
+            }
+            // Apply env fallbacks to linked projects — the binary is permanently
+            // gone, so e.g. MAIL_MAILER should revert to "log".
+            applyFallbacksToLinkedProjects(reg, name)
+            ui.Success(fmt.Sprintf("%s removed (data preserved)", binSvc.DisplayName()))
+```
+
+### Edit 3: `internal/commands/service/destroy.go` binary path (~line 75)
+
+Add fallback call before the success message (same pattern as remove).
+
+Before:
+```go
+            if server.IsRunning() {
+                if err := server.SignalDaemon(); err != nil {
+                    ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+                }
+            }
+            ui.Success(fmt.Sprintf("%s destroyed (binary + data gone)", binSvc.DisplayName()))
+```
+
+After:
+```go
+            if server.IsRunning() {
+                if err := server.SignalDaemon(); err != nil {
+                    ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+                }
+            }
+            // Apply env fallbacks to linked projects — the binary is permanently
+            // gone, so e.g. MAIL_MAILER should revert to "log".
+            applyFallbacksToLinkedProjects(reg, name)
+            ui.Success(fmt.Sprintf("%s destroyed (binary + data gone)", binSvc.DisplayName()))
+```
+
+## Testing
+
+### New test: stop-all skips binary services
+
+In `internal/commands/service/hooks_test.go`, add a test that:
+1. Creates a registry with a binary service ("mail", Kind="binary") and a linked Laravel project whose `.env` has `MAIL_MAILER=smtp`.
+2. Calls `applyFallbacksToLinkedProjects` with the same name — verifies it WOULD change `MAIL_MAILER` to `log` (the function itself works).
+3. Separately, the stop-all fallback loop's `inst.Kind == "binary"` skip is a control-flow guard, not a function-level behavior. The unit test of the function itself confirms it's kind-agnostic; the skip is verified by reading the code.
+
+The stop-all skip is hard to unit-test without running the full cobra command (needs Docker engine setup). A targeted code-review assertion is acceptable here — the fix is 2 lines (`if inst.Kind == "binary" { continue }`).
+
+### New test: fallback works for mail service
+
+In `hooks_test.go`, add a test mirroring the existing Redis one but for mail: register a mail binary service, set up a linked project with `MAIL_MAILER=smtp`, call `applyFallbacksToLinkedProjects(reg, "mail")`, assert `MAIL_MAILER=log`. This pins the `FallbackMapping("mail")` wiring for the remove/destroy paths.
+
+### Existing tests
+
+The existing `TestApplyFallbacksToLinkedProjects_Integration` (Redis) and `TestFallbackMapping_Mail` / `TestFallbackMapping_S3` in `internal/laravel/env_test.go` are unaffected and continue to pass.
+
+## Verification items
+
+1. Confirm `laravel.FallbackMapping("mail")` returns rules for `MAIL_MAILER` → `log`. Already confirmed by reading `internal/laravel/env_test.go:125-134`.
+2. Confirm `remove.go` binary path has access to the `name` variable (service name, e.g., "mail") at the insertion point. Confirmed: `name := binSvc.Name()` at line 37.
+3. Confirm `destroy.go` binary path has the same `name` variable. Confirmed: `name := binSvc.Name()` at line 38.

--- a/docs/superpowers/specs/2026-04-16-binary-service-fallbacks-design.md
+++ b/docs/superpowers/specs/2026-04-16-binary-service-fallbacks-design.md
@@ -1,29 +1,32 @@
 # Binary Service Fallback Semantics
 
-**Date:** 2026-04-16
+**Date:** 2026-04-16 (revised 2026-04-17)
 **Status:** Approved
 
 ## Problem
 
-After the rustfs and mailpit binary-service migrations, the `.env` fallback system (`applyFallbacksToLinkedProjects`) has two bugs:
+After the rustfs and mailpit binary-service migrations, the `.env` fallback system (`applyFallbacksToLinkedProjects`) has three bugs:
 
 1. **False positive (stop.go:65-68):** `pv service:stop` (no args) applies fallbacks to all registered services, including binary services it didn't actually stop. Binary services are skipped in the stop loop (line 38-42, "managed by the daemon") but NOT skipped in the fallback loop. Result: linked Laravel projects have `MAIL_MAILER=smtp → log` rewritten even though mail is still supervised and listening.
 
-2. **Missing fallback on removal (remove.go / destroy.go binary paths):** `pv service:remove mail` and `pv service:destroy mail` permanently delete the binary but do NOT apply `.env` fallbacks to linked projects. The Docker equivalents DO apply fallbacks. Result: linked projects keep `MAIL_MAILER=smtp` after mail is gone; the next mail send fails with no hint.
+2. **Missing fallback + unbind on binary removal (remove.go / destroy.go binary paths):** `pv service:remove mail` and `pv service:destroy mail` permanently delete the binary but do NOT apply `.env` fallbacks to linked projects, and do NOT call `reg.UnbindService(name)` to clear the `ProjectServices.Mail` flag. The Docker `service:remove` path does both (remove.go:116-118). Result: linked projects keep `MAIL_MAILER=smtp` after mail is gone (next mail send fails), and `ProjectServices.Mail` stays set, leaking into `ProjectsUsingService`, `service:list`, and future fallback prompts.
+
+3. **Missing fallback on Docker destroy (destroy.go:128-130):** Docker `service:destroy` calls `reg.UnbindService(svcName)` but does NOT call `applyFallbacksToLinkedProjects` first — unlike Docker `service:remove` which does both. Result: `pv service:destroy mysql` unbinds the project but leaves `DB_CONNECTION=mysql` in the linked `.env` instead of falling back to `sqlite`. This is a pre-existing Docker bug, not introduced by the binary migrations.
 
 ## Correct semantics
 
-| Operation | Binary actually stopped? | Fallback? | Rationale |
-|---|---|---|---|
-| `pv service:stop` (no args) | No (skipped in loop) | No | Binary is still supervised |
-| `pv service:stop mail` (named) | Yes (Enabled=false + daemon signal) | No | Transient — may come back via `service:start` |
-| `pv service:remove mail` | Yes (binary deleted) | **Yes** | Permanent removal |
-| `pv service:destroy mail` | Yes (binary + data deleted) | **Yes** | Permanent removal |
+| Operation | Service gone? | Fallback? | Unbind? | Rationale |
+|---|---|---|---|---|
+| `pv service:stop` (no args) | Docker yes, Binary no | Docker yes, Binary **no** | No | Binary still supervised |
+| `pv service:stop <name>` (named) | Yes (both kinds) | No | No | Transient — may come back |
+| `pv service:remove <name>` | Yes (both kinds) | **Yes** | **Yes** | Permanent removal |
+| `pv service:destroy <name>` | Yes (both kinds) | **Yes** | **Yes** | Permanent removal + data |
 
 ## Goals
 
 - Fix the false positive: skip binary services in `stop.go`'s no-args fallback loop.
-- Fix the missing fallback: add `applyFallbacksToLinkedProjects` calls to the binary paths of `remove.go` and `destroy.go`.
+- Fix binary remove/destroy: add `applyFallbacksToLinkedProjects`, `reg.UnbindService`, and `reg.Save` to the binary paths so they match the Docker `service:remove` pattern.
+- Fix Docker destroy: add `applyFallbacksToLinkedProjects` before the existing `reg.UnbindService` call so destroy matches remove.
 
 ## Non-goals
 
@@ -33,7 +36,7 @@ After the rustfs and mailpit binary-service migrations, the `.env` fallback syst
 
 ## Changes
 
-Three surgical edits across three files. No new functions, no interface changes.
+Four surgical edits across three files. No new functions, no interface changes.
 
 ### Edit 1: `internal/commands/service/stop.go:65-68`
 
@@ -41,98 +44,133 @@ Skip binary services in the post-stop fallback loop.
 
 Before:
 ```go
-for key := range reg.ListServices() {
-    svcName, _ := services.ParseServiceKey(key)
-    applyFallbacksToLinkedProjects(reg, svcName)
-}
+			// Apply fallbacks for each stopped service.
+			for key := range reg.ListServices() {
+				svcName, _ := services.ParseServiceKey(key)
+				applyFallbacksToLinkedProjects(reg, svcName)
+			}
 ```
 
 After:
 ```go
-for key, inst := range reg.ListServices() {
-    if inst.Kind == "binary" {
-        continue // binary services were not stopped above; no fallback needed.
-    }
-    svcName, _ := services.ParseServiceKey(key)
-    applyFallbacksToLinkedProjects(reg, svcName)
-}
+			// Apply fallbacks for each stopped service.
+			for key, inst := range reg.ListServices() {
+				if inst.Kind == "binary" {
+					continue // binary services were not stopped above; no fallback needed.
+				}
+				svcName, _ := services.ParseServiceKey(key)
+				applyFallbacksToLinkedProjects(reg, svcName)
+			}
 ```
 
-### Edit 2: `internal/commands/service/remove.go` binary path (~line 71)
+### Edit 2: `internal/commands/service/remove.go` binary path
 
-Add fallback call before the success message.
+Add fallback + unbind after the daemon signal, before the success message. Mirrors the Docker path at remove.go:115-118 (`applyFallbacksToLinkedProjects` → `reg.UnbindService`).
 
-Before:
+Before (lines 67-72):
 ```go
-            if server.IsRunning() {
-                if err := server.SignalDaemon(); err != nil {
-                    ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
-                }
-            }
-            ui.Success(fmt.Sprintf("%s removed (data preserved)", binSvc.DisplayName()))
-```
-
-After:
-```go
-            if server.IsRunning() {
-                if err := server.SignalDaemon(); err != nil {
-                    ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
-                }
-            }
-            // Apply env fallbacks to linked projects — the binary is permanently
-            // gone, so e.g. MAIL_MAILER should revert to "log".
-            applyFallbacksToLinkedProjects(reg, name)
-            ui.Success(fmt.Sprintf("%s removed (data preserved)", binSvc.DisplayName()))
-```
-
-### Edit 3: `internal/commands/service/destroy.go` binary path (~line 75)
-
-Add fallback call before the success message (same pattern as remove).
-
-Before:
-```go
-            if server.IsRunning() {
-                if err := server.SignalDaemon(); err != nil {
-                    ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
-                }
-            }
-            ui.Success(fmt.Sprintf("%s destroyed (binary + data gone)", binSvc.DisplayName()))
+			if server.IsRunning() {
+				if err := server.SignalDaemon(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+				}
+			}
+			ui.Success(fmt.Sprintf("%s removed (data preserved)", binSvc.DisplayName()))
 ```
 
 After:
 ```go
-            if server.IsRunning() {
-                if err := server.SignalDaemon(); err != nil {
-                    ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
-                }
-            }
-            // Apply env fallbacks to linked projects — the binary is permanently
-            // gone, so e.g. MAIL_MAILER should revert to "log".
-            applyFallbacksToLinkedProjects(reg, name)
-            ui.Success(fmt.Sprintf("%s destroyed (binary + data gone)", binSvc.DisplayName()))
+			if server.IsRunning() {
+				if err := server.SignalDaemon(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+				}
+			}
+			// Apply env fallbacks and unbind from linked projects — the binary
+			// is permanently gone. Mirrors the Docker path at remove.go:115-118.
+			applyFallbacksToLinkedProjects(reg, name)
+			reg.UnbindService(name)
+			if err := reg.Save(); err != nil {
+				return fmt.Errorf("cannot save registry: %w", err)
+			}
+			ui.Success(fmt.Sprintf("%s removed (data preserved)", binSvc.DisplayName()))
+```
+
+Note: `reg.Save()` is needed because `UnbindService` mutates the in-memory registry but does not persist — the existing `reg.Save()` at line 44-46 was called BEFORE the binary cleanup, so the unbind mutation must be saved separately. The Docker path avoids this because its unbind happens AFTER `reg.RemoveService` + `reg.Save` at lines 120-125, which saves both the removal and the unbind in one call. For the binary path, the service was already removed and saved at lines 41-46, so a second `reg.Save()` is required for the unbind.
+
+### Edit 3: `internal/commands/service/destroy.go` binary path
+
+Same pattern as Edit 2 — add fallback + unbind after the daemon signal.
+
+Before (lines 71-76):
+```go
+			if server.IsRunning() {
+				if err := server.SignalDaemon(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+				}
+			}
+			ui.Success(fmt.Sprintf("%s destroyed (binary + data gone)", binSvc.DisplayName()))
+```
+
+After:
+```go
+			if server.IsRunning() {
+				if err := server.SignalDaemon(); err != nil {
+					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
+				}
+			}
+			// Apply env fallbacks and unbind from linked projects — the binary
+			// is permanently gone. Mirrors the Docker path pattern.
+			applyFallbacksToLinkedProjects(reg, name)
+			reg.UnbindService(name)
+			if err := reg.Save(); err != nil {
+				return fmt.Errorf("cannot save registry: %w", err)
+			}
+			ui.Success(fmt.Sprintf("%s destroyed (binary + data gone)", binSvc.DisplayName()))
+```
+
+### Edit 4: `internal/commands/service/destroy.go` Docker path (~line 128)
+
+Add `applyFallbacksToLinkedProjects` before the existing `reg.UnbindService` so Docker destroy matches Docker remove.
+
+Before (lines 128-130):
+```go
+		// Unbind from all projects.
+		projects := reg.ProjectsUsingService(svcName)
+		reg.UnbindService(svcName)
+```
+
+After:
+```go
+		// Apply fallbacks and unbind from all projects.
+		applyFallbacksToLinkedProjects(reg, svcName)
+		projects := reg.ProjectsUsingService(svcName)
+		reg.UnbindService(svcName)
 ```
 
 ## Testing
 
-### New test: stop-all skips binary services
+### New test: mail fallback integration (hooks_test.go)
 
-In `internal/commands/service/hooks_test.go`, add a test that:
-1. Creates a registry with a binary service ("mail", Kind="binary") and a linked Laravel project whose `.env` has `MAIL_MAILER=smtp`.
-2. Calls `applyFallbacksToLinkedProjects` with the same name — verifies it WOULD change `MAIL_MAILER` to `log` (the function itself works).
-3. Separately, the stop-all fallback loop's `inst.Kind == "binary"` skip is a control-flow guard, not a function-level behavior. The unit test of the function itself confirms it's kind-agnostic; the skip is verified by reading the code.
+Mirror the existing Redis integration test for mail. Register a mail binary service, set up a linked Laravel project with `MAIL_MAILER=smtp`, call `applyFallbacksToLinkedProjects(reg, "mail")`, assert `MAIL_MAILER=log`. This pins the `FallbackMapping("mail")` wiring that the binary remove/destroy paths now depend on.
 
-The stop-all skip is hard to unit-test without running the full cobra command (needs Docker engine setup). A targeted code-review assertion is acceptable here — the fix is 2 lines (`if inst.Kind == "binary" { continue }`).
+### New test: stop-all skips binary fallback (hooks_test.go)
 
-### New test: fallback works for mail service
+Test the control-flow guard directly: create a registry with both a Docker service and a binary service, each with a linked project whose `.env` has service-specific values. Simulate the stop-all fallback loop (iterate `reg.ListServices()`, skip `Kind == "binary"`, apply fallbacks for the rest). Assert the Docker service's project got fallback-rewritten but the binary service's project did NOT.
 
-In `hooks_test.go`, add a test mirroring the existing Redis one but for mail: register a mail binary service, set up a linked project with `MAIL_MAILER=smtp`, call `applyFallbacksToLinkedProjects(reg, "mail")`, assert `MAIL_MAILER=log`. This pins the `FallbackMapping("mail")` wiring for the remove/destroy paths.
+This tests the exact loop logic from `stop.go:65-68` in isolation without needing a Docker engine. The test extracts the loop body into a helper-like pattern using the same `inst.Kind == "binary"` check the production code uses.
+
+### New test: unbind clears project binding (hooks_test.go)
+
+Register a mail binary service, bind a project to it (`ProjectServices.Mail = true`), call `reg.UnbindService("mail")`, assert `ProjectServices.Mail == false`. Pins the unbind wiring that binary remove/destroy now depend on.
 
 ### Existing tests
 
-The existing `TestApplyFallbacksToLinkedProjects_Integration` (Redis) and `TestFallbackMapping_Mail` / `TestFallbackMapping_S3` in `internal/laravel/env_test.go` are unaffected and continue to pass.
+- `TestApplyFallbacksToLinkedProjects_Integration` (Redis) — unaffected, continues to pass.
+- `TestFallbackMapping_Mail` / `TestFallbackMapping_S3` in `internal/laravel/env_test.go` — unaffected.
 
 ## Verification items
 
-1. Confirm `laravel.FallbackMapping("mail")` returns rules for `MAIL_MAILER` → `log`. Already confirmed by reading `internal/laravel/env_test.go:125-134`.
-2. Confirm `remove.go` binary path has access to the `name` variable (service name, e.g., "mail") at the insertion point. Confirmed: `name := binSvc.Name()` at line 37.
-3. Confirm `destroy.go` binary path has the same `name` variable. Confirmed: `name := binSvc.Name()` at line 38.
+1. `laravel.FallbackMapping("mail")` returns rules for `MAIL_MAILER` → `log`. Confirmed by `internal/laravel/env_test.go:125-134`.
+2. `remove.go` binary path: `name := binSvc.Name()` is in scope at the insertion point (line 37). Confirmed.
+3. `destroy.go` binary path: `name := binSvc.Name()` is in scope at the insertion point (line 38). Confirmed.
+4. `destroy.go` Docker path: `svcName` is in scope at the insertion point (assigned at line 94 via `services.ParseServiceKey`). Confirmed.
+5. `reg.UnbindService(name)` does not call `reg.Save()` internally — the caller must save. Confirmed by reading `internal/registry/registry.go`.

--- a/internal/commands/service/destroy.go
+++ b/internal/commands/service/destroy.go
@@ -73,6 +73,13 @@ var destroyCmd = &cobra.Command{
 					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
 				}
 			}
+			// Apply env fallbacks and unbind from linked projects — the binary
+			// is permanently gone. Mirrors the Docker path pattern.
+			applyFallbacksToLinkedProjects(reg, name)
+			reg.UnbindService(name)
+			if err := reg.Save(); err != nil {
+				return fmt.Errorf("cannot save registry: %w", err)
+			}
 			ui.Success(fmt.Sprintf("%s destroyed (binary + data gone)", binSvc.DisplayName()))
 			return nil
 		}
@@ -125,7 +132,8 @@ var destroyCmd = &cobra.Command{
 			return err
 		}
 
-		// Unbind from all projects.
+		// Apply fallbacks and unbind from all projects.
+		applyFallbacksToLinkedProjects(reg, svcName)
 		projects := reg.ProjectsUsingService(svcName)
 		reg.UnbindService(svcName)
 

--- a/internal/commands/service/hooks.go
+++ b/internal/commands/service/hooks.go
@@ -123,6 +123,20 @@ func updateLinkedProjectsEnvBinary(reg *registry.Registry, svcName string, svc s
 	}
 }
 
+// applyStopAllFallbacks applies env fallbacks for every Docker service in the
+// registry. Binary services are skipped because the stop-all command does not
+// stop them (they're managed by the daemon). Called from the no-args
+// service:stop path after stopping all Docker containers.
+func applyStopAllFallbacks(reg *registry.Registry) {
+	for key, inst := range reg.ListServices() {
+		if inst.Kind == "binary" {
+			continue // binary services were not stopped; no fallback needed.
+		}
+		svcName, _ := services.ParseServiceKey(key)
+		applyFallbacksToLinkedProjects(reg, svcName)
+	}
+}
+
 // applyFallbacksToLinkedProjects applies safe env fallbacks when a service
 // is stopped or removed.
 func applyFallbacksToLinkedProjects(reg *registry.Registry, svcName string) {

--- a/internal/commands/service/hooks_test.go
+++ b/internal/commands/service/hooks_test.go
@@ -41,3 +41,107 @@ func TestApplyFallbacksToLinkedProjects_Integration(t *testing.T) {
 		t.Errorf("SESSION_DRIVER = %q, want file", env["SESSION_DRIVER"])
 	}
 }
+
+func TestApplyFallbacksToLinkedProjects_Mail(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	projectDir := t.TempDir()
+	envPath := filepath.Join(projectDir, ".env")
+	os.WriteFile(envPath, []byte("MAIL_MAILER=smtp\n"), 0644)
+
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{
+			"mail": {Kind: "binary", Port: 1025},
+		},
+		Projects: []registry.Project{
+			{Name: "test-app", Path: projectDir, Type: "laravel",
+				Services: &registry.ProjectServices{Mail: true}},
+		},
+	}
+
+	origConfirm := automation.ConfirmFunc
+	automation.ConfirmFunc = func(label string) (bool, error) { return true, nil }
+	defer func() { automation.ConfirmFunc = origConfirm }()
+
+	applyFallbacksToLinkedProjects(reg, "mail")
+
+	env, _ := services.ReadDotEnv(envPath)
+	if env["MAIL_MAILER"] != "log" {
+		t.Errorf("MAIL_MAILER = %q, want log", env["MAIL_MAILER"])
+	}
+}
+
+// TestStopAllFallbackLoop_SkipsBinaryServices simulates the stop-all fallback
+// loop from stop.go:64-68 and verifies that binary services are skipped while
+// Docker services still get fallbacks applied.
+func TestStopAllFallbackLoop_SkipsBinaryServices(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Two linked projects: one using redis (Docker), one using mail (binary).
+	redisProjectDir := t.TempDir()
+	os.WriteFile(filepath.Join(redisProjectDir, ".env"),
+		[]byte("CACHE_STORE=redis\n"), 0644)
+
+	mailProjectDir := t.TempDir()
+	os.WriteFile(filepath.Join(mailProjectDir, ".env"),
+		[]byte("MAIL_MAILER=smtp\n"), 0644)
+
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{
+			"redis": {Image: "redis:latest", Port: 6379},
+			"mail":  {Kind: "binary", Port: 1025},
+		},
+		Projects: []registry.Project{
+			{Name: "redis-app", Path: redisProjectDir, Type: "laravel",
+				Services: &registry.ProjectServices{Redis: true}},
+			{Name: "mail-app", Path: mailProjectDir, Type: "laravel",
+				Services: &registry.ProjectServices{Mail: true}},
+		},
+	}
+
+	origConfirm := automation.ConfirmFunc
+	automation.ConfirmFunc = func(label string) (bool, error) { return true, nil }
+	defer func() { automation.ConfirmFunc = origConfirm }()
+
+	// Simulate the stop-all fallback loop (same logic as stop.go:64-68).
+	for key, inst := range reg.ListServices() {
+		if inst.Kind == "binary" {
+			continue
+		}
+		svcName, _ := services.ParseServiceKey(key)
+		applyFallbacksToLinkedProjects(reg, svcName)
+	}
+
+	// Docker service (redis) should have fallback applied.
+	redisEnv, _ := services.ReadDotEnv(filepath.Join(redisProjectDir, ".env"))
+	if redisEnv["CACHE_STORE"] != "file" {
+		t.Errorf("redis CACHE_STORE = %q, want file", redisEnv["CACHE_STORE"])
+	}
+
+	// Binary service (mail) should NOT have fallback applied.
+	mailEnv, _ := services.ReadDotEnv(filepath.Join(mailProjectDir, ".env"))
+	if mailEnv["MAIL_MAILER"] != "smtp" {
+		t.Errorf("mail MAIL_MAILER = %q, want smtp (should NOT have been changed)",
+			mailEnv["MAIL_MAILER"])
+	}
+}
+
+func TestUnbindService_ClearsMailBinding(t *testing.T) {
+	reg := &registry.Registry{
+		Projects: []registry.Project{
+			{Name: "test-app", Path: "/tmp/test",
+				Services: &registry.ProjectServices{Mail: true, Redis: true}},
+		},
+	}
+
+	reg.UnbindService("mail")
+
+	project := reg.Find("test-app")
+	if project.Services.Mail {
+		t.Error("ProjectServices.Mail should be false after UnbindService")
+	}
+	// Redis should be untouched.
+	if !project.Services.Redis {
+		t.Error("ProjectServices.Redis should still be true")
+	}
+}

--- a/internal/commands/service/hooks_test.go
+++ b/internal/commands/service/hooks_test.go
@@ -71,10 +71,10 @@ func TestApplyFallbacksToLinkedProjects_Mail(t *testing.T) {
 	}
 }
 
-// TestStopAllFallbackLoop_SkipsBinaryServices simulates the stop-all fallback
-// loop from stop.go:64-68 and verifies that binary services are skipped while
-// Docker services still get fallbacks applied.
-func TestStopAllFallbackLoop_SkipsBinaryServices(t *testing.T) {
+// TestApplyStopAllFallbacks verifies the extracted production function that
+// stop.go calls in the no-args path. Docker services get fallbacks; binary
+// services are skipped (they were not stopped).
+func TestApplyStopAllFallbacks(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	// Two linked projects: one using redis (Docker), one using mail (binary).
@@ -103,14 +103,8 @@ func TestStopAllFallbackLoop_SkipsBinaryServices(t *testing.T) {
 	automation.ConfirmFunc = func(label string) (bool, error) { return true, nil }
 	defer func() { automation.ConfirmFunc = origConfirm }()
 
-	// Simulate the stop-all fallback loop (same logic as stop.go:64-68).
-	for key, inst := range reg.ListServices() {
-		if inst.Kind == "binary" {
-			continue
-		}
-		svcName, _ := services.ParseServiceKey(key)
-		applyFallbacksToLinkedProjects(reg, svcName)
-	}
+	// Call the production function — same code stop.go uses.
+	applyStopAllFallbacks(reg)
 
 	// Docker service (redis) should have fallback applied.
 	redisEnv, _ := services.ReadDotEnv(filepath.Join(redisProjectDir, ".env"))

--- a/internal/commands/service/remove.go
+++ b/internal/commands/service/remove.go
@@ -69,6 +69,13 @@ var removeCmd = &cobra.Command{
 					ui.Subtle(fmt.Sprintf("Could not signal daemon: %v", err))
 				}
 			}
+			// Apply env fallbacks and unbind from linked projects — the binary
+			// is permanently gone. Mirrors the Docker path at remove.go:115-118.
+			applyFallbacksToLinkedProjects(reg, name)
+			reg.UnbindService(name)
+			if err := reg.Save(); err != nil {
+				return fmt.Errorf("cannot save registry: %w", err)
+			}
 			ui.Success(fmt.Sprintf("%s removed (data preserved)", binSvc.DisplayName()))
 			return nil
 		}

--- a/internal/commands/service/stop.go
+++ b/internal/commands/service/stop.go
@@ -61,14 +61,9 @@ var stopCmd = &cobra.Command{
 					return err
 				}
 			}
-			// Apply fallbacks for each stopped service.
-			for key, inst := range reg.ListServices() {
-				if inst.Kind == "binary" {
-					continue // binary services were not stopped above; no fallback needed.
-				}
-				svcName, _ := services.ParseServiceKey(key)
-				applyFallbacksToLinkedProjects(reg, svcName)
-			}
+			// Apply fallbacks for each stopped Docker service. Binary services
+			// are skipped by applyStopAllFallbacks because they were not stopped.
+			applyStopAllFallbacks(reg)
 		} else {
 			// Dispatch on service kind. Binary services don't use the versioned-key
 			// machinery below; they flip a registry flag and let the daemon reconcile.

--- a/internal/commands/service/stop.go
+++ b/internal/commands/service/stop.go
@@ -62,7 +62,10 @@ var stopCmd = &cobra.Command{
 				}
 			}
 			// Apply fallbacks for each stopped service.
-			for key := range reg.ListServices() {
+			for key, inst := range reg.ListServices() {
+				if inst.Kind == "binary" {
+					continue // binary services were not stopped above; no fallback needed.
+				}
 				svcName, _ := services.ParseServiceKey(key)
 				applyFallbacksToLinkedProjects(reg, svcName)
 			}


### PR DESCRIPTION
## Summary

- **stop.go**: `pv service:stop` (no args) no longer applies `.env` fallbacks to binary services it didn't actually stop. Previously rewrote e.g. `MAIL_MAILER=smtp → log` while mail was still supervised and listening.
- **remove.go + destroy.go**: binary `service:remove` and `service:destroy` now apply `.env` fallbacks and call `reg.UnbindService` to clear `ProjectServices.Mail/S3` flags on linked projects, matching Docker `service:remove` behavior.
- **destroy.go Docker path**: fixes a pre-existing bug where Docker `service:destroy` unbinds projects but doesn't apply fallbacks first (unlike `service:remove` which does both).

## Bugs fixed

| Operation | Was | Now |
|---|---|---|
| `pv service:stop` (no args) | Fallback applied to binary services that were never stopped | Binary services skipped in fallback loop |
| `pv service:remove mail` | No fallback, no unbind | Fallback applied + project unbound |
| `pv service:destroy mail` | No fallback, no unbind | Fallback applied + project unbound |
| `pv service:destroy mysql` (Docker) | Unbind but no fallback | Fallback applied before unbind |

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...` — 30 packages pass
- [x] 3 new tests: `TestApplyFallbacksToLinkedProjects_Mail`, `TestStopAllFallbackLoop_SkipsBinaryServices`, `TestUnbindService_ClearsMailBinding`
- [ ] CI: existing E2E phases pass (no E2E changes in this PR)
- [ ] Manual: `pv service:stop` with a linked project using mail — verify `.env` keeps `MAIL_MAILER=smtp`
- [ ] Manual: `pv service:destroy mail` with a linked project — verify `.env` gets `MAIL_MAILER=log`