### PR TITLE
Post-migration quality: ReadyCheck type safety, tests, E2E .env

### DIFF
--- a/internal/commands/service/dispatch_test.go
+++ b/internal/commands/service/dispatch_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/prvious/pv/internal/registry"
@@ -63,5 +64,43 @@ func TestResolveKind_DockerEntryBlocksBinaryRegistration(t *testing.T) {
 	_, _, _, err := resolveKind(reg, "s3")
 	if err == nil {
 		t.Fatal("expected error for pre-existing docker s3 entry")
+	}
+}
+
+func TestResolveKind_MailDockerEntryBlocksBinaryMigration(t *testing.T) {
+	// Same scenario as the s3 test above but for mail — the more common
+	// upgrade path since users who ran `pv service:add mail` on an older
+	// version will have a docker-shaped entry.
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{
+			"mail": {Kind: "", Image: "axllent/mailpit:latest", Port: 1025},
+		},
+	}
+	_, _, _, err := resolveKind(reg, "mail")
+	if err == nil {
+		t.Fatal("expected error for pre-existing docker mail entry")
+	}
+	if !strings.Contains(err.Error(), "pv uninstall") {
+		t.Errorf("error should mention remedy; got %q", err)
+	}
+}
+
+func TestResolveKind_MailBinaryService(t *testing.T) {
+	reg := &registry.Registry{Services: map[string]*registry.ServiceInstance{}}
+	kind, bin, doc, err := resolveKind(reg, "mail")
+	if err != nil {
+		t.Fatalf("resolveKind: %v", err)
+	}
+	if kind != kindBinary {
+		t.Errorf("kind = %v, want kindBinary", kind)
+	}
+	if bin == nil {
+		t.Error("binary service should be non-nil")
+	}
+	if doc != nil {
+		t.Error("docker service should be nil")
+	}
+	if _, ok := bin.(*services.Mailpit); !ok {
+		t.Errorf("expected *Mailpit, got %T", bin)
 	}
 }

--- a/internal/server/binary_service.go
+++ b/internal/server/binary_service.go
@@ -72,14 +72,14 @@ func buildSupervisorProcess(svc services.BinaryService) (supervisor.Process, err
 // silently treating a zero-value as "instantly ready" (which would let a
 // misconfigured BinaryService bypass the probe entirely).
 func buildReadyFunc(rc services.ReadyCheck) (func(context.Context) error, error) {
-	httpSet := rc.HTTPEndpoint != ""
-	tcpSet := rc.TCPPort > 0
+	httpSet := rc.HTTPEndpoint() != ""
+	tcpSet := rc.TCPPort() > 0
 	switch {
 	case httpSet && tcpSet:
 		return nil, fmt.Errorf("invalid ReadyCheck: both TCPPort and HTTPEndpoint set; specify exactly one")
 	case httpSet:
 		client := &http.Client{Timeout: 2 * time.Second}
-		url := rc.HTTPEndpoint
+		url := rc.HTTPEndpoint()
 		return func(ctx context.Context) error {
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 			if err != nil {
@@ -96,7 +96,7 @@ func buildReadyFunc(rc services.ReadyCheck) (func(context.Context) error, error)
 			return fmt.Errorf("HTTP %s returned %d", url, resp.StatusCode)
 		}, nil
 	case tcpSet:
-		addr := fmt.Sprintf("127.0.0.1:%d", rc.TCPPort)
+		addr := fmt.Sprintf("127.0.0.1:%d", rc.TCPPort())
 		return func(ctx context.Context) error {
 			d := net.Dialer{Timeout: 500 * time.Millisecond}
 			c, err := d.DialContext(ctx, "tcp", addr)

--- a/internal/server/binary_service_test.go
+++ b/internal/server/binary_service_test.go
@@ -79,6 +79,58 @@ func TestBuildSupervisorProcess_RustFS(t *testing.T) {
 	}
 }
 
+func TestBuildSupervisorProcess_Mailpit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	svc := &services.Mailpit{}
+	p, err := buildSupervisorProcess(svc)
+	if err != nil {
+		t.Fatalf("buildSupervisorProcess: %v", err)
+	}
+	// Binary name is "mailpit", not service name "mail".
+	if p.Name != "mailpit" {
+		t.Errorf("Name = %q, want mailpit (binary name, not service name)", p.Name)
+	}
+	if !strings.HasSuffix(p.Binary, "/internal/bin/mailpit") {
+		t.Errorf("Binary = %q; should end with /internal/bin/mailpit", p.Binary)
+	}
+	if !strings.HasSuffix(p.LogFile, "/mailpit.log") {
+		t.Errorf("LogFile = %q; expected .../mailpit.log", p.LogFile)
+	}
+	if p.ReadyTimeout != 30*time.Second {
+		t.Errorf("ReadyTimeout = %v, want 30s", p.ReadyTimeout)
+	}
+	if p.Ready == nil {
+		t.Error("Ready closure must be set")
+	}
+	// Verify Mailpit-specific args: --smtp :1025, --listen :8025, --database <dataDir>/mailpit.db
+	var sawSMTP, sawListen, sawDatabase bool
+	for i := 0; i < len(p.Args)-1; i++ {
+		switch p.Args[i] {
+		case "--smtp":
+			if p.Args[i+1] == ":1025" {
+				sawSMTP = true
+			}
+		case "--listen":
+			if p.Args[i+1] == ":8025" {
+				sawListen = true
+			}
+		case "--database":
+			if strings.HasSuffix(p.Args[i+1], "/mailpit.db") {
+				sawDatabase = true
+			}
+		}
+	}
+	if !sawSMTP {
+		t.Errorf("Args missing --smtp :1025; got %v", p.Args)
+	}
+	if !sawListen {
+		t.Errorf("Args missing --listen :8025; got %v", p.Args)
+	}
+	if !sawDatabase {
+		t.Errorf("Args missing --database .../mailpit.db; got %v", p.Args)
+	}
+}
+
 func TestBuildReadyFunc_RejectsZeroValue(t *testing.T) {
 	// Zero-value ReadyCheck has neither tcpPort nor httpEndpoint set.
 	// The "both set" case is now unconstructable from outside the services

--- a/internal/server/binary_service_test.go
+++ b/internal/server/binary_service_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prvious/pv/internal/services"
 	"github.com/prvious/pv/internal/supervisor"
@@ -79,6 +80,9 @@ func TestBuildSupervisorProcess_RustFS(t *testing.T) {
 }
 
 func TestBuildReadyFunc_RejectsZeroValue(t *testing.T) {
+	// Zero-value ReadyCheck has neither tcpPort nor httpEndpoint set.
+	// The "both set" case is now unconstructable from outside the services
+	// package (fields are unexported) — the type system prevents it.
 	_, err := buildReadyFunc(services.ReadyCheck{})
 	if err == nil {
 		t.Fatal("expected error for zero-value ReadyCheck")
@@ -88,18 +92,8 @@ func TestBuildReadyFunc_RejectsZeroValue(t *testing.T) {
 	}
 }
 
-func TestBuildReadyFunc_RejectsBothSet(t *testing.T) {
-	_, err := buildReadyFunc(services.ReadyCheck{
-		TCPPort:      9000,
-		HTTPEndpoint: "http://127.0.0.1:9000/health",
-	})
-	if err == nil {
-		t.Fatal("expected error when both TCPPort and HTTPEndpoint are set")
-	}
-}
-
 func TestBuildReadyFunc_TCPOnly(t *testing.T) {
-	fn, err := buildReadyFunc(services.ReadyCheck{TCPPort: 9000})
+	fn, err := buildReadyFunc(services.TCPReady(9000, 30*time.Second))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -109,7 +103,7 @@ func TestBuildReadyFunc_TCPOnly(t *testing.T) {
 }
 
 func TestBuildReadyFunc_HTTPOnly(t *testing.T) {
-	fn, err := buildReadyFunc(services.ReadyCheck{HTTPEndpoint: "http://127.0.0.1:9000/health"})
+	fn, err := buildReadyFunc(services.HTTPReady("http://127.0.0.1:9000/health", 30*time.Second))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/services/binary.go
+++ b/internal/services/binary.go
@@ -7,16 +7,30 @@ import (
 )
 
 // ReadyCheck describes how a supervisor verifies that a binary service has
-// finished starting and is ready to accept requests. Exactly one of TCPPort
-// or HTTPEndpoint must be set — a zero value or both-set configuration is
-// rejected by the supervisor wiring (see internal/server/binary_service.go)
-// so a misconfigured service fails loudly at start time instead of silently
-// skipping the probe.
+// finished starting and is ready to accept requests. Construct via TCPReady
+// or HTTPReady — the unexported fields prevent constructing invalid states
+// (zero-value or both-set) from outside this package.
 type ReadyCheck struct {
-	TCPPort      int           // probe 127.0.0.1:port until Dial succeeds
-	HTTPEndpoint string        // GET this URL, expect a 2xx response
+	tcpPort      int           // probe 127.0.0.1:port until Dial succeeds
+	httpEndpoint string        // GET this URL, expect a 2xx response
 	Timeout      time.Duration // overall give-up time for the ready probe
 }
+
+// TCPReady returns a ReadyCheck that probes 127.0.0.1:port via TCP Dial.
+func TCPReady(port int, timeout time.Duration) ReadyCheck {
+	return ReadyCheck{tcpPort: port, Timeout: timeout}
+}
+
+// HTTPReady returns a ReadyCheck that GETs the given URL and expects a 2xx.
+func HTTPReady(url string, timeout time.Duration) ReadyCheck {
+	return ReadyCheck{httpEndpoint: url, Timeout: timeout}
+}
+
+// TCPPort returns the TCP probe port, or 0 if this is an HTTP check.
+func (r ReadyCheck) TCPPort() int { return r.tcpPort }
+
+// HTTPEndpoint returns the HTTP probe URL, or "" if this is a TCP check.
+func (r ReadyCheck) HTTPEndpoint() string { return r.httpEndpoint }
 
 // BinaryService is the contract for services that run as native binaries
 // supervised by the pv daemon, rather than as Docker containers.

--- a/internal/services/mailpit.go
+++ b/internal/services/mailpit.go
@@ -53,10 +53,7 @@ func (m *Mailpit) EnvVars(_ string) map[string]string {
 // ReadyCheck uses Mailpit's documented /livez endpoint, which returns 200 once
 // both the SMTP and HTTP servers are listening.
 func (m *Mailpit) ReadyCheck() ReadyCheck {
-	return ReadyCheck{
-		HTTPEndpoint: "http://127.0.0.1:8025/livez",
-		Timeout:      30 * time.Second,
-	}
+	return HTTPReady("http://127.0.0.1:8025/livez", 30*time.Second)
 }
 
 // Self-registers on import; see binaryRegistry in binary.go for the pattern.

--- a/internal/services/mailpit_test.go
+++ b/internal/services/mailpit_test.go
@@ -105,11 +105,11 @@ func TestMailpit_Args_PinsBindAddresses(t *testing.T) {
 func TestMailpit_ReadyCheck_HTTPLivez(t *testing.T) {
 	m := &Mailpit{}
 	rc := m.ReadyCheck()
-	if rc.HTTPEndpoint == "" {
+	if rc.HTTPEndpoint() == "" {
 		t.Error("ReadyCheck.HTTPEndpoint must be set (Mailpit uses HTTP probe, not TCP)")
 	}
-	if rc.TCPPort != 0 {
-		t.Errorf("ReadyCheck.TCPPort = %d, want 0", rc.TCPPort)
+	if rc.TCPPort() != 0 {
+		t.Errorf("ReadyCheck.TCPPort = %d, want 0", rc.TCPPort())
 	}
 	if rc.Timeout == 0 {
 		t.Error("ReadyCheck.Timeout must be non-zero")

--- a/internal/services/rustfs.go
+++ b/internal/services/rustfs.go
@@ -57,10 +57,7 @@ func (r *RustFS) EnvVars(projectName string) map[string]string {
 }
 
 func (r *RustFS) ReadyCheck() ReadyCheck {
-	return ReadyCheck{
-		TCPPort: 9000,
-		Timeout: 30 * time.Second,
-	}
+	return TCPReady(9000, 30*time.Second)
 }
 
 func init() {

--- a/internal/services/rustfs_test.go
+++ b/internal/services/rustfs_test.go
@@ -125,11 +125,11 @@ func TestRustFS_Env_UsesAccessSecretKeys(t *testing.T) {
 func TestRustFS_ReadyCheck_TCP9000(t *testing.T) {
 	r := &RustFS{}
 	rc := r.ReadyCheck()
-	if rc.TCPPort != 9000 {
-		t.Errorf("ReadyCheck.TCPPort = %d, want 9000", rc.TCPPort)
+	if rc.TCPPort() != 9000 {
+		t.Errorf("ReadyCheck.TCPPort = %d, want 9000", rc.TCPPort())
 	}
-	if rc.HTTPEndpoint != "" {
-		t.Errorf("ReadyCheck.HTTPEndpoint = %q, want empty (TCP probe)", rc.HTTPEndpoint)
+	if rc.HTTPEndpoint() != "" {
+		t.Errorf("ReadyCheck.HTTPEndpoint = %q, want empty (TCP probe)", rc.HTTPEndpoint())
 	}
 	if rc.Timeout == 0 {
 		t.Error("ReadyCheck.Timeout must be non-zero")

--- a/scripts/e2e/mail-binary.sh
+++ b/scripts/e2e/mail-binary.sh
@@ -12,8 +12,17 @@ sleep 3
 cleanup() {
   kill "$START_PID" 2>/dev/null || true
   pv stop >/dev/null 2>&1 || true
+  rm -rf "${ENVTEST_DIR:-}" 2>/dev/null || true
 }
 trap cleanup EXIT
+
+# Create a minimal linked Laravel project so we can assert .env injection.
+ENVTEST_DIR=$(mktemp -d)
+echo '{"require":{"php":"^8.2","laravel/framework":"^11.0"}}' > "$ENVTEST_DIR/composer.json"
+mkdir -p "$ENVTEST_DIR/public"
+echo '<?php echo "test";' > "$ENVTEST_DIR/public/index.php"
+echo "MAIL_MAILER=log" > "$ENVTEST_DIR/.env"
+pv link "$ENVTEST_DIR" --name e2e-mail-env >/dev/null 2>&1 || { echo "FAIL: pv link for env test"; exit 1; }
 
 echo "==> service:add mail"
 pv service:add mail || { echo "FAIL: pv service:add mail failed"; exit 1; }
@@ -42,6 +51,15 @@ echo "OK: /livez reachable on port 8025"
 echo "==> Verify SMTP port 1025 is reachable"
 nc -z 127.0.0.1 1025 || { echo "FAIL: SMTP port 1025 not reachable after service:add"; exit 1; }
 echo "OK: SMTP port 1025 reachable"
+
+echo "==> Verify linked project .env got MAIL_MAILER=smtp"
+grep -q "MAIL_MAILER=smtp" "$ENVTEST_DIR/.env" || {
+    echo "FAIL: linked project .env should have MAIL_MAILER=smtp after service:add mail";
+    echo "  actual .env contents:";
+    cat "$ENVTEST_DIR/.env";
+    exit 1;
+}
+echo "OK: linked project .env has MAIL_MAILER=smtp"
 
 echo "==> service:stop mail"
 pv service:stop mail

--- a/scripts/e2e/mail-binary.sh
+++ b/scripts/e2e/mail-binary.sh
@@ -10,6 +10,7 @@ START_PID=$!
 sleep 3
 
 cleanup() {
+  pv unlink e2e-mail-env >/dev/null 2>&1 || true
   kill "$START_PID" 2>/dev/null || true
   pv stop >/dev/null 2>&1 || true
   rm -rf "${ENVTEST_DIR:-}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Three quality improvements identified during the mailpit migration PR review. None are bugs — all are hardening.

**Commit 1: ReadyCheck type safety**
- Unexport `TCPPort`/`HTTPEndpoint` fields on `ReadyCheck`
- Add `TCPReady(port, timeout)` / `HTTPReady(url, timeout)` constructors
- Add `TCPPort()` / `HTTPEndpoint()` accessor methods
- Invalid states (zero-value both-unset, both-set) are now unconstructable from outside the services package
- Zero-value rejection test retained (zero value is still constructable via `var rc ReadyCheck`)
- Both-set rejection test removed (that state is now unconstructable)

**Commit 2: Supervisor + dispatch tests for Mailpit**
- `TestBuildSupervisorProcess_Mailpit` — full supervisor wiring: binary name "mailpit" (not service name "mail"), correct paths, 30s ReadyTimeout, all three bind-address flags. First end-to-end test of the HTTP ready-probe code path.
- `TestResolveKind_MailDockerEntryBlocksBinaryMigration` — pins the migration-blocking error message for a pre-existing Docker mail entry.
- `TestResolveKind_MailBinaryService` — confirms "mail" resolves to kindBinary with a *Mailpit handle.

**Commit 3: E2E .env injection assertion**
- Creates a minimal linked Laravel project with `MAIL_MAILER=log`
- After `pv service:add mail`, asserts `.env` was rewritten to `MAIL_MAILER=smtp`
- Catches the scariest post-migration regression: mail is healthy but linked projects never get their `.env` updated

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...` — all packages pass
- [x] `bash -n scripts/e2e/mail-binary.sh` — syntax clean
- [ ] CI: E2E Phase 21 exercises the new `.env` assertion