### PR TITLE
Fix service env update writing to all projects instead of only linked ones

### DIFF
--- a/internal/commands/service/hooks.go
+++ b/internal/commands/service/hooks.go
@@ -12,8 +12,8 @@ import (
 	"github.com/prvious/pv/internal/ui"
 )
 
-// updateLinkedProjectsEnv updates .env for all linked Laravel projects
-// (including Octane) when a service is added or started.
+// updateLinkedProjectsEnv updates .env for Laravel projects linked to the
+// given service (including Octane) when a service is added or started.
 func updateLinkedProjectsEnv(reg *registry.Registry, svcName string, svc services.Service, version string) {
 	settings, err := config.LoadSettings()
 	if err != nil {
@@ -24,10 +24,12 @@ func updateLinkedProjectsEnv(reg *registry.Registry, svcName string, svc service
 		return
 	}
 
+	linkedNames := reg.ProjectsUsingService(svcName)
 	var laravelProjects []registry.Project
-	for _, p := range reg.List() {
-		if p.Type == "laravel" || p.Type == "laravel-octane" {
-			laravelProjects = append(laravelProjects, p)
+	for _, name := range linkedNames {
+		p := reg.Find(name)
+		if p != nil && (p.Type == "laravel" || p.Type == "laravel-octane") {
+			laravelProjects = append(laravelProjects, *p)
 		}
 	}
 	if len(laravelProjects) == 0 {
@@ -81,10 +83,12 @@ func updateLinkedProjectsEnvBinary(reg *registry.Registry, svcName string, svc s
 		return
 	}
 
+	linkedNames := reg.ProjectsUsingService(svcName)
 	var laravelProjects []registry.Project
-	for _, p := range reg.List() {
-		if p.Type == "laravel" || p.Type == "laravel-octane" {
-			laravelProjects = append(laravelProjects, p)
+	for _, name := range linkedNames {
+		p := reg.Find(name)
+		if p != nil && (p.Type == "laravel" || p.Type == "laravel-octane") {
+			laravelProjects = append(laravelProjects, *p)
 		}
 	}
 	if len(laravelProjects) == 0 {

--- a/internal/commands/service/hooks_test.go
+++ b/internal/commands/service/hooks_test.go
@@ -120,6 +120,49 @@ func TestApplyStopAllFallbacks(t *testing.T) {
 	}
 }
 
+// TestUpdateLinkedProjectsEnv_OnlyUpdatesLinkedProject verifies that when a
+// service is added/started, only projects linked to that service have their
+// .env updated — not unrelated projects that happen to be in the registry.
+func TestUpdateLinkedProjectsEnv_OnlyUpdatesLinkedProject(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	mysqlProjectDir := t.TempDir()
+	os.WriteFile(filepath.Join(mysqlProjectDir, ".env"),
+		[]byte("DB_CONNECTION=sqlite\n"), 0644)
+
+	postgresProjectDir := t.TempDir()
+	os.WriteFile(filepath.Join(postgresProjectDir, ".env"),
+		[]byte("DB_CONNECTION=sqlite\n"), 0644)
+
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{
+			"mysql@8.4": {Image: "mysql:8.4", Port: 33000},
+		},
+		Projects: []registry.Project{
+			{Name: "mysql-app", Path: mysqlProjectDir, Type: "laravel",
+				Services: &registry.ProjectServices{MySQL: "8.4"}},
+			{Name: "postgres-app", Path: postgresProjectDir, Type: "laravel",
+				Services: &registry.ProjectServices{Postgres: "17"}},
+		},
+	}
+
+	origConfirm := automation.ConfirmFunc
+	automation.ConfirmFunc = func(label string) (bool, error) { return true, nil }
+	defer func() { automation.ConfirmFunc = origConfirm }()
+
+	updateLinkedProjectsEnv(reg, "mysql", &services.MySQL{}, "8.4")
+
+	mysqlEnv, _ := services.ReadDotEnv(filepath.Join(mysqlProjectDir, ".env"))
+	if mysqlEnv["DB_CONNECTION"] != "mysql" {
+		t.Errorf("mysql-app DB_CONNECTION = %q, want mysql", mysqlEnv["DB_CONNECTION"])
+	}
+
+	postgresEnv, _ := services.ReadDotEnv(filepath.Join(postgresProjectDir, ".env"))
+	if postgresEnv["DB_CONNECTION"] != "sqlite" {
+		t.Errorf("postgres-app DB_CONNECTION = %q, want sqlite (should not have changed)", postgresEnv["DB_CONNECTION"])
+	}
+}
+
 func TestUnbindService_ClearsMailBinding(t *testing.T) {
 	reg := &registry.Registry{
 		Projects: []registry.Project{


### PR DESCRIPTION
Fixes #63

## Summary

- `updateLinkedProjectsEnv` and `updateLinkedProjectsEnvBinary` in `hooks.go` were iterating all Laravel projects in the registry
- When adding or starting a service (e.g. mysql), unrelated projects (e.g. postgres-only) would also have their `.env` overwritten
- Fix: use `reg.ProjectsUsingService()` to scope updates to only the projects linked to the service being added/started
- Added regression test `TestUpdateLinkedProjectsEnv_OnlyUpdatesLinkedProject`

Generated with [Claude Code](https://claude.ai/code)