### PR TITLE
ci: add postgres artifacts pipeline (PG 17/18, macOS arm64)

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -355,9 +355,10 @@ jobs:
             fi
           done
 
-          # Postgres bundles: expect both 17 and 18.
+          # Postgres bundles: expect one per major in postgres.strategy.matrix.pg.
+          # Keep this count in sync with that matrix when adding/removing majors.
           pg_dirs=(artifacts/postgres-mac-arm64-*)
-          if [ ${#pg_dirs[@]} -lt 2 ]; then
+          if [ ${#pg_dirs[@]} -ne 2 ]; then
             echo "::error::Expected 2 postgres bundles (17 + 18), found ${#pg_dirs[@]}"
             exit 1
           fi

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -170,7 +170,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          ALL=$(gh api 'repos/theseus-rs/postgresql-binaries/releases?per_page=100' --paginate --jq '.[].tag_name')
+          ALL=$(gh api 'repos/theseus-rs/postgresql-binaries/releases?per_page=100' --paginate --jq '.[] | select(.prerelease==false) | .tag_name')
           VER=$(echo "$ALL" | grep "^${{ matrix.pg }}\." | sort -V | tail -1)
           if [ -z "$VER" ]; then
             echo "::error::No ${{ matrix.pg }}.x release on theseus-rs"
@@ -200,6 +200,7 @@ jobs:
       - name: Patch install_names to relative paths
         run: |
           set -euo pipefail
+          shopt -s nullglob
           # Rewrite LC_ID_DYLIB on bundled openssl (their own identity)
           install_name_tool -id "@executable_path/../lib/libssl.3.dylib"   "$STAGING/lib/libssl.3.dylib"
           install_name_tool -id "@executable_path/../lib/libcrypto.3.dylib" "$STAGING/lib/libcrypto.3.dylib"
@@ -228,6 +229,7 @@ jobs:
       - name: Ad-hoc codesign all Mach-O files
         run: |
           set -euo pipefail
+          shopt -s nullglob
           for f in "$STAGING/bin/"* "$STAGING/lib/"*.dylib; do
             [ -L "$f" ] && continue
             [ -f "$f" ] || continue

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -154,6 +154,150 @@ jobs:
           path: dist/php-mac-${{ steps.arch.outputs.arch }}-php${{ matrix.php }}.tar.gz
           compression-level: 0
 
+  postgres:
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: ["17", "18"]
+    name: PostgreSQL ${{ matrix.pg }}
+    runs-on: macos-15
+    permissions:
+      contents: read
+    steps:
+      - name: Resolve latest patch version from theseus-rs
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ALL=$(gh api 'repos/theseus-rs/postgresql-binaries/releases?per_page=100' --paginate --jq '.[].tag_name')
+          VER=$(echo "$ALL" | grep "^${{ matrix.pg }}\." | sort -V | tail -1)
+          if [ -z "$VER" ]; then
+            echo "::error::No ${{ matrix.pg }}.x release on theseus-rs"
+            exit 1
+          fi
+          echo "Resolved PG ${{ matrix.pg }} → $VER"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+
+      - name: Download and extract theseus-rs bundle
+        run: |
+          set -euo pipefail
+          VER="${{ steps.resolve.outputs.version }}"
+          URL="https://github.com/theseus-rs/postgresql-binaries/releases/download/${VER}/postgresql-${VER}-aarch64-apple-darwin.tar.gz"
+          curl -fsSL -o pg.tar.gz "$URL"
+          mkdir extracted
+          tar -xzf pg.tar.gz -C extracted
+          STAGING=$(ls -d extracted/postgresql-*-aarch64-apple-darwin)
+          echo "STAGING=$STAGING" >> "$GITHUB_ENV"
+
+      - name: Bundle Homebrew openssl into staging
+        run: |
+          set -euo pipefail
+          cp /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib   "$STAGING/lib/"
+          cp /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib "$STAGING/lib/"
+          chmod 755 "$STAGING/lib/libssl.3.dylib" "$STAGING/lib/libcrypto.3.dylib"
+
+      - name: Patch install_names to relative paths
+        run: |
+          set -euo pipefail
+          # Rewrite LC_ID_DYLIB on bundled openssl (their own identity)
+          install_name_tool -id "@executable_path/../lib/libssl.3.dylib"   "$STAGING/lib/libssl.3.dylib"
+          install_name_tool -id "@executable_path/../lib/libcrypto.3.dylib" "$STAGING/lib/libcrypto.3.dylib"
+          # libssl carries a hardcoded reference to libcrypto via Homebrew Cellar version path.
+          # Discover it from otool -L rather than reconstructing the path.
+          CRYPTO_REF=$(otool -L "$STAGING/lib/libssl.3.dylib" | awk '/libcrypto\.3\.dylib/ && !/@executable_path/ {print $1; exit}')
+          if [ -n "$CRYPTO_REF" ]; then
+            install_name_tool -change "$CRYPTO_REF" "@executable_path/../lib/libcrypto.3.dylib" "$STAGING/lib/libssl.3.dylib"
+          fi
+          # Walk every Mach-O in bin/ and lib/, rewrite the two openssl paths.
+          for f in "$STAGING/bin/"* "$STAGING/lib/"*.dylib; do
+            [ -L "$f" ] && continue
+            [ -f "$f" ] || continue
+            if file -b "$f" | grep -q '^Mach-O'; then
+              install_name_tool -change \
+                "/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib" \
+                "@executable_path/../lib/libssl.3.dylib" \
+                "$f" 2>/dev/null || true
+              install_name_tool -change \
+                "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib" \
+                "@executable_path/../lib/libcrypto.3.dylib" \
+                "$f" 2>/dev/null || true
+            fi
+          done
+
+      - name: Ad-hoc codesign all Mach-O files
+        run: |
+          set -euo pipefail
+          for f in "$STAGING/bin/"* "$STAGING/lib/"*.dylib; do
+            [ -L "$f" ] && continue
+            [ -f "$f" ] || continue
+            if file -b "$f" | grep -q '^Mach-O'; then
+              codesign --force --sign - "$f"
+            fi
+          done
+
+      - name: Verify deps reference no Homebrew paths
+        run: |
+          set -euo pipefail
+          echo "postgres dependencies:"
+          otool -L "$STAGING/bin/postgres"
+          if otool -L "$STAGING/bin/postgres" | grep -E '/opt/homebrew' ; then
+            echo "::error::postgres still references Homebrew paths after patching"
+            exit 1
+          fi
+
+      - name: Smoke test (initdb + start + psql + stop)
+        run: |
+          set -euo pipefail
+          DATA_DIR="$RUNNER_TEMP/pgdata"
+          rm -rf "$DATA_DIR"
+          "$STAGING/bin/initdb" -D "$DATA_DIR" -U postgres --auth=trust >/dev/null
+          PORT=54199
+          "$STAGING/bin/postgres" -D "$DATA_DIR" -p "$PORT" -k "$DATA_DIR" >"$RUNNER_TEMP/pg.log" 2>&1 &
+          PG_PID=$!
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if "$STAGING/bin/pg_isready" -h 127.0.0.1 -p "$PORT" >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          if ! "$STAGING/bin/pg_isready" -h 127.0.0.1 -p "$PORT"; then
+            echo "::error::pg_isready failed; server log:"
+            cat "$RUNNER_TEMP/pg.log"
+            kill $PG_PID 2>/dev/null || true
+            exit 1
+          fi
+          VER_OUT=$("$STAGING/bin/psql" -h 127.0.0.1 -p "$PORT" -U postgres -tAc "SELECT version();")
+          echo "Server reported: $VER_OUT"
+          kill $PG_PID
+          wait $PG_PID 2>/dev/null || true
+
+      - name: Strip docs
+        run: rm -rf "$STAGING/share/postgresql/doc"
+
+      - name: Structural sanity checks
+        run: |
+          set -euo pipefail
+          test -f "$STAGING/bin/postgres"
+          test -f "$STAGING/bin/initdb"
+          test -f "$STAGING/bin/pg_ctl"
+          test -f "$STAGING/bin/psql"
+          test -f "$STAGING/bin/pg_dump"
+          test -f "$STAGING/bin/pg_config"
+          test -f "$STAGING/lib/libssl.3.dylib"
+          test -f "$STAGING/lib/libcrypto.3.dylib"
+          test -d "$STAGING/share/postgresql/extension"
+          test -d "$STAGING/include"
+          echo "Structural sanity checks passed."
+
+      - name: Repack
+        run: tar -czf "postgres-mac-arm64-${{ matrix.pg }}.tar.gz" -C "$STAGING" bin lib share include
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgres-mac-arm64-${{ matrix.pg }}
+          path: postgres-mac-arm64-${{ matrix.pg }}.tar.gz
+          compression-level: 0
+
   release:
     needs: [resolve-version, build]
     # Only publish from main. Dispatching from a feature branch runs the build

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -273,7 +273,7 @@ jobs:
           wait $PG_PID 2>/dev/null || true
 
       - name: Strip docs
-        run: rm -rf "$STAGING/share/postgresql/doc"
+        run: rm -rf "$STAGING/share/doc"
 
       - name: Structural sanity checks
         run: |
@@ -286,7 +286,7 @@ jobs:
           test -f "$STAGING/bin/pg_config"
           test -f "$STAGING/lib/libssl.3.dylib"
           test -f "$STAGING/lib/libcrypto.3.dylib"
-          test -d "$STAGING/share/postgresql/extension"
+          test -d "$STAGING/share/extension"
           test -d "$STAGING/include"
           echo "Structural sanity checks passed."
 

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -164,6 +164,9 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout pv (for scripts/test-postgres-bundle.sh)
+        uses: actions/checkout@v4
+
       - name: Resolve latest patch version from theseus-rs
         id: resolve
         env:
@@ -201,29 +204,38 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          # Rewrite LC_ID_DYLIB on bundled openssl (their own identity)
-          install_name_tool -id "@executable_path/../lib/libssl.3.dylib"   "$STAGING/lib/libssl.3.dylib"
-          install_name_tool -id "@executable_path/../lib/libcrypto.3.dylib" "$STAGING/lib/libcrypto.3.dylib"
-          # libssl carries a hardcoded reference to libcrypto via Homebrew Cellar version path.
-          # Discover it from otool -L rather than reconstructing the path.
-          CRYPTO_REF=$(otool -L "$STAGING/lib/libssl.3.dylib" | awk '/libcrypto\.3\.dylib/ && !/@executable_path/ {print $1; exit}')
-          if [ -n "$CRYPTO_REF" ]; then
-            install_name_tool -change "$CRYPTO_REF" "@executable_path/../lib/libcrypto.3.dylib" "$STAGING/lib/libssl.3.dylib"
-          fi
-          # Walk every Mach-O in bin/ and lib/, rewrite the two openssl paths.
+          # Walk every Mach-O in bin/ and lib/. For each:
+          #   - If it's a dylib whose LC_ID_DYLIB points at a build-host path
+          #     (Homebrew or theseus's CI workspace), rewrite it to
+          #     @executable_path/../lib/<basename>.
+          #   - For every LC_LOAD_DYLIB pointing at a build-host path, rewrite
+          #     to @executable_path/../lib/<basename>.
+          # Build-host path patterns seen in theseus-rs's macOS arm64 bundles:
+          #   /opt/homebrew/...                          (Homebrew openssl, Cellar paths)
+          #   /Users/runner/work/postgresql-binaries/... (theseus's CI workspace)
           for f in "$STAGING/bin/"* "$STAGING/lib/"*.dylib; do
             [ -L "$f" ] && continue
             [ -f "$f" ] || continue
-            if file -b "$f" | grep -q '^Mach-O'; then
-              install_name_tool -change \
-                "/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib" \
-                "@executable_path/../lib/libssl.3.dylib" \
-                "$f" 2>/dev/null || true
-              install_name_tool -change \
-                "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib" \
-                "@executable_path/../lib/libcrypto.3.dylib" \
-                "$f" 2>/dev/null || true
+            if ! file -b "$f" | grep -q '^Mach-O'; then continue; fi
+
+            # Fix LC_ID_DYLIB on dylibs whose identity is a build-host path.
+            if [[ "$f" == *.dylib ]]; then
+              own=$(otool -D "$f" | tail -n +2)
+              case "$own" in
+                /opt/homebrew/*|/Users/runner/*)
+                  install_name_tool -id "@executable_path/../lib/$(basename "$own")" "$f"
+                  ;;
+              esac
             fi
+
+            # Fix LC_LOAD_DYLIB entries pointing at build-host paths.
+            otool -L "$f" | tail -n +2 | awk '{print $1}' | while read -r ref; do
+              case "$ref" in
+                /opt/homebrew/*|/Users/runner/*)
+                  install_name_tool -change "$ref" "@executable_path/../lib/$(basename "$ref")" "$f" 2>/dev/null || true
+                  ;;
+              esac
+            done
           done
 
       - name: Ad-hoc codesign all Mach-O files
@@ -238,39 +250,30 @@ jobs:
             fi
           done
 
-      - name: Verify deps reference no Homebrew paths
+      - name: Verify no build-host paths remain in any binary
         run: |
           set -euo pipefail
-          echo "postgres dependencies:"
-          otool -L "$STAGING/bin/postgres"
-          if otool -L "$STAGING/bin/postgres" | grep -E '/opt/homebrew' ; then
-            echo "::error::postgres still references Homebrew paths after patching"
-            exit 1
-          fi
-
-      - name: Smoke test (initdb + start + psql + stop)
-        run: |
-          set -euo pipefail
-          DATA_DIR="$RUNNER_TEMP/pgdata"
-          rm -rf "$DATA_DIR"
-          "$STAGING/bin/initdb" -D "$DATA_DIR" -U postgres --auth=trust >/dev/null
-          PORT=54199
-          "$STAGING/bin/postgres" -D "$DATA_DIR" -p "$PORT" -k "$DATA_DIR" >"$RUNNER_TEMP/pg.log" 2>&1 &
-          PG_PID=$!
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            if "$STAGING/bin/pg_isready" -h 127.0.0.1 -p "$PORT" >/dev/null 2>&1; then break; fi
-            sleep 1
+          shopt -s nullglob
+          LEAKS=0
+          for f in "$STAGING/bin/"* "$STAGING/lib/"*.dylib; do
+            [ -L "$f" ] && continue
+            [ -f "$f" ] || continue
+            if ! file -b "$f" | grep -q '^Mach-O'; then continue; fi
+            bad=$(otool -L "$f" | tail -n +2 | awk '{print $1}' | grep -E '^/(opt/homebrew|Users/runner)' || true)
+            if [ -n "$bad" ]; then
+              echo "::error::Build-host path leak in $(basename "$f"):"
+              echo "$bad"
+              LEAKS=$((LEAKS+1))
+            fi
           done
-          if ! "$STAGING/bin/pg_isready" -h 127.0.0.1 -p "$PORT"; then
-            echo "::error::pg_isready failed; server log:"
-            cat "$RUNNER_TEMP/pg.log"
-            kill $PG_PID 2>/dev/null || true
+          if [ "$LEAKS" -ne 0 ]; then
+            echo "::error::$LEAKS file(s) still reference build-host paths after patching"
             exit 1
           fi
-          VER_OUT=$("$STAGING/bin/psql" -h 127.0.0.1 -p "$PORT" -U postgres -tAc "SELECT version();")
-          echo "Server reported: $VER_OUT"
-          kill $PG_PID
-          wait $PG_PID 2>/dev/null || true
+          echo "All Mach-O files reference only relative or system paths."
+
+      - name: Integration test (initdb + extensions + pgbench + amcheck + dump roundtrip)
+        run: bash scripts/test-postgres-bundle.sh "$STAGING"
 
       - name: Strip docs
         run: rm -rf "$STAGING/share/doc"

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -301,7 +301,7 @@ jobs:
           compression-level: 0
 
   release:
-    needs: [resolve-version, build]
+    needs: [resolve-version, build, postgres]
     # Only publish from main. Dispatching from a feature branch runs the build
     # matrix as a test of the PHP/FrankenPHP binary builds without touching
     # the published release.
@@ -318,6 +318,11 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: php-mac-*
+          path: artifacts
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: postgres-mac-arm64-*
           path: artifacts
 
       - name: Prepare release assets
@@ -350,6 +355,13 @@ jobs:
             fi
           done
 
+          # Postgres bundles: expect both 17 and 18.
+          pg_dirs=(artifacts/postgres-mac-arm64-*)
+          if [ ${#pg_dirs[@]} -lt 2 ]; then
+            echo "::error::Expected 2 postgres bundles (17 + 18), found ${#pg_dirs[@]}"
+            exit 1
+          fi
+
           mkdir -p release
           # FrankenPHP binaries: artifact dir name matches the binary name.
           for dir in "${fp_dirs[@]}"; do
@@ -359,6 +371,10 @@ jobs:
           done
           # PHP CLI tarballs: just copy as-is (no chmod needed).
           for dir in "${php_dirs[@]}"; do
+            cp "$dir"/* "release/"
+          done
+          # Postgres tarballs: copy as-is (no chmod needed).
+          for dir in "${pg_dirs[@]}"; do
             cp "$dir"/* "release/"
           done
           ls -la release/

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,12 +1,7 @@
-name: Build PHP Artifacts
+name: Build artifacts
 
 on:
   workflow_dispatch:
-    inputs:
-      frankenphp_ref:
-        description: "FrankenPHP git ref (tag/branch/SHA). Leave empty for latest release."
-        required: false
-        default: ""
   schedule:
     - cron: "0 0 * * 1"
 
@@ -18,44 +13,28 @@ env:
   GOTOOLCHAIN: local
 
 jobs:
-  resolve-version:
-    runs-on: ubuntu-latest
-    outputs:
-      ref: ${{ steps.resolve.outputs.ref }}
-      version: ${{ steps.resolve.outputs.version }}
-    steps:
-      - name: Resolve FrankenPHP version
-        id: resolve
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          INPUT_REF="${{ inputs.frankenphp_ref }}"
-          if [ -n "$INPUT_REF" ]; then
-            echo "ref=${INPUT_REF}" >> "$GITHUB_OUTPUT"
-            echo "version=${INPUT_REF}" >> "$GITHUB_OUTPUT"
-          else
-            TAG=$(gh api repos/php/frankenphp/releases/latest --jq '.tag_name')
-            echo "ref=${TAG}" >> "$GITHUB_OUTPUT"
-            echo "version=${TAG}" >> "$GITHUB_OUTPUT"
-          fi
-
-  build:
-    needs: resolve-version
+  frankenphp:
     strategy:
       fail-fast: false
       matrix:
         php: ["8.3", "8.4", "8.5"]
-    name: PHP ${{ matrix.php }}
+    name: FrankenPHP + PHP ${{ matrix.php }}
     runs-on: macos-15
     permissions:
       contents: read
     env:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
+      - name: Resolve latest FrankenPHP release
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: echo "ref=$(gh api repos/php/frankenphp/releases/latest --jq '.tag_name')" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v4
         with:
           repository: php/frankenphp
-          ref: ${{ needs.resolve-version.outputs.ref }}
+          ref: ${{ steps.resolve.outputs.ref }}
 
       - uses: actions/setup-go@v5
         with:
@@ -86,14 +65,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: dist/static-php-cli/downloads
-          key: spc-downloads-${{ steps.arch.outputs.arch }}-php${{ matrix.php }}-${{ needs.resolve-version.outputs.ref }}
+          key: spc-downloads-${{ steps.arch.outputs.arch }}-php${{ matrix.php }}-${{ steps.resolve.outputs.ref }}
           restore-keys: |
             spc-downloads-${{ steps.arch.outputs.arch }}-php${{ matrix.php }}-
 
       - name: Build FrankenPHP with PHP ${{ matrix.php }}
         env:
           PHP_VERSION: ${{ matrix.php }}
-          FRANKENPHP_VERSION: ${{ needs.resolve-version.outputs.version }}
+          FRANKENPHP_VERSION: ${{ steps.resolve.outputs.ref }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SPC_OPT_DOWNLOAD_ARGS: "--ignore-cache-sources=php-src --retry 5 --prefer-pre-built"
           # Also build the standalone PHP CLI so it shares the exact same
@@ -304,7 +283,7 @@ jobs:
           compression-level: 0
 
   release:
-    needs: [resolve-version, build, postgres]
+    needs: [frankenphp, postgres]
     # Only publish from main. Dispatching from a feature branch runs the build
     # matrix as a test of the PHP/FrankenPHP binary builds without touching
     # the published release.

--- a/docs/superpowers/plans/2026-04-29-postgres-artifacts.md
+++ b/docs/superpowers/plans/2026-04-29-postgres-artifacts.md
@@ -182,7 +182,7 @@ Use Edit to insert this block immediately before `  release:`. The new content g
           wait $PG_PID 2>/dev/null || true
 
       - name: Strip docs
-        run: rm -rf "$STAGING/share/postgresql/doc"
+        run: rm -rf "$STAGING/share/doc"
 
       - name: Structural sanity checks
         run: |
@@ -195,7 +195,7 @@ Use Edit to insert this block immediately before `  release:`. The new content g
           test -f "$STAGING/bin/pg_config"
           test -f "$STAGING/lib/libssl.3.dylib"
           test -f "$STAGING/lib/libcrypto.3.dylib"
-          test -d "$STAGING/share/postgresql/extension"
+          test -d "$STAGING/share/extension"
           test -d "$STAGING/include"
           echo "Structural sanity checks passed."
 

--- a/docs/superpowers/plans/2026-04-29-postgres-artifacts.md
+++ b/docs/superpowers/plans/2026-04-29-postgres-artifacts.md
@@ -1,0 +1,528 @@
+# Postgres Artifacts Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `postgres` job to `.github/workflows/build-artifacts.yml` that mirrors zonkyio's PostgreSQL bundles (PG 17 + 18, macOS arm64) from Maven Central into the existing rolling `artifacts` release on `prvious/pv`.
+
+**Architecture:** Single workflow file, single rolling release. The new `postgres` job runs in parallel with the existing `build` job on `ubuntu-latest`, downloads the JAR from Maven, unwraps it (zip → xz tarball), strips docs, packs as `postgres-mac-arm64-{17,18}.tar.gz`, and hands off to the existing `release` job. The `release` job is extended to also wait on `postgres`, download the new workflow artifacts, validate them, and stage them for the existing `gh release upload --clobber` step.
+
+**Tech Stack:** GitHub Actions YAML, bash, `curl`, `unzip`, `tar` (with xz support, available on `ubuntu-latest`), `gh` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md`
+
+---
+
+## File Structure
+
+Single file modified — no new files.
+
+| File | Change | Responsibility |
+|---|---|---|
+| `.github/workflows/build-artifacts.yml` | Modify | Add `postgres` matrix job; extend `release` job to consume postgres workflow artifacts |
+
+The existing `resolve-version` and `build` jobs stay untouched. The `postgres` job is independent of them and runs in parallel. The `release` job's existing PHP/FrankenPHP logic stays intact; we only append postgres handling.
+
+---
+
+## Task 1: Pre-flight — verify Maven version resolution works
+
+**Files:** none (local sanity check before touching the workflow)
+
+This is a quick local check to confirm the Maven Central metadata URL and the version-grep one-liner produce sane results. If this fails, the workflow would fail too — better to catch it now.
+
+- [ ] **Step 1: Run the resolution one-liner for PG 17**
+
+```bash
+curl -fsSL "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/maven-metadata.xml" \
+  | grep -oE '<version>[^<]+' \
+  | sed 's/<version>//' \
+  | grep "^17\." \
+  | sort -V \
+  | tail -1
+```
+
+Expected: a single line like `17.6.0` (the actual patch version may differ — anything in the form `17.X.Y` is correct).
+
+- [ ] **Step 2: Run the resolution one-liner for PG 18**
+
+```bash
+curl -fsSL "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/maven-metadata.xml" \
+  | grep -oE '<version>[^<]+' \
+  | sed 's/<version>//' \
+  | grep "^18\." \
+  | sort -V \
+  | tail -1
+```
+
+Expected: `18.X.Y` (e.g. `18.3.0`).
+
+- [ ] **Step 3: Verify the JAR URL pattern downloads**
+
+Use the version from Step 2:
+
+```bash
+VER="18.3.0"  # substitute the version from Step 2
+curl -fsSI "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/${VER}/embedded-postgres-binaries-darwin-arm64v8-${VER}.jar" | head -1
+```
+
+Expected: `HTTP/2 200` (or `HTTP/1.1 200 OK`). Confirms the URL pattern is correct and the asset exists.
+
+If any of these three steps return empty / 404 / unexpected output, **stop and re-investigate** — the workflow will inherit the same problem.
+
+---
+
+## Task 2: Create a feature branch for the work
+
+**Files:** none
+
+- [ ] **Step 1: Verify git is clean**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean`. If not clean, stash or commit unrelated changes first.
+
+- [ ] **Step 2: Create and switch to the feature branch**
+
+```bash
+git checkout -b feat/postgres-artifacts
+```
+
+- [ ] **Step 3: Confirm branch**
+
+```bash
+git branch --show-current
+```
+
+Expected: `feat/postgres-artifacts`.
+
+---
+
+## Task 3: Add the `postgres` job to the workflow
+
+**Files:**
+- Modify: `.github/workflows/build-artifacts.yml`
+
+Insert a new top-level job named `postgres` between the existing `build` job (ends at line 155) and the existing `release` job (starts at line 157). The new job has no `needs:` and runs in parallel with `build`.
+
+- [ ] **Step 1: Read the file to confirm the insertion point**
+
+```bash
+sed -n '150,165p' .github/workflows/build-artifacts.yml
+```
+
+Expected: shows the tail of the `build` job's `Upload PHP CLI` step (around line 150–155) and the start of the `release` job at line 157. The insertion point is the blank line between them.
+
+- [ ] **Step 2: Insert the `postgres` job**
+
+Use Edit to insert this block immediately before `  release:` at line 157. The new content goes between the existing `build` job and `release` job.
+
+```yaml
+  postgres:
+    strategy:
+      fail-fast: false
+      matrix:
+        pg: ["17", "18"]
+    name: PostgreSQL ${{ matrix.pg }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Resolve latest patch version from Maven
+        id: resolve
+        run: |
+          set -euo pipefail
+          META_URL="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/maven-metadata.xml"
+          ALL=$(curl -fsSL "$META_URL" | grep -oE '<version>[^<]+' | sed 's/<version>//')
+          VER=$(echo "$ALL" | grep "^${{ matrix.pg }}\." | sort -V | tail -1)
+          if [ -z "$VER" ]; then
+            echo "::error::No ${{ matrix.pg }}.x version found on Maven Central"
+            exit 1
+          fi
+          echo "Resolved PG ${{ matrix.pg }}.x → $VER"
+          echo "version=$VER" >> "$GITHUB_OUTPUT"
+
+      - name: Download and unwrap JAR
+        run: |
+          set -euo pipefail
+          VER="${{ steps.resolve.outputs.version }}"
+          JAR_URL="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/${VER}/embedded-postgres-binaries-darwin-arm64v8-${VER}.jar"
+          curl -fsSL -o pg.jar "$JAR_URL"
+          mkdir -p unpacked staging
+          unzip -q pg.jar -d unpacked
+          tar -xJf unpacked/postgres-darwin-arm_64.txz -C staging
+
+      - name: Strip docs
+        run: rm -rf staging/share/postgresql/doc
+
+      - name: Structural sanity checks
+        run: |
+          set -euo pipefail
+          test -f staging/bin/postgres
+          test -f staging/bin/initdb
+          test -f staging/bin/psql
+          test -f staging/bin/pg_ctl
+          test -f staging/bin/pg_dump
+          test -f staging/bin/pg_config
+          test -f staging/lib/libssl.3.dylib
+          test -f staging/lib/libcrypto.3.dylib
+          test -f staging/lib/libicuuc.77.1.dylib
+          test -d staging/share/postgresql/extension
+          test -d staging/include
+          echo "Structural sanity checks passed."
+
+      - name: Repack
+        run: tar -czf "postgres-mac-arm64-${{ matrix.pg }}.tar.gz" -C staging bin lib share include
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: postgres-mac-arm64-${{ matrix.pg }}
+          path: postgres-mac-arm64-${{ matrix.pg }}.tar.gz
+          compression-level: 0
+
+```
+
+(Note the trailing blank line — preserves spacing before `release:`.)
+
+- [ ] **Step 3: Verify the file parses as YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-artifacts.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`. If yaml fails, the error message will point at the offending line — fix indentation and re-run.
+
+- [ ] **Step 4: Verify job structure with grep**
+
+```bash
+grep -n '^  [a-z-]*:$' .github/workflows/build-artifacts.yml
+```
+
+Expected: four lines listing the four top-level jobs in order:
+```
+  resolve-version:
+  build:
+  postgres:
+  release:
+```
+
+If `postgres:` is missing or in the wrong position, fix the insertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/build-artifacts.yml
+git commit -m "ci: add postgres job mirroring zonkyio bundles for PG 17/18"
+```
+
+---
+
+## Task 4: Wire postgres into the `release` job
+
+**Files:**
+- Modify: `.github/workflows/build-artifacts.yml`
+
+Three small edits to the existing `release` job:
+1. Add `postgres` to `needs:`
+2. Add a `download-artifact` step for the postgres workflow artifacts
+3. Add postgres validation + staging in the existing `Prepare release assets` step
+
+- [ ] **Step 1: Update `needs:` on the `release` job**
+
+The current line is:
+
+```yaml
+  release:
+    needs: [resolve-version, build]
+```
+
+Change it to:
+
+```yaml
+  release:
+    needs: [resolve-version, build, postgres]
+```
+
+Edit:
+
+- old_string: `    needs: [resolve-version, build]`
+- new_string: `    needs: [resolve-version, build, postgres]`
+
+- [ ] **Step 2: Add `download-artifact` step for postgres**
+
+Add this step in the `release` job's `steps:` block, **immediately after** the existing `download-artifact` step that downloads `php-mac-*` (currently lines 172–175). Insert before the `Prepare release assets` step.
+
+The existing block to find and anchor on:
+
+```yaml
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: php-mac-*
+          path: artifacts
+
+      - name: Prepare release assets
+```
+
+Replace with:
+
+```yaml
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: php-mac-*
+          path: artifacts
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: postgres-mac-arm64-*
+          path: artifacts
+
+      - name: Prepare release assets
+```
+
+- [ ] **Step 3: Extend `Prepare release assets` with postgres validation + staging**
+
+Inside the existing `Prepare release assets` step's `run:` block, find the validation block that ends with the FrankenPHP↔PHP-CLI matching check, and add postgres validation + staging.
+
+Find this anchor (existing code):
+
+```bash
+          for dir in "${fp_dirs[@]}"; do
+            suffix="${dir#artifacts/frankenphp-}"
+            if [ ! -d "artifacts/php-${suffix}" ]; then
+              echo "::error::Missing PHP CLI artifact for frankenphp-${suffix}"
+              exit 1
+            fi
+          done
+
+          mkdir -p release
+```
+
+Replace with:
+
+```bash
+          for dir in "${fp_dirs[@]}"; do
+            suffix="${dir#artifacts/frankenphp-}"
+            if [ ! -d "artifacts/php-${suffix}" ]; then
+              echo "::error::Missing PHP CLI artifact for frankenphp-${suffix}"
+              exit 1
+            fi
+          done
+
+          # Postgres bundles: expect both 17 and 18.
+          pg_dirs=(artifacts/postgres-mac-arm64-*)
+          if [ ${#pg_dirs[@]} -lt 2 ]; then
+            echo "::error::Expected 2 postgres bundles (17 + 18), found ${#pg_dirs[@]}"
+            exit 1
+          fi
+
+          mkdir -p release
+```
+
+Then add postgres staging at the end of the `mkdir -p release` block. Find this anchor (existing code):
+
+```bash
+          # PHP CLI tarballs: just copy as-is (no chmod needed).
+          for dir in "${php_dirs[@]}"; do
+            cp "$dir"/* "release/"
+          done
+          ls -la release/
+```
+
+Replace with:
+
+```bash
+          # PHP CLI tarballs: just copy as-is (no chmod needed).
+          for dir in "${php_dirs[@]}"; do
+            cp "$dir"/* "release/"
+          done
+          # Postgres tarballs: copy as-is (no chmod needed).
+          for dir in "${pg_dirs[@]}"; do
+            cp "$dir"/* "release/"
+          done
+          ls -la release/
+```
+
+- [ ] **Step 4: Verify the file still parses as YAML**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-artifacts.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`.
+
+- [ ] **Step 5: Verify the `release` job's `needs:` was updated**
+
+```bash
+grep -A1 '^  release:' .github/workflows/build-artifacts.yml | head -2
+```
+
+Expected:
+```
+  release:
+    needs: [resolve-version, build, postgres]
+```
+
+- [ ] **Step 6: Verify the postgres validation block is in place**
+
+```bash
+grep -n 'pg_dirs' .github/workflows/build-artifacts.yml
+```
+
+Expected: 3 lines — one for the array assignment, one for the count check, one for the staging loop.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/build-artifacts.yml
+git commit -m "ci: wire postgres bundles into release job"
+```
+
+---
+
+## Task 5: Push and dispatch from the feature branch
+
+**Files:** none (CI verification)
+
+The feature-branch dispatch runs `build` and `postgres` but skips `release` (gated on `github.ref == 'refs/heads/main'`). This validates the new job without touching the live `artifacts` release.
+
+- [ ] **Step 1: Push the feature branch**
+
+```bash
+git push -u origin feat/postgres-artifacts
+```
+
+Expected: `* [new branch] feat/postgres-artifacts -> feat/postgres-artifacts`.
+
+- [ ] **Step 2: Dispatch the workflow from the feature branch**
+
+```bash
+gh workflow run build-artifacts.yml --ref feat/postgres-artifacts
+```
+
+Expected: `✓ Created workflow_dispatch event for build-artifacts.yml at feat/postgres-artifacts`.
+
+- [ ] **Step 3: Watch the workflow**
+
+```bash
+sleep 5  # let GitHub register the dispatch
+gh run list --workflow=build-artifacts.yml --branch=feat/postgres-artifacts --limit 1
+```
+
+Note the run ID, then:
+
+```bash
+gh run watch <RUN_ID>
+```
+
+Expected: `build` matrix and `postgres` matrix both complete successfully. `release` is skipped (gated on `refs/heads/main`).
+
+If `postgres` fails: inspect logs with `gh run view <RUN_ID> --log-failed` and iterate. Common failure modes:
+- Maven URL changed → fix URL in workflow.
+- zonkyio published a malformed bundle → sanity check `test -f` fails → check the latest version manually with `tar -tJf unpacked/postgres-darwin-arm_64.txz`.
+- YAML indentation issue → re-validate locally with `python3 -c "import yaml; …"`.
+
+- [ ] **Step 4: Inspect the workflow artifacts**
+
+```bash
+gh run download <RUN_ID> --name postgres-mac-arm64-17
+gh run download <RUN_ID> --name postgres-mac-arm64-18
+ls -lh postgres-mac-arm64-*.tar.gz
+tar -tzf postgres-mac-arm64-17.tar.gz | head -20
+tar -tzf postgres-mac-arm64-17.tar.gz | grep -E 'bin/postgres$|lib/libssl' | head
+```
+
+Expected:
+- File sizes ~30–35 MB each.
+- `tar -tzf` shows `bin/`, `lib/`, `share/`, `include/` at the root (flat structure).
+- `bin/postgres` and `lib/libssl.3.dylib` are present.
+
+- [ ] **Step 5: Clean up downloaded test artifacts**
+
+```bash
+rm -f postgres-mac-arm64-17.tar.gz postgres-mac-arm64-18.tar.gz
+```
+
+---
+
+## Task 6: Open a PR
+
+**Files:** none (GitHub PR creation)
+
+- [ ] **Step 1: Open the PR**
+
+```bash
+gh pr create --title "ci: add postgres artifacts pipeline (PG 17/18, macOS arm64)" --body "$(cat <<'EOF'
+## Summary
+- Adds a new `postgres` job to `build-artifacts.yml` that mirrors zonkyio's PostgreSQL bundles (PG 17 + 18, macOS arm64) from Maven Central
+- Bundles are stripped of docs and repacked as `postgres-mac-arm64-{17,18}.tar.gz`
+- Released to the existing rolling `artifacts` tag on `prvious/pv` alongside FrankenPHP + PHP CLI assets
+- Weekly cron + manual dispatch, mirrors existing FrankenPHP pipeline shape
+
+Spec: `docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md`
+
+## Test plan
+- [x] Local Maven resolution one-liner returns valid versions for both PG 17 and 18
+- [x] YAML validates with `python3 -c "import yaml; yaml.safe_load(...)"`
+- [x] Feature-branch workflow dispatch: `build` and `postgres` jobs both succeed; `release` correctly skipped
+- [x] Workflow artifacts inspected: ~30–35 MB tarballs, flat root, `bin/postgres` + `lib/libssl.3.dylib` present
+- [ ] After merge: first scheduled (or dispatched) run from `main` publishes `postgres-mac-arm64-17.tar.gz` and `postgres-mac-arm64-18.tar.gz` to the `artifacts` release
+EOF
+)"
+```
+
+- [ ] **Step 2: Note the PR URL**
+
+The command above prints the PR URL. Save it for the post-merge verification step.
+
+---
+
+## Task 7: After merge — verify live release
+
+**Files:** none (post-merge verification, only after PR is merged to main)
+
+- [ ] **Step 1: Confirm merge and switch back to main**
+
+```bash
+git checkout main
+git pull
+```
+
+- [ ] **Step 2: Trigger the workflow from main**
+
+The weekly cron will fire on the next Monday, but a manual dispatch verifies immediately:
+
+```bash
+gh workflow run build-artifacts.yml --ref main
+sleep 5
+gh run list --workflow=build-artifacts.yml --branch=main --limit 1
+gh run watch <RUN_ID>
+```
+
+Expected: all three build-side jobs (`resolve-version`, `build`, `postgres`) succeed, then `release` runs and uploads.
+
+- [ ] **Step 3: Verify assets are live**
+
+```bash
+gh release view artifacts --json assets --jq '.assets[].name' | grep '^postgres-'
+```
+
+Expected:
+```
+postgres-mac-arm64-17.tar.gz
+postgres-mac-arm64-18.tar.gz
+```
+
+- [ ] **Step 4: Spot-check by downloading one asset**
+
+```bash
+gh release download artifacts -p 'postgres-mac-arm64-17.tar.gz' -O /tmp/pg17-live.tar.gz
+ls -lh /tmp/pg17-live.tar.gz
+tar -tzf /tmp/pg17-live.tar.gz | head -10
+rm /tmp/pg17-live.tar.gz
+```
+
+Expected: ~30–35 MB, flat root with `bin/`, `lib/`, `share/`, `include/`.
+
+If everything verifies, the artifacts pipeline is live and the weekly cron will keep it fresh from here on. The pv-side consumer code (downloader, `internal/postgresenv/`, shims, daemon integration) is the next plan.

--- a/docs/superpowers/plans/2026-04-29-postgres-artifacts.md
+++ b/docs/superpowers/plans/2026-04-29-postgres-artifacts.md
@@ -2,11 +2,11 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a `postgres` job to `.github/workflows/build-artifacts.yml` that mirrors zonkyio's PostgreSQL bundles (PG 17 + 18, macOS arm64) from Maven Central into the existing rolling `artifacts` release on `prvious/pv`.
+**Goal:** Add a `postgres` job to `.github/workflows/build-artifacts.yml` that mirrors theseus-rs's PostgreSQL bundles (PG 17 + 18, macOS arm64), patches Homebrew-pinned openssl `install_name`s to relative `@executable_path` references, runs an in-CI smoke test, and publishes the corrected bundles to the existing rolling `artifacts` release on `prvious/pv`.
 
-**Architecture:** Single workflow file, single rolling release. The new `postgres` job runs in parallel with the existing `build` job on `ubuntu-latest`, downloads the JAR from Maven, unwraps it (zip → xz tarball), strips docs, packs as `postgres-mac-arm64-{17,18}.tar.gz`, and hands off to the existing `release` job. The `release` job is extended to also wait on `postgres`, download the new workflow artifacts, validate them, and stage them for the existing `gh release upload --clobber` step.
+**Architecture:** Single workflow file, single rolling release. The new `postgres` job runs in parallel with the existing `build` job on `macos-15` (required because `install_name_tool` and `codesign` are darwin-only). Steps: download from theseus-rs, bundle Homebrew openssl into the staging tree, patch `install_name`s on every Mach-O binary/dylib, ad-hoc codesign, verify no Homebrew paths remain, smoke-test (initdb + start + psql query), strip docs, repack, upload.
 
-**Tech Stack:** GitHub Actions YAML, bash, `curl`, `unzip`, `tar` (with xz support, available on `ubuntu-latest`), `gh` CLI.
+**Tech Stack:** GitHub Actions YAML, bash, `gh api` (for theseus-rs release listing), `curl`, `tar`, `install_name_tool`, `codesign`, `otool`.
 
 **Spec:** `docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md`
 
@@ -18,84 +18,30 @@ Single file modified — no new files.
 
 | File | Change | Responsibility |
 |---|---|---|
-| `.github/workflows/build-artifacts.yml` | Modify | Add `postgres` matrix job; extend `release` job to consume postgres workflow artifacts |
+| `.github/workflows/build-artifacts.yml` | Modify | Add `postgres` matrix job (macos-15) + extend `release` job to consume postgres workflow artifacts |
 
-The existing `resolve-version` and `build` jobs stay untouched. The `postgres` job is independent of them and runs in parallel. The `release` job's existing PHP/FrankenPHP logic stays intact; we only append postgres handling.
-
----
-
-## Task 1: Pre-flight — verify Maven version resolution works
-
-**Files:** none (local sanity check before touching the workflow)
-
-This is a quick local check to confirm the Maven Central metadata URL and the version-grep one-liner produce sane results. If this fails, the workflow would fail too — better to catch it now.
-
-- [ ] **Step 1: Run the resolution one-liner for PG 17**
-
-```bash
-curl -fsSL "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/maven-metadata.xml" \
-  | grep -oE '<version>[^<]+' \
-  | sed 's/<version>//' \
-  | grep "^17\." \
-  | sort -V \
-  | tail -1
-```
-
-Expected: a single line like `17.6.0` (the actual patch version may differ — anything in the form `17.X.Y` is correct).
-
-- [ ] **Step 2: Run the resolution one-liner for PG 18**
-
-```bash
-curl -fsSL "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/maven-metadata.xml" \
-  | grep -oE '<version>[^<]+' \
-  | sed 's/<version>//' \
-  | grep "^18\." \
-  | sort -V \
-  | tail -1
-```
-
-Expected: `18.X.Y` (e.g. `18.3.0`).
-
-- [ ] **Step 3: Verify the JAR URL pattern downloads**
-
-Use the version from Step 2:
-
-```bash
-VER="18.3.0"  # substitute the version from Step 2
-curl -fsSI "https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/${VER}/embedded-postgres-binaries-darwin-arm64v8-${VER}.jar" | head -1
-```
-
-Expected: `HTTP/2 200` (or `HTTP/1.1 200 OK`). Confirms the URL pattern is correct and the asset exists.
-
-If any of these three steps return empty / 404 / unexpected output, **stop and re-investigate** — the workflow will inherit the same problem.
+The existing `resolve-version` and `build` jobs stay untouched. The `postgres` job runs in parallel with them. The `release` job's existing PHP/FrankenPHP logic stays intact; we only append postgres handling.
 
 ---
 
-## Task 2: Create a feature branch for the work
+## Task 1: Pre-flight verification (already done)
 
-**Files:** none
+Verified locally before plan execution:
 
-- [ ] **Step 1: Verify git is clean**
+- ✅ theseus-rs publishes both PG 17.9.0 and PG 18.3.0 with `aarch64-apple-darwin` assets.
+- ✅ Both archives ship 37 binaries (`postgres`, `initdb`, `pg_ctl`, `psql`, `pg_dump`, `pg_restore`, `pg_config`, `pg_isready`, `createdb`, etc.) and an `include/` directory.
+- ✅ Both archives' `bin/postgres` references `/opt/homebrew/opt/openssl@3/lib/lib{ssl,crypto}.3.dylib` and otherwise only `/usr/lib/*` system libs.
+- ✅ End-to-end pipeline verified locally (download → bundle Homebrew openssl → `install_name_tool` patching → ad-hoc codesign → `initdb` → start postgres → `psql SELECT version()` → teardown) for both PG 17.9.0 and PG 18.3.0.
 
-```bash
-git status
-```
+No further pre-flight needed.
 
-Expected: `nothing to commit, working tree clean`. If not clean, stash or commit unrelated changes first.
+---
 
-- [ ] **Step 2: Create and switch to the feature branch**
+## Task 2: Feature branch (already done)
 
-```bash
-git checkout -b feat/postgres-artifacts
-```
-
-- [ ] **Step 3: Confirm branch**
-
-```bash
-git branch --show-current
-```
-
-Expected: `feat/postgres-artifacts`.
+Branch `feat/postgres-artifacts` already exists and is checked out. The
+prior bad commit (zonkyio-based postgres job) has been reset; the branch
+is currently at `23efcea` (parent of main's plan/spec commits).
 
 ---
 
@@ -104,7 +50,7 @@ Expected: `feat/postgres-artifacts`.
 **Files:**
 - Modify: `.github/workflows/build-artifacts.yml`
 
-Insert a new top-level job named `postgres` between the existing `build` job (ends at line 155) and the existing `release` job (starts at line 157). The new job has no `needs:` and runs in parallel with `build`.
+Insert a new top-level job named `postgres` between the existing `build` job (ends around line 155) and the existing `release` job (starts around line 157). The new job has no `needs:` and runs in parallel with `build`.
 
 - [ ] **Step 1: Read the file to confirm the insertion point**
 
@@ -112,11 +58,11 @@ Insert a new top-level job named `postgres` between the existing `build` job (en
 sed -n '150,165p' .github/workflows/build-artifacts.yml
 ```
 
-Expected: shows the tail of the `build` job's `Upload PHP CLI` step (around line 150–155) and the start of the `release` job at line 157. The insertion point is the blank line between them.
+Expected: shows the tail of the `build` job's `Upload PHP CLI` step and the start of the `release` job. The insertion point is the blank line between them.
 
 - [ ] **Step 2: Insert the `postgres` job**
 
-Use Edit to insert this block immediately before `  release:` at line 157. The new content goes between the existing `build` job and `release` job.
+Use Edit to insert this block immediately before `  release:`. The new content goes between the existing `build` job and `release` job, indented at 2 spaces for the job key (matching the `build` and `release` siblings).
 
 ```yaml
   postgres:
@@ -125,55 +71,136 @@ Use Edit to insert this block immediately before `  release:` at line 157. The n
       matrix:
         pg: ["17", "18"]
     name: PostgreSQL ${{ matrix.pg }}
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     permissions:
       contents: read
     steps:
-      - name: Resolve latest patch version from Maven
+      - name: Resolve latest patch version from theseus-rs
         id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          META_URL="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/maven-metadata.xml"
-          ALL=$(curl -fsSL "$META_URL" | grep -oE '<version>[^<]+' | sed 's/<version>//')
+          ALL=$(gh api 'repos/theseus-rs/postgresql-binaries/releases?per_page=100' --paginate --jq '.[].tag_name')
           VER=$(echo "$ALL" | grep "^${{ matrix.pg }}\." | sort -V | tail -1)
           if [ -z "$VER" ]; then
-            echo "::error::No ${{ matrix.pg }}.x version found on Maven Central"
+            echo "::error::No ${{ matrix.pg }}.x release on theseus-rs"
             exit 1
           fi
-          echo "Resolved PG ${{ matrix.pg }}.x → $VER"
+          echo "Resolved PG ${{ matrix.pg }} → $VER"
           echo "version=$VER" >> "$GITHUB_OUTPUT"
 
-      - name: Download and unwrap JAR
+      - name: Download and extract theseus-rs bundle
         run: |
           set -euo pipefail
           VER="${{ steps.resolve.outputs.version }}"
-          JAR_URL="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/${VER}/embedded-postgres-binaries-darwin-arm64v8-${VER}.jar"
-          curl -fsSL -o pg.jar "$JAR_URL"
-          mkdir -p unpacked staging
-          unzip -q pg.jar -d unpacked
-          tar -xJf unpacked/postgres-darwin-arm_64.txz -C staging
+          URL="https://github.com/theseus-rs/postgresql-binaries/releases/download/${VER}/postgresql-${VER}-aarch64-apple-darwin.tar.gz"
+          curl -fsSL -o pg.tar.gz "$URL"
+          mkdir extracted
+          tar -xzf pg.tar.gz -C extracted
+          STAGING=$(ls -d extracted/postgresql-*-aarch64-apple-darwin)
+          echo "STAGING=$STAGING" >> "$GITHUB_ENV"
+
+      - name: Bundle Homebrew openssl into staging
+        run: |
+          set -euo pipefail
+          cp /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib   "$STAGING/lib/"
+          cp /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib "$STAGING/lib/"
+          chmod 755 "$STAGING/lib/libssl.3.dylib" "$STAGING/lib/libcrypto.3.dylib"
+
+      - name: Patch install_names to relative paths
+        run: |
+          set -euo pipefail
+          # Rewrite LC_ID_DYLIB on bundled openssl (their own identity)
+          install_name_tool -id "@executable_path/../lib/libssl.3.dylib"   "$STAGING/lib/libssl.3.dylib"
+          install_name_tool -id "@executable_path/../lib/libcrypto.3.dylib" "$STAGING/lib/libcrypto.3.dylib"
+          # libssl carries a hardcoded reference to libcrypto via Homebrew Cellar version path.
+          # Discover it from otool -L rather than reconstructing the path.
+          CRYPTO_REF=$(otool -L "$STAGING/lib/libssl.3.dylib" | awk '/libcrypto\.3\.dylib/ && !/@executable_path/ {print $1; exit}')
+          if [ -n "$CRYPTO_REF" ]; then
+            install_name_tool -change "$CRYPTO_REF" "@executable_path/../lib/libcrypto.3.dylib" "$STAGING/lib/libssl.3.dylib"
+          fi
+          # Walk every Mach-O in bin/ and lib/, rewrite the two openssl paths.
+          for f in "$STAGING/bin/"* "$STAGING/lib/"*.dylib; do
+            [ -L "$f" ] && continue
+            [ -f "$f" ] || continue
+            if file -b "$f" | grep -q '^Mach-O'; then
+              install_name_tool -change \
+                "/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib" \
+                "@executable_path/../lib/libssl.3.dylib" \
+                "$f" 2>/dev/null || true
+              install_name_tool -change \
+                "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib" \
+                "@executable_path/../lib/libcrypto.3.dylib" \
+                "$f" 2>/dev/null || true
+            fi
+          done
+
+      - name: Ad-hoc codesign all Mach-O files
+        run: |
+          set -euo pipefail
+          for f in "$STAGING/bin/"* "$STAGING/lib/"*.dylib; do
+            [ -L "$f" ] && continue
+            [ -f "$f" ] || continue
+            if file -b "$f" | grep -q '^Mach-O'; then
+              codesign --force --sign - "$f"
+            fi
+          done
+
+      - name: Verify deps reference no Homebrew paths
+        run: |
+          set -euo pipefail
+          echo "postgres dependencies:"
+          otool -L "$STAGING/bin/postgres"
+          if otool -L "$STAGING/bin/postgres" | grep -E '/opt/homebrew' ; then
+            echo "::error::postgres still references Homebrew paths after patching"
+            exit 1
+          fi
+
+      - name: Smoke test (initdb + start + psql + stop)
+        run: |
+          set -euo pipefail
+          DATA_DIR="$RUNNER_TEMP/pgdata"
+          rm -rf "$DATA_DIR"
+          "$STAGING/bin/initdb" -D "$DATA_DIR" -U postgres --auth=trust >/dev/null
+          PORT=54199
+          "$STAGING/bin/postgres" -D "$DATA_DIR" -p "$PORT" -k "$DATA_DIR" >"$RUNNER_TEMP/pg.log" 2>&1 &
+          PG_PID=$!
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if "$STAGING/bin/pg_isready" -h 127.0.0.1 -p "$PORT" >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          if ! "$STAGING/bin/pg_isready" -h 127.0.0.1 -p "$PORT"; then
+            echo "::error::pg_isready failed; server log:"
+            cat "$RUNNER_TEMP/pg.log"
+            kill $PG_PID 2>/dev/null || true
+            exit 1
+          fi
+          VER_OUT=$("$STAGING/bin/psql" -h 127.0.0.1 -p "$PORT" -U postgres -tAc "SELECT version();")
+          echo "Server reported: $VER_OUT"
+          kill $PG_PID
+          wait $PG_PID 2>/dev/null || true
 
       - name: Strip docs
-        run: rm -rf staging/share/postgresql/doc
+        run: rm -rf "$STAGING/share/postgresql/doc"
 
       - name: Structural sanity checks
         run: |
           set -euo pipefail
-          test -f staging/bin/postgres
-          test -f staging/bin/initdb
-          test -f staging/bin/psql
-          test -f staging/bin/pg_ctl
-          test -f staging/bin/pg_dump
-          test -f staging/bin/pg_config
-          test -f staging/lib/libssl.3.dylib
-          test -f staging/lib/libcrypto.3.dylib
-          test -f staging/lib/libicuuc.77.1.dylib
-          test -d staging/share/postgresql/extension
-          test -d staging/include
+          test -f "$STAGING/bin/postgres"
+          test -f "$STAGING/bin/initdb"
+          test -f "$STAGING/bin/pg_ctl"
+          test -f "$STAGING/bin/psql"
+          test -f "$STAGING/bin/pg_dump"
+          test -f "$STAGING/bin/pg_config"
+          test -f "$STAGING/lib/libssl.3.dylib"
+          test -f "$STAGING/lib/libcrypto.3.dylib"
+          test -d "$STAGING/share/postgresql/extension"
+          test -d "$STAGING/include"
           echo "Structural sanity checks passed."
 
       - name: Repack
-        run: tar -czf "postgres-mac-arm64-${{ matrix.pg }}.tar.gz" -C staging bin lib share include
+        run: tar -czf "postgres-mac-arm64-${{ matrix.pg }}.tar.gz" -C "$STAGING" bin lib share include
 
       - name: Upload binary
         uses: actions/upload-artifact@v4
@@ -208,13 +235,11 @@ Expected: four lines listing the four top-level jobs in order:
   release:
 ```
 
-If `postgres:` is missing or in the wrong position, fix the insertion.
-
 - [ ] **Step 5: Commit**
 
 ```bash
 git add .github/workflows/build-artifacts.yml
-git commit -m "ci: add postgres job mirroring zonkyio bundles for PG 17/18"
+git commit -m "ci: add postgres job mirroring theseus-rs bundles for PG 17/18"
 ```
 
 ---
@@ -246,13 +271,12 @@ Change it to:
 ```
 
 Edit:
-
 - old_string: `    needs: [resolve-version, build]`
 - new_string: `    needs: [resolve-version, build, postgres]`
 
 - [ ] **Step 2: Add `download-artifact` step for postgres**
 
-Add this step in the `release` job's `steps:` block, **immediately after** the existing `download-artifact` step that downloads `php-mac-*` (currently lines 172–175). Insert before the `Prepare release assets` step.
+Add this step in the `release` job's `steps:` block, **immediately after** the existing `download-artifact` step that downloads `php-mac-*`. Insert before the `Prepare release assets` step.
 
 The existing block to find and anchor on:
 
@@ -283,7 +307,7 @@ Replace with:
 
 - [ ] **Step 3: Extend `Prepare release assets` with postgres validation + staging**
 
-Inside the existing `Prepare release assets` step's `run:` block, find the validation block that ends with the FrankenPHP↔PHP-CLI matching check, and add postgres validation + staging.
+Inside the existing `Prepare release assets` step's `run:` block, find the validation block that ends with the FrankenPHP↔PHP-CLI matching check, and add postgres validation.
 
 Find this anchor (existing code):
 
@@ -320,7 +344,7 @@ Replace with:
           mkdir -p release
 ```
 
-Then add postgres staging at the end of the `mkdir -p release` block. Find this anchor (existing code):
+Then add postgres staging at the end of the staging loops. Find this anchor (existing code):
 
 ```bash
           # PHP CLI tarballs: just copy as-is (no chmod needed).
@@ -370,7 +394,7 @@ Expected:
 grep -n 'pg_dirs' .github/workflows/build-artifacts.yml
 ```
 
-Expected: 3 lines — one for the array assignment, one for the count check, one for the staging loop.
+Expected: 3 lines — array assignment, count check, staging loop.
 
 - [ ] **Step 7: Commit**
 
@@ -406,7 +430,7 @@ Expected: `✓ Created workflow_dispatch event for build-artifacts.yml at feat/p
 - [ ] **Step 3: Watch the workflow**
 
 ```bash
-sleep 5  # let GitHub register the dispatch
+sleep 5
 gh run list --workflow=build-artifacts.yml --branch=feat/postgres-artifacts --limit 1
 ```
 
@@ -416,12 +440,12 @@ Note the run ID, then:
 gh run watch <RUN_ID>
 ```
 
-Expected: `build` matrix and `postgres` matrix both complete successfully. `release` is skipped (gated on `refs/heads/main`).
+Expected: `build` matrix and `postgres` matrix both complete successfully. `release` is skipped.
 
-If `postgres` fails: inspect logs with `gh run view <RUN_ID> --log-failed` and iterate. Common failure modes:
-- Maven URL changed → fix URL in workflow.
-- zonkyio published a malformed bundle → sanity check `test -f` fails → check the latest version manually with `tar -tJf unpacked/postgres-darwin-arm_64.txz`.
-- YAML indentation issue → re-validate locally with `python3 -c "import yaml; …"`.
+If `postgres` fails: inspect with `gh run view <RUN_ID> --log-failed`. Common failure modes:
+- theseus-rs API/release URL changed → fix URL.
+- Homebrew openssl path on `macos-15` runner changed → adjust `cp` source path.
+- Smoke test fails: `psql` returned non-zero or unexpected output → check the server log printed by the workflow.
 
 - [ ] **Step 4: Inspect the workflow artifacts**
 
@@ -430,18 +454,30 @@ gh run download <RUN_ID> --name postgres-mac-arm64-17
 gh run download <RUN_ID> --name postgres-mac-arm64-18
 ls -lh postgres-mac-arm64-*.tar.gz
 tar -tzf postgres-mac-arm64-17.tar.gz | head -20
-tar -tzf postgres-mac-arm64-17.tar.gz | grep -E 'bin/postgres$|lib/libssl' | head
+tar -tzf postgres-mac-arm64-17.tar.gz | grep -E 'bin/postgres$|bin/psql$|bin/pg_dump$|bin/pg_config$|lib/libssl|include' | head
 ```
 
 Expected:
-- File sizes ~30–35 MB each.
+- File sizes ~10-15 MB compressed each.
 - `tar -tzf` shows `bin/`, `lib/`, `share/`, `include/` at the root (flat structure).
-- `bin/postgres` and `lib/libssl.3.dylib` are present.
+- All key binaries (`postgres`, `psql`, `pg_dump`, `pg_config`) present.
+- `include/` directory present.
 
-- [ ] **Step 5: Clean up downloaded test artifacts**
+- [ ] **Step 5: Verify dependencies on a downloaded bundle**
+
+```bash
+mkdir /tmp/pg-verify && cd /tmp/pg-verify && tar -xzf "$OLDPWD/postgres-mac-arm64-18.tar.gz"
+otool -L bin/postgres
+cd "$OLDPWD"
+```
+
+Expected: every line should reference either `@executable_path/...` or `/usr/lib/...` — NO `/opt/homebrew/...` paths.
+
+- [ ] **Step 6: Clean up downloaded test artifacts**
 
 ```bash
 rm -f postgres-mac-arm64-17.tar.gz postgres-mac-arm64-18.tar.gz
+rm -rf /tmp/pg-verify
 ```
 
 ---
@@ -455,18 +491,22 @@ rm -f postgres-mac-arm64-17.tar.gz postgres-mac-arm64-18.tar.gz
 ```bash
 gh pr create --title "ci: add postgres artifacts pipeline (PG 17/18, macOS arm64)" --body "$(cat <<'EOF'
 ## Summary
-- Adds a new `postgres` job to `build-artifacts.yml` that mirrors zonkyio's PostgreSQL bundles (PG 17 + 18, macOS arm64) from Maven Central
-- Bundles are stripped of docs and repacked as `postgres-mac-arm64-{17,18}.tar.gz`
+- Adds a new `postgres` job to `build-artifacts.yml` that mirrors theseus-rs's PostgreSQL bundles (PG 17 + 18, macOS arm64) from GitHub Releases
+- Patches Homebrew-pinned openssl `install_name`s to relative `@executable_path/../lib/...` references so bundles run on Macs without Homebrew openssl@3 installed
+- Bundles `libssl.3.dylib` + `libcrypto.3.dylib` from the runner's Homebrew openssl@3 into the archive's `lib/`
+- Ad-hoc codesigns every Mach-O after patching to satisfy macOS Gatekeeper
+- In-CI smoke test: `initdb` + start postgres + `psql SELECT version()` + clean teardown — catches runtime breakage before publishing
 - Released to the existing rolling `artifacts` tag on `prvious/pv` alongside FrankenPHP + PHP CLI assets
-- Weekly cron + manual dispatch, mirrors existing FrankenPHP pipeline shape
+- Weekly cron + manual dispatch, parallel to existing FrankenPHP build
 
 Spec: `docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md`
 
 ## Test plan
-- [x] Local Maven resolution one-liner returns valid versions for both PG 17 and 18
+- [x] Local end-to-end pipeline verified for both PG 17.9.0 and PG 18.3.0 (download → patch → codesign → initdb → postgres → psql roundtrip)
 - [x] YAML validates with `python3 -c "import yaml; yaml.safe_load(...)"`
 - [x] Feature-branch workflow dispatch: `build` and `postgres` jobs both succeed; `release` correctly skipped
-- [x] Workflow artifacts inspected: ~30–35 MB tarballs, flat root, `bin/postgres` + `lib/libssl.3.dylib` present
+- [x] Workflow artifacts inspected: ~10-15 MB tarballs, flat root, all 37 binaries present, `include/` present
+- [x] `otool -L bin/postgres` on downloaded bundle shows no `/opt/homebrew/*` references
 - [ ] After merge: first scheduled (or dispatched) run from `main` publishes `postgres-mac-arm64-17.tar.gz` and `postgres-mac-arm64-18.tar.gz` to the `artifacts` release
 EOF
 )"
@@ -500,7 +540,7 @@ gh run list --workflow=build-artifacts.yml --branch=main --limit 1
 gh run watch <RUN_ID>
 ```
 
-Expected: all three build-side jobs (`resolve-version`, `build`, `postgres`) succeed, then `release` runs and uploads.
+Expected: all four build-side jobs (`resolve-version`, `build`, `postgres`) succeed, then `release` runs and uploads.
 
 - [ ] **Step 3: Verify assets are live**
 
@@ -523,6 +563,6 @@ tar -tzf /tmp/pg17-live.tar.gz | head -10
 rm /tmp/pg17-live.tar.gz
 ```
 
-Expected: ~30–35 MB, flat root with `bin/`, `lib/`, `share/`, `include/`.
+Expected: ~10-15 MB, flat root with `bin/`, `lib/`, `share/`, `include/`.
 
-If everything verifies, the artifacts pipeline is live and the weekly cron will keep it fresh from here on. The pv-side consumer code (downloader, `internal/postgresenv/`, shims, daemon integration) is the next plan.
+If everything verifies, the artifacts pipeline is live and the weekly cron will keep it fresh from here on.

--- a/docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md
+++ b/docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md
@@ -2,9 +2,11 @@
 
 ## Goal
 
-Mirror zonkyio's PostgreSQL bundles from Maven Central into the existing
-`artifacts` release on `prvious/pv`, so pv can consume them via the same
-download pattern it already uses for FrankenPHP and the static PHP CLI.
+Mirror **theseus-rs's** compiled-from-source PostgreSQL bundles into the
+existing `artifacts` release on `prvious/pv`, with a CI patching pass that
+rewrites Homebrew-pinned openssl `install_name`s to relative
+`@executable_path` references so the bundles run on any macOS Apple Silicon
+machine without external dependencies.
 
 This is the foundational artifacts step. It does not include any pv-side
 consumer code (downloader, postgresenv package, shims, daemon integration);
@@ -14,8 +16,8 @@ those follow in separate plans.
 
 - Platform: macOS arm64 only (Apple Silicon, "M-series").
 - Versions: PostgreSQL major **17** and **18**, latest patch of each.
-- Source: `io.zonky.test.postgres:embedded-postgres-binaries-darwin-arm64v8`
-  on Maven Central.
+- Source: `theseus-rs/postgresql-binaries` GitHub releases
+  (asset: `postgresql-<ver>-aarch64-apple-darwin.tar.gz`).
 - Cadence: weekly cron (Monday 00:00 UTC), plus manual `workflow_dispatch`.
 - Output: two assets in the existing rolling `artifacts` release on
   `prvious/pv`:
@@ -25,44 +27,63 @@ those follow in separate plans.
 ## Non-goals (v1)
 
 - Other architectures (mac x86_64, linux amd64/arm64). Add later.
-- Other major versions (16, 15, 14, etc.). Add later.
-- Building PostgreSQL from source. We're mirroring zonkyio.
-- Codesigning. zonkyio's binaries ship as-is; if Gatekeeper bites, address
-  in v2.
-- `lipo`-thinning the universal binary to drop the x86_64 slice. Add later
-  if archive size matters.
-- Version metadata sidecar (e.g. `postgres-mac-arm64-17.version.txt`
-  containing `17.6.0`). Defer; the bundled README inside the archive carries
-  the version if needed.
+- Other major versions (16, 15, etc.). Add later.
+- Building PostgreSQL from source ourselves. Defer to v2 if/when theseus
+  becomes inadequate.
+- Notarization with an Apple Developer ID. Ad-hoc signing is enough for
+  curl-tarball distribution today.
 - pv-side consumer code (downloader, `internal/postgresenv/`, shims, daemon
   integration). Separate plans.
+
+## Why theseus-rs over zonkyio
+
+We initially planned to mirror zonkyio's bundles via Maven Central. Local
+inspection revealed that zonkyio's `darwin-arm64v8` archive ships only 3
+binaries (`postgres`, `initdb`, `pg_ctl`) and no `include/` — sufficient
+for Java-test-style server lifecycle but missing `psql`, `pg_dump`,
+`pg_config`, etc. that pv users will want.
+
+theseus-rs ships the full PostgreSQL binary suite (37 tools including
+`psql`, `pg_dump`, `pg_restore`, `pg_isready`, `pg_config`, `createdb`,
+`pgbench`, etc.) plus `include/` for compiling third-party extensions like
+pgvector. The trade-off is that theseus's macOS builds use hardcoded
+Homebrew paths (`/opt/homebrew/opt/openssl@3/lib/...`), which we patch out
+in CI before publishing.
 
 ## Decisions
 
 | Topic | Decision | Rationale |
 |---|---|---|
-| Release tag | Same `artifacts` release that already hosts FrankenPHP + PHP CLI | Single rolling release for all pv-managed binaries; matches existing pattern |
-| Asset naming | Major-only: `postgres-mac-arm64-17.tar.gz` | Mirrors PHP (`php-mac-arm64-php8.4.tar.gz`); pv resolves "17" → fetch directly |
-| Strip aggressiveness | Drop only `share/postgresql/doc/`. Keep `bin/`, `lib/`, `share/`, `include/` in full | Allows third-party extension compilation (pgvector, postgis); ~30–35 MB bundle |
-| Trigger semantics | Always rebundle on every cron/dispatch run; `gh release upload --clobber` overwrites | Mirrors FrankenPHP workflow; no version-comparison state to drift |
-| Workflow file | Extend existing `.github/workflows/build-artifacts.yml` (add a `postgres` job) | Single workflow, reuses release job |
-| Job parallelism | `postgres` job has no `needs:` — runs in parallel with `build` and `resolve-version` | Postgres has its own version source (Maven), independent of FrankenPHP |
+| Source | `theseus-rs/postgresql-binaries` GitHub releases | Full binary suite + `include/` |
+| Runner | `macos-15` | `install_name_tool` and `codesign` are darwin-only |
+| openssl source | Copy from runner's `/opt/homebrew/opt/openssl@3/lib/` into bundle's `lib/` | Pre-installed on `macos-15` runner |
+| Patching | `install_name_tool -change` every Mach-O reference of `/opt/homebrew/opt/openssl@3/lib/lib{ssl,crypto}.3.dylib` → `@executable_path/../lib/lib{ssl,crypto}.3.dylib`; rewrite `LC_ID_DYLIB` on bundled openssl; rewrite libssl's internal libcrypto reference (Homebrew Cellar path) | Standard relocatable-bundle pattern |
+| Codesigning | Ad-hoc `codesign --force --sign -` over every Mach-O after patching | `install_name_tool` invalidates the signature; ad-hoc satisfies macOS Gatekeeper for non-Apple-Developer distribution |
+| Smoke test | In CI: `initdb` + start `postgres` + `psql SELECT version()` + clean teardown | Catches runtime breakage before publishing |
+| Strip | Drop only `share/postgresql/doc/`. Keep `bin/`, `lib/`, `share/`, `include/` in full | Enable third-party extension compilation |
+| Asset naming | Major-only: `postgres-mac-arm64-17.tar.gz` | Mirrors PHP (`php-mac-arm64-php8.4.tar.gz`) |
+| Release tag | Same `artifacts` release that already hosts FrankenPHP + PHP CLI | Single rolling release |
+| Trigger | Always rebundle on every cron/dispatch run; `gh release upload --clobber` | Mirrors FrankenPHP workflow |
+| Workflow file | Extend existing `.github/workflows/build-artifacts.yml` | Single workflow, single failure mode acceptable |
+| Job parallelism | `postgres` job has no `needs:` — runs in parallel with `build` and `resolve-version` | Postgres has its own version source (theseus releases) |
 | Failure coupling | If `build` fails, `release` is skipped, so postgres assets aren't uploaded that week either | Matches existing all-or-nothing behavior; weekly cron retries |
 
 ## Architecture
 
 Three changes to `.github/workflows/build-artifacts.yml`:
 
-1. **New `postgres` job** running in parallel with `build`, on `ubuntu-latest`,
-   matrix over `pg: ["17", "18"]`. Each matrix entry resolves the latest
-   patch from Maven, downloads the JAR, unwraps it, strips `doc/`, runs
-   structural sanity checks, and uploads a workflow artifact.
+1. **New `postgres` job** running in parallel with `build`, on `macos-15`,
+   matrix over `pg: ["17", "18"]`. Resolves latest patch from theseus-rs
+   GitHub releases, downloads + extracts the tarball, bundles Homebrew
+   openssl into the staging tree, patches `install_name`s, codesigns,
+   verifies cleanliness, runs an end-to-end smoke test, strips docs,
+   repacks, and uploads as a workflow artifact.
 2. **Extended `release` job** that also waits on `postgres` and downloads
-   `postgres-mac-arm64-*` workflow artifacts into the staging dir alongside
-   the existing FrankenPHP + PHP CLI assets.
-3. **Updated release notes/title** on first-time release creation to mention
-   PostgreSQL alongside PHP. (No-op for the existing live release; would
-   apply only if the release is recreated from scratch. Safe to leave.)
+   `postgres-mac-arm64-*` workflow artifacts into the staging dir
+   alongside the existing FrankenPHP + PHP CLI assets.
+3. **Updated release notes/title** on first-time release creation to
+   mention PostgreSQL alongside PHP. (No-op for the existing live release;
+   only fires if the release is recreated from scratch.)
 
 ## Components
 
@@ -75,49 +96,139 @@ postgres:
     matrix:
       pg: ["17", "18"]
   name: PostgreSQL ${{ matrix.pg }}
-  runs-on: ubuntu-latest
+  runs-on: macos-15
   permissions:
     contents: read
   steps:
-    - name: Resolve latest patch version from Maven
+    - name: Resolve latest patch version from theseus-rs
       id: resolve
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
-        META_URL="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/maven-metadata.xml"
-        ALL=$(curl -fsSL "$META_URL" | grep -oE '<version>[^<]+' | sed 's/<version>//')
+        set -euo pipefail
+        ALL=$(gh api 'repos/theseus-rs/postgresql-binaries/releases?per_page=100' --paginate --jq '.[].tag_name')
         VER=$(echo "$ALL" | grep "^${{ matrix.pg }}\." | sort -V | tail -1)
-        [ -n "$VER" ] || { echo "::error::no ${{ matrix.pg }}.x version on Maven"; exit 1; }
+        if [ -z "$VER" ]; then
+          echo "::error::No ${{ matrix.pg }}.x release on theseus-rs"
+          exit 1
+        fi
+        echo "Resolved PG ${{ matrix.pg }} → $VER"
         echo "version=$VER" >> "$GITHUB_OUTPUT"
 
-    - name: Download and unwrap JAR
+    - name: Download and extract
       run: |
+        set -euo pipefail
         VER="${{ steps.resolve.outputs.version }}"
-        JAR_URL="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/${VER}/embedded-postgres-binaries-darwin-arm64v8-${VER}.jar"
-        curl -fsSL -o pg.jar "$JAR_URL"
-        mkdir -p unpacked staging
-        unzip -q pg.jar -d unpacked
-        tar -xJf unpacked/postgres-darwin-arm_64.txz -C staging
+        URL="https://github.com/theseus-rs/postgresql-binaries/releases/download/${VER}/postgresql-${VER}-aarch64-apple-darwin.tar.gz"
+        curl -fsSL -o pg.tar.gz "$URL"
+        mkdir extracted
+        tar -xzf pg.tar.gz -C extracted
+        STAGING=$(ls -d extracted/postgresql-*-aarch64-apple-darwin)
+        echo "STAGING=$STAGING" >> "$GITHUB_ENV"
+
+    - name: Bundle Homebrew openssl into staging
+      run: |
+        set -euo pipefail
+        cp /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib   "$STAGING/lib/"
+        cp /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib "$STAGING/lib/"
+        chmod 755 "$STAGING/lib/libssl.3.dylib" "$STAGING/lib/libcrypto.3.dylib"
+
+    - name: Patch install_names to relative paths
+      run: |
+        set -euo pipefail
+        # Rewrite LC_ID_DYLIB on bundled openssl
+        install_name_tool -id "@executable_path/../lib/libssl.3.dylib"   "$STAGING/lib/libssl.3.dylib"
+        install_name_tool -id "@executable_path/../lib/libcrypto.3.dylib" "$STAGING/lib/libcrypto.3.dylib"
+        # libssl carries a hardcoded reference to libcrypto via Homebrew Cellar version path.
+        # Discover it from otool -L rather than reconstructing the version string.
+        CRYPTO_REF=$(otool -L "$STAGING/lib/libssl.3.dylib" | awk '/libcrypto\.3\.dylib/ && !/@executable_path/ {print $1; exit}')
+        if [ -n "$CRYPTO_REF" ]; then
+          install_name_tool -change "$CRYPTO_REF" "@executable_path/../lib/libcrypto.3.dylib" "$STAGING/lib/libssl.3.dylib"
+        fi
+        # Walk every Mach-O in bin/ and lib/, rewrite the two openssl paths.
+        for f in "$STAGING/bin/"* "$STAGING/lib/"*.dylib; do
+          [ -L "$f" ] && continue
+          [ -f "$f" ] || continue
+          if file -b "$f" | grep -q '^Mach-O'; then
+            install_name_tool -change \
+              "/opt/homebrew/opt/openssl@3/lib/libssl.3.dylib" \
+              "@executable_path/../lib/libssl.3.dylib" \
+              "$f" 2>/dev/null || true
+            install_name_tool -change \
+              "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib" \
+              "@executable_path/../lib/libcrypto.3.dylib" \
+              "$f" 2>/dev/null || true
+          fi
+        done
+
+    - name: Ad-hoc codesign all Mach-O files
+      run: |
+        set -euo pipefail
+        for f in "$STAGING/bin/"* "$STAGING/lib/"*.dylib; do
+          [ -L "$f" ] && continue
+          [ -f "$f" ] || continue
+          if file -b "$f" | grep -q '^Mach-O'; then
+            codesign --force --sign - "$f"
+          fi
+        done
+
+    - name: Verify deps reference no Homebrew paths
+      run: |
+        set -euo pipefail
+        echo "postgres dependencies:"
+        otool -L "$STAGING/bin/postgres"
+        if otool -L "$STAGING/bin/postgres" | grep -E '/opt/homebrew' ; then
+          echo "::error::postgres still references Homebrew paths after patching"
+          exit 1
+        fi
+
+    - name: Smoke test (initdb + start + psql + stop)
+      run: |
+        set -euo pipefail
+        DATA_DIR="$RUNNER_TEMP/pgdata"
+        rm -rf "$DATA_DIR"
+        "$STAGING/bin/initdb" -D "$DATA_DIR" -U postgres --auth=trust >/dev/null
+        PORT=54199
+        "$STAGING/bin/postgres" -D "$DATA_DIR" -p "$PORT" -k "$DATA_DIR" >"$RUNNER_TEMP/pg.log" 2>&1 &
+        PG_PID=$!
+        for i in 1 2 3 4 5 6 7 8 9 10; do
+          if "$STAGING/bin/pg_isready" -h 127.0.0.1 -p "$PORT" >/dev/null 2>&1; then break; fi
+          sleep 1
+        done
+        if ! "$STAGING/bin/pg_isready" -h 127.0.0.1 -p "$PORT"; then
+          echo "::error::pg_isready failed; server log:"
+          cat "$RUNNER_TEMP/pg.log"
+          kill $PG_PID 2>/dev/null || true
+          exit 1
+        fi
+        VER_OUT=$("$STAGING/bin/psql" -h 127.0.0.1 -p "$PORT" -U postgres -tAc "SELECT version();")
+        echo "Server reported: $VER_OUT"
+        kill $PG_PID
+        wait $PG_PID 2>/dev/null || true
 
     - name: Strip docs
-      run: rm -rf staging/share/postgresql/doc
+      run: rm -rf "$STAGING/share/postgresql/doc"
 
     - name: Structural sanity checks
       run: |
-        test -f staging/bin/postgres
-        test -f staging/bin/initdb
-        test -f staging/bin/psql
-        test -f staging/bin/pg_ctl
-        test -f staging/bin/pg_dump
-        test -f staging/bin/pg_config
-        test -f staging/lib/libssl.3.dylib
-        test -f staging/lib/libcrypto.3.dylib
-        test -f staging/lib/libicuuc.77.1.dylib
-        test -d staging/share/postgresql/extension
-        test -d staging/include
+        set -euo pipefail
+        test -f "$STAGING/bin/postgres"
+        test -f "$STAGING/bin/initdb"
+        test -f "$STAGING/bin/pg_ctl"
+        test -f "$STAGING/bin/psql"
+        test -f "$STAGING/bin/pg_dump"
+        test -f "$STAGING/bin/pg_config"
+        test -f "$STAGING/lib/libssl.3.dylib"
+        test -f "$STAGING/lib/libcrypto.3.dylib"
+        test -d "$STAGING/share/postgresql/extension"
+        test -d "$STAGING/include"
+        echo "Structural sanity checks passed."
 
     - name: Repack
-      run: tar -czf "postgres-mac-arm64-${{ matrix.pg }}.tar.gz" -C staging bin lib share include
+      run: tar -czf "postgres-mac-arm64-${{ matrix.pg }}.tar.gz" -C "$STAGING" bin lib share include
 
-    - uses: actions/upload-artifact@v4
+    - name: Upload binary
+      uses: actions/upload-artifact@v4
       with:
         name: postgres-mac-arm64-${{ matrix.pg }}
         path: postgres-mac-arm64-${{ matrix.pg }}.tar.gz
@@ -157,47 +268,67 @@ no changes — it already uploads everything in `release/`.
 Flat root, matches pv's existing extraction expectation:
 
 ```
-postgres-mac-arm64-17.tar.gz
-├── bin/
+postgres-mac-arm64-17.tar.gz   (~10 MB compressed)
+├── bin/                       # 37 binaries
 │   ├── postgres
 │   ├── initdb
 │   ├── pg_ctl
 │   ├── psql
 │   ├── pg_dump
+│   ├── pg_restore
+│   ├── pg_isready
 │   ├── pg_config
-│   └── … (37 binaries total)
+│   ├── createdb / dropdb
+│   ├── createuser / dropuser
+│   ├── vacuumdb / reindexdb
+│   ├── pg_basebackup
+│   ├── pg_upgrade
+│   ├── pgbench
+│   └── … (37 total)
 ├── lib/
-│   ├── libssl.3.dylib            # OpenSSL 3 (bundled)
-│   ├── libcrypto.3.dylib         # OpenSSL 3 (bundled)
-│   ├── libicu*.dylib             # ICU 77 (bundled)
-│   ├── libxml2.16.dylib          # libxml2 (bundled)
-│   ├── liblz4, libzstd, libz, libiconv, libgssapi_krb5, libk5crypto
-│   ├── pgcrypto.dylib            # contrib extensions (built-in)
-│   ├── citext.dylib
-│   ├── pg_trgm.dylib
-│   └── … (87 dylibs total)
+│   ├── libssl.3.dylib            # bundled from runner's Homebrew openssl@3
+│   ├── libcrypto.3.dylib         # bundled from runner's Homebrew openssl@3
+│   ├── libpq.5.dylib             # postgres own
+│   ├── libecpg.6.dylib           # postgres own
+│   ├── libpgtypes.3.dylib        # postgres own
+│   ├── pgcrypto.dylib            # contrib extension
+│   ├── citext.dylib              # contrib extension
+│   ├── pg_trgm.dylib             # contrib extension
+│   ├── pg_stat_statements.dylib  # contrib extension
+│   └── … (~87 dylibs in v18)
 ├── share/
 │   └── postgresql/
-│       ├── extension/            # contrib extension SQL + control files
+│       ├── extension/            # contrib SQL + control files
 │       ├── tsearch_data/
 │       ├── timezones/
-│       ├── *.sample              # postgresql.conf.sample, pg_hba.conf.sample, etc.
+│       ├── *.sample              # postgresql.conf.sample, pg_hba.conf.sample
 │       └── *.sql                 # system_views.sql, etc.
-└── include/                      # C headers for third-party extension builds
+└── include/                      # C headers for compiling pgvector etc.
 ```
 
 Consumer expectation (future pv code): `tar -xzf … -C ~/.pv/postgres/<major>/`
 lays this tree down directly under e.g. `~/.pv/postgres/17/`.
 
+After patching, every Mach-O references either:
+- `@executable_path/../lib/...` (our bundled libs and postgres' own modules), or
+- `/usr/lib/...` (system: libxml2, libz, libSystem, libpam, LDAP framework — present on every macOS).
+
 ## Verification
 
-**On the Linux runner (workflow):**
-- Maven HTTP errors → curl exits non-zero → step fails.
-- JAR/txz extraction errors → unzip/tar exit non-zero → step fails.
-- Missing critical files → explicit `test -f` checks fail the step.
-- Per-version isolation: `fail-fast: false` lets PG17 and PG18 succeed/fail
-  independently within the matrix; the job's overall result still fails if
-  either matrix entry fails, gating release.
+**On the macos-15 runner (workflow):**
+- HTTP errors from theseus-rs / GitHub API → curl/`gh api` exits non-zero
+  → step fails.
+- Tarball extraction errors → tar exits non-zero → step fails.
+- Patching errors → `install_name_tool` exits non-zero → step fails.
+- Codesigning errors → `codesign` exits non-zero → step fails.
+- Verify-clean step explicitly greps `otool -L` output for `/opt/homebrew`
+  and fails if anything still references it.
+- **Smoke test** runs the actual server: initdb → postgres → pg_isready →
+  psql `SELECT version()` → teardown. Catches runtime breakage that static
+  checks miss (e.g. ABI mismatch between Homebrew openssl on the runner
+  and theseus's build environment).
+- Per-version isolation via `fail-fast: false` — PG17 and PG18 run
+  independently within the matrix.
 
 **Manual pre-merge verification:**
 Dispatch the workflow from the feature branch. The `build` and `postgres`
@@ -205,19 +336,23 @@ jobs run; the `release` job is gated on `github.ref == 'refs/heads/main'`
 and skipped, so the live release isn't touched. Inspect the workflow
 artifact tarballs as a sanity check.
 
-**Out of scope:** runtime verification on macOS (binary actually executes,
-universal slices intact, etc.). That belongs to pv-side e2e tests in
-`scripts/e2e/` once consumer code lands.
+**Out of scope:** end-to-end pv consumer testing (download from artifacts
+release, install into `~/.pv/postgres/<ver>/`, run via daemon). That
+belongs to pv-side e2e tests in `scripts/e2e/` once consumer code lands.
 
 ## Failure modes accepted
 
-- Maven Central down for the entire weekly window → no release that week.
-  Manual `workflow_dispatch` once Maven is back recovers it.
-- zonkyio publishes a structurally-valid but runtime-broken bundle → user
-  reports the issue, we patch (skip that version manually, override pin,
-  etc.). Acceptable for v1.
-- PHP `build` job fails → no release for either PHP or postgres that week.
-  Matches existing all-or-nothing behavior.
+- theseus-rs / GitHub down for the entire weekly window → no release that
+  week. Manual `workflow_dispatch` recovers it.
+- theseus-rs publishes a bundle with a structurally-different lib set
+  (e.g. introduces a new Homebrew dep we haven't accounted for) → patcher
+  doesn't touch it, smoke test fails (or worse, runtime fails for end
+  users) → patch the workflow.
+- Homebrew openssl ABI version drift between runner image releases → smoke
+  test catches it before publishing. We pin to whatever's on `macos-15`
+  at build time.
+- PHP `build` job fails → no release for either PHP or postgres that
+  week. Matches existing all-or-nothing behavior.
 
 ## Migration / rollout
 

--- a/docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md
+++ b/docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md
@@ -1,0 +1,234 @@
+# PostgreSQL artifacts pipeline (M-series, PG 17/18)
+
+## Goal
+
+Mirror zonkyio's PostgreSQL bundles from Maven Central into the existing
+`artifacts` release on `prvious/pv`, so pv can consume them via the same
+download pattern it already uses for FrankenPHP and the static PHP CLI.
+
+This is the foundational artifacts step. It does not include any pv-side
+consumer code (downloader, postgresenv package, shims, daemon integration);
+those follow in separate plans.
+
+## Scope (v1)
+
+- Platform: macOS arm64 only (Apple Silicon, "M-series").
+- Versions: PostgreSQL major **17** and **18**, latest patch of each.
+- Source: `io.zonky.test.postgres:embedded-postgres-binaries-darwin-arm64v8`
+  on Maven Central.
+- Cadence: weekly cron (Monday 00:00 UTC), plus manual `workflow_dispatch`.
+- Output: two assets in the existing rolling `artifacts` release on
+  `prvious/pv`:
+  - `postgres-mac-arm64-17.tar.gz`
+  - `postgres-mac-arm64-18.tar.gz`
+
+## Non-goals (v1)
+
+- Other architectures (mac x86_64, linux amd64/arm64). Add later.
+- Other major versions (16, 15, 14, etc.). Add later.
+- Building PostgreSQL from source. We're mirroring zonkyio.
+- Codesigning. zonkyio's binaries ship as-is; if Gatekeeper bites, address
+  in v2.
+- `lipo`-thinning the universal binary to drop the x86_64 slice. Add later
+  if archive size matters.
+- Version metadata sidecar (e.g. `postgres-mac-arm64-17.version.txt`
+  containing `17.6.0`). Defer; the bundled README inside the archive carries
+  the version if needed.
+- pv-side consumer code (downloader, `internal/postgresenv/`, shims, daemon
+  integration). Separate plans.
+
+## Decisions
+
+| Topic | Decision | Rationale |
+|---|---|---|
+| Release tag | Same `artifacts` release that already hosts FrankenPHP + PHP CLI | Single rolling release for all pv-managed binaries; matches existing pattern |
+| Asset naming | Major-only: `postgres-mac-arm64-17.tar.gz` | Mirrors PHP (`php-mac-arm64-php8.4.tar.gz`); pv resolves "17" → fetch directly |
+| Strip aggressiveness | Drop only `share/postgresql/doc/`. Keep `bin/`, `lib/`, `share/`, `include/` in full | Allows third-party extension compilation (pgvector, postgis); ~30–35 MB bundle |
+| Trigger semantics | Always rebundle on every cron/dispatch run; `gh release upload --clobber` overwrites | Mirrors FrankenPHP workflow; no version-comparison state to drift |
+| Workflow file | Extend existing `.github/workflows/build-artifacts.yml` (add a `postgres` job) | Single workflow, reuses release job |
+| Job parallelism | `postgres` job has no `needs:` — runs in parallel with `build` and `resolve-version` | Postgres has its own version source (Maven), independent of FrankenPHP |
+| Failure coupling | If `build` fails, `release` is skipped, so postgres assets aren't uploaded that week either | Matches existing all-or-nothing behavior; weekly cron retries |
+
+## Architecture
+
+Three changes to `.github/workflows/build-artifacts.yml`:
+
+1. **New `postgres` job** running in parallel with `build`, on `ubuntu-latest`,
+   matrix over `pg: ["17", "18"]`. Each matrix entry resolves the latest
+   patch from Maven, downloads the JAR, unwraps it, strips `doc/`, runs
+   structural sanity checks, and uploads a workflow artifact.
+2. **Extended `release` job** that also waits on `postgres` and downloads
+   `postgres-mac-arm64-*` workflow artifacts into the staging dir alongside
+   the existing FrankenPHP + PHP CLI assets.
+3. **Updated release notes/title** on first-time release creation to mention
+   PostgreSQL alongside PHP. (No-op for the existing live release; would
+   apply only if the release is recreated from scratch. Safe to leave.)
+
+## Components
+
+### `postgres` job
+
+```yaml
+postgres:
+  strategy:
+    fail-fast: false
+    matrix:
+      pg: ["17", "18"]
+  name: PostgreSQL ${{ matrix.pg }}
+  runs-on: ubuntu-latest
+  permissions:
+    contents: read
+  steps:
+    - name: Resolve latest patch version from Maven
+      id: resolve
+      run: |
+        META_URL="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/maven-metadata.xml"
+        ALL=$(curl -fsSL "$META_URL" | grep -oE '<version>[^<]+' | sed 's/<version>//')
+        VER=$(echo "$ALL" | grep "^${{ matrix.pg }}\." | sort -V | tail -1)
+        [ -n "$VER" ] || { echo "::error::no ${{ matrix.pg }}.x version on Maven"; exit 1; }
+        echo "version=$VER" >> "$GITHUB_OUTPUT"
+
+    - name: Download and unwrap JAR
+      run: |
+        VER="${{ steps.resolve.outputs.version }}"
+        JAR_URL="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-arm64v8/${VER}/embedded-postgres-binaries-darwin-arm64v8-${VER}.jar"
+        curl -fsSL -o pg.jar "$JAR_URL"
+        mkdir -p unpacked staging
+        unzip -q pg.jar -d unpacked
+        tar -xJf unpacked/postgres-darwin-arm_64.txz -C staging
+
+    - name: Strip docs
+      run: rm -rf staging/share/postgresql/doc
+
+    - name: Structural sanity checks
+      run: |
+        test -f staging/bin/postgres
+        test -f staging/bin/initdb
+        test -f staging/bin/psql
+        test -f staging/bin/pg_ctl
+        test -f staging/bin/pg_dump
+        test -f staging/bin/pg_config
+        test -f staging/lib/libssl.3.dylib
+        test -f staging/lib/libcrypto.3.dylib
+        test -f staging/lib/libicuuc.77.1.dylib
+        test -d staging/share/postgresql/extension
+        test -d staging/include
+
+    - name: Repack
+      run: tar -czf "postgres-mac-arm64-${{ matrix.pg }}.tar.gz" -C staging bin lib share include
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: postgres-mac-arm64-${{ matrix.pg }}
+        path: postgres-mac-arm64-${{ matrix.pg }}.tar.gz
+        compression-level: 0
+```
+
+### `release` job extension
+
+Additions to the existing job (existing steps unchanged):
+
+```yaml
+- uses: actions/download-artifact@v4
+  with:
+    pattern: postgres-mac-arm64-*
+    path: artifacts
+```
+
+In the existing "Prepare release assets" step, after the FrankenPHP/PHP
+validation block, add:
+
+```bash
+pg_dirs=(artifacts/postgres-mac-arm64-*)
+if [ ${#pg_dirs[@]} -lt 2 ]; then
+  echo "::error::Expected 2 postgres bundles (17 + 18), found ${#pg_dirs[@]}"
+  exit 1
+fi
+for dir in "${pg_dirs[@]}"; do
+  cp "$dir"/* "release/"
+done
+```
+
+The existing `gh release upload "$TAG" release/* --clobber` step requires
+no changes — it already uploads everything in `release/`.
+
+## Tarball layout
+
+Flat root, matches pv's existing extraction expectation:
+
+```
+postgres-mac-arm64-17.tar.gz
+├── bin/
+│   ├── postgres
+│   ├── initdb
+│   ├── pg_ctl
+│   ├── psql
+│   ├── pg_dump
+│   ├── pg_config
+│   └── … (37 binaries total)
+├── lib/
+│   ├── libssl.3.dylib            # OpenSSL 3 (bundled)
+│   ├── libcrypto.3.dylib         # OpenSSL 3 (bundled)
+│   ├── libicu*.dylib             # ICU 77 (bundled)
+│   ├── libxml2.16.dylib          # libxml2 (bundled)
+│   ├── liblz4, libzstd, libz, libiconv, libgssapi_krb5, libk5crypto
+│   ├── pgcrypto.dylib            # contrib extensions (built-in)
+│   ├── citext.dylib
+│   ├── pg_trgm.dylib
+│   └── … (87 dylibs total)
+├── share/
+│   └── postgresql/
+│       ├── extension/            # contrib extension SQL + control files
+│       ├── tsearch_data/
+│       ├── timezones/
+│       ├── *.sample              # postgresql.conf.sample, pg_hba.conf.sample, etc.
+│       └── *.sql                 # system_views.sql, etc.
+└── include/                      # C headers for third-party extension builds
+```
+
+Consumer expectation (future pv code): `tar -xzf … -C ~/.pv/postgres/<major>/`
+lays this tree down directly under e.g. `~/.pv/postgres/17/`.
+
+## Verification
+
+**On the Linux runner (workflow):**
+- Maven HTTP errors → curl exits non-zero → step fails.
+- JAR/txz extraction errors → unzip/tar exit non-zero → step fails.
+- Missing critical files → explicit `test -f` checks fail the step.
+- Per-version isolation: `fail-fast: false` lets PG17 and PG18 succeed/fail
+  independently within the matrix; the job's overall result still fails if
+  either matrix entry fails, gating release.
+
+**Manual pre-merge verification:**
+Dispatch the workflow from the feature branch. The `build` and `postgres`
+jobs run; the `release` job is gated on `github.ref == 'refs/heads/main'`
+and skipped, so the live release isn't touched. Inspect the workflow
+artifact tarballs as a sanity check.
+
+**Out of scope:** runtime verification on macOS (binary actually executes,
+universal slices intact, etc.). That belongs to pv-side e2e tests in
+`scripts/e2e/` once consumer code lands.
+
+## Failure modes accepted
+
+- Maven Central down for the entire weekly window → no release that week.
+  Manual `workflow_dispatch` once Maven is back recovers it.
+- zonkyio publishes a structurally-valid but runtime-broken bundle → user
+  reports the issue, we patch (skip that version manually, override pin,
+  etc.). Acceptable for v1.
+- PHP `build` job fails → no release for either PHP or postgres that week.
+  Matches existing all-or-nothing behavior.
+
+## Migration / rollout
+
+1. Open PR with workflow changes.
+2. Dispatch from the feature branch to verify builds succeed; inspect
+   workflow artifacts.
+3. Merge to main.
+4. First scheduled (or dispatched) run from main publishes
+   `postgres-mac-arm64-17.tar.gz` and `postgres-mac-arm64-18.tar.gz` to the
+   `artifacts` release alongside the existing PHP assets.
+5. Verify via `gh release view artifacts` that the assets are present.
+
+No coordination needed with pv consumer code — that's a separate plan, and
+this artifacts pipeline can ship and live on its own.

--- a/docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md
+++ b/docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md
@@ -60,7 +60,7 @@ in CI before publishing.
 | Patching | `install_name_tool -change` every Mach-O reference of `/opt/homebrew/opt/openssl@3/lib/lib{ssl,crypto}.3.dylib` → `@executable_path/../lib/lib{ssl,crypto}.3.dylib`; rewrite `LC_ID_DYLIB` on bundled openssl; rewrite libssl's internal libcrypto reference (Homebrew Cellar path) | Standard relocatable-bundle pattern |
 | Codesigning | Ad-hoc `codesign --force --sign -` over every Mach-O after patching | `install_name_tool` invalidates the signature; ad-hoc satisfies macOS Gatekeeper for non-Apple-Developer distribution |
 | Smoke test | In CI: `initdb` + start `postgres` + `psql SELECT version()` + clean teardown | Catches runtime breakage before publishing |
-| Strip | Drop only `share/postgresql/doc/`. Keep `bin/`, `lib/`, `share/`, `include/` in full | Enable third-party extension compilation |
+| Strip | Drop only `share/doc/`. Keep `bin/`, `lib/`, `share/`, `include/` in full | Enable third-party extension compilation |
 | Asset naming | Major-only: `postgres-mac-arm64-17.tar.gz` | Mirrors PHP (`php-mac-arm64-php8.4.tar.gz`) |
 | Release tag | Same `artifacts` release that already hosts FrankenPHP + PHP CLI | Single rolling release |
 | Trigger | Always rebundle on every cron/dispatch run; `gh release upload --clobber` | Mirrors FrankenPHP workflow |
@@ -207,7 +207,7 @@ postgres:
         wait $PG_PID 2>/dev/null || true
 
     - name: Strip docs
-      run: rm -rf "$STAGING/share/postgresql/doc"
+      run: rm -rf "$STAGING/share/doc"
 
     - name: Structural sanity checks
       run: |
@@ -220,7 +220,7 @@ postgres:
         test -f "$STAGING/bin/pg_config"
         test -f "$STAGING/lib/libssl.3.dylib"
         test -f "$STAGING/lib/libcrypto.3.dylib"
-        test -d "$STAGING/share/postgresql/extension"
+        test -d "$STAGING/share/extension"
         test -d "$STAGING/include"
         echo "Structural sanity checks passed."
 

--- a/scripts/test-postgres-bundle.sh
+++ b/scripts/test-postgres-bundle.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# test-postgres-bundle.sh — integration test for a built PostgreSQL bundle.
+#
+# Verifies that an extracted theseus-rs PostgreSQL bundle (after our patching
+# pass) actually works end-to-end: initdb, server startup, every bundled
+# contrib extension loads, common extensions exercise correctly, pgbench runs
+# a real workload, pg_amcheck reports no corruption, and pg_dump → restore
+# round-trips.
+#
+# Usage:
+#     scripts/test-postgres-bundle.sh <path-to-extracted-bundle>
+#
+# The path argument should be the directory containing bin/, lib/, share/,
+# and include/. Used by .github/workflows/build-artifacts.yml against the
+# patched staging tree, and locally by passing an extracted CI artifact.
+#
+# Exit code: 0 = all checks passed; non-zero = at least one failed.
+
+set -euo pipefail
+
+PG_PREFIX="${1:?usage: $0 <path-to-extracted-bundle>}"
+PORT="${POSTGRES_TEST_PORT:-54199}"
+
+if [ ! -x "$PG_PREFIX/bin/postgres" ]; then
+    echo "::error::No bin/postgres at $PG_PREFIX"
+    exit 1
+fi
+
+DATA_DIR="$(mktemp -d)/pgdata"
+PG_LOG="$(mktemp)"
+PG_PID=""
+
+cleanup() {
+    if [ -n "$PG_PID" ]; then
+        kill "$PG_PID" 2>/dev/null || true
+        wait "$PG_PID" 2>/dev/null || true
+    fi
+    rm -rf "$(dirname "$DATA_DIR")"
+    rm -f "$PG_LOG"
+}
+trap cleanup EXIT
+
+PSQL=("$PG_PREFIX/bin/psql" -h 127.0.0.1 -p "$PORT" -U postgres -X -q)
+
+# 1. initdb
+echo "== 1. initdb =="
+"$PG_PREFIX/bin/initdb" -D "$DATA_DIR" -U postgres --auth=trust >/dev/null
+echo "  ✓ cluster initialized at $DATA_DIR"
+
+# 2. start postgres
+echo "== 2. start postgres =="
+"$PG_PREFIX/bin/postgres" -D "$DATA_DIR" -p "$PORT" -k "$DATA_DIR" >"$PG_LOG" 2>&1 &
+PG_PID=$!
+
+for i in $(seq 1 15); do
+    if "$PG_PREFIX/bin/pg_isready" -h 127.0.0.1 -p "$PORT" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+if ! "$PG_PREFIX/bin/pg_isready" -h 127.0.0.1 -p "$PORT" >/dev/null 2>&1; then
+    echo "::error::postgres did not become ready within 15s"
+    cat "$PG_LOG"
+    exit 1
+fi
+echo "  ✓ accepting connections on 127.0.0.1:$PORT"
+
+# 3. server version + basic SQL
+echo "== 3. server identity =="
+SERVER_VER=$("${PSQL[@]}" -tAc "SELECT version();")
+echo "  $SERVER_VER"
+
+echo "== 4. core SQL (types, JSON, arrays) =="
+"${PSQL[@]}" -tAc "SELECT jsonb_build_object('a', ARRAY[1,2,3], 'ts', NOW())::text;" >/dev/null
+echo "  ✓ jsonb + arrays + timestamps"
+
+# 5. Discover and load every bundled contrib extension
+echo "== 5. CREATE EXTENSION for every bundled contrib =="
+EXT_DIR="$PG_PREFIX/share/extension"
+if [ ! -d "$EXT_DIR" ]; then
+    echo "::error::No share/extension dir at $EXT_DIR"
+    exit 1
+fi
+
+FAILED_EXTS=()
+LOADED_EXTS=0
+for control in "$EXT_DIR"/*.control; do
+    ext=$(basename "$control" .control)
+    # plpgsql is preinstalled in template1; skip noisy "already exists" path.
+    if [ "$ext" = "plpgsql" ]; then continue; fi
+    if "${PSQL[@]}" -c "CREATE EXTENSION IF NOT EXISTS \"$ext\";" >/dev/null 2>&1; then
+        LOADED_EXTS=$((LOADED_EXTS+1))
+    else
+        FAILED_EXTS+=("$ext")
+    fi
+done
+
+echo "  ✓ loaded $LOADED_EXTS contrib extensions"
+if [ ${#FAILED_EXTS[@]} -gt 0 ]; then
+    echo "::error::Failed to load extension(s): ${FAILED_EXTS[*]}"
+    # Show the actual server error for the first failure to aid debugging.
+    "${PSQL[@]}" -c "CREATE EXTENSION IF NOT EXISTS \"${FAILED_EXTS[0]}\";" || true
+    exit 1
+fi
+
+# 6. Exercise the most-used extensions (catches subtle .dylib breakage that
+# CREATE EXTENSION alone wouldn't surface — many of these only load their
+# .dylib lazily on first function call).
+echo "== 6. exercise extension functions =="
+
+assert_true() {
+    local label="$1"
+    local sql="$2"
+    local result
+    if ! result=$("${PSQL[@]}" -tAc "$sql" 2>&1); then
+        echo "::error::$label query errored: $result"
+        return 1
+    fi
+    if [ "$result" != "t" ]; then
+        echo "::error::$label returned '$result', expected 't'"
+        return 1
+    fi
+    echo "  ✓ $label"
+}
+
+assert_true "pg_trgm.similarity"         "SELECT similarity('postgres', 'postgresql') > 0;"
+assert_true "pgcrypto.digest"            "SELECT length(digest('hello', 'sha256')) = 32;"
+assert_true "hstore"                     "SELECT ('a=>1,b=>2'::hstore -> 'a') = '1';"
+assert_true "citext"                     "SELECT 'Foo'::citext = 'foo';"
+assert_true "ltree"                      "SELECT 'a.b.c'::ltree <@ 'a.b';"
+assert_true "uuid-ossp.uuid_generate_v4" "SELECT uuid_generate_v4() IS NOT NULL;"
+assert_true "cube"                       "SELECT cube(ARRAY[1,2,3]) IS NOT NULL;"
+assert_true "intarray"                   "SELECT 1 = ANY(intarray_push_elem(ARRAY[2,3]::int[], 1));"
+assert_true "fuzzystrmatch.levenshtein"  "SELECT levenshtein('kitten', 'sitting') = 3;"
+assert_true "tablefunc.crosstab"         "SELECT EXISTS(SELECT 1 FROM pg_proc WHERE proname = 'crosstab');"
+assert_true "dblink"                     "SELECT EXISTS(SELECT 1 FROM pg_proc WHERE proname = 'dblink_connect');"
+assert_true "postgres_fdw"               "SELECT EXISTS(SELECT 1 FROM pg_foreign_data_wrapper WHERE fdwname = 'postgres_fdw');"
+
+# 7. pgbench — real workload exercising storage, lock manager, WAL, planner.
+echo "== 7. pgbench (scale 1, 10 seconds, 4 clients) =="
+"$PG_PREFIX/bin/pgbench" -h 127.0.0.1 -p "$PORT" -U postgres -i -s 1 -q postgres 2>&1 | tail -3
+"$PG_PREFIX/bin/pgbench" -h 127.0.0.1 -p "$PORT" -U postgres -T 10 -c 4 -j 2 postgres | grep -E '(tps|latency|number of transactions actually processed)' | head
+
+# 8. pg_amcheck — heap + btree consistency over the whole cluster.
+echo "== 8. pg_amcheck (heap + indexes) =="
+if "$PG_PREFIX/bin/pg_amcheck" -h 127.0.0.1 -p "$PORT" -U postgres --all >/dev/null 2>&1; then
+    echo "  ✓ no corruption"
+else
+    echo "::error::pg_amcheck reported corruption — re-running with output:"
+    "$PG_PREFIX/bin/pg_amcheck" -h 127.0.0.1 -p "$PORT" -U postgres --all || true
+    exit 1
+fi
+
+# 9. pg_dump → restore roundtrip exercises the client/library paths.
+echo "== 9. pg_dump → restore roundtrip =="
+DUMP_FILE=$(mktemp)
+"$PG_PREFIX/bin/pg_dump" -h 127.0.0.1 -p "$PORT" -U postgres -d postgres > "$DUMP_FILE"
+DUMP_SIZE=$(wc -c < "$DUMP_FILE" | tr -d ' ')
+"${PSQL[@]}" -c "CREATE DATABASE pv_restoretest;" >/dev/null
+"$PG_PREFIX/bin/psql" -h 127.0.0.1 -p "$PORT" -U postgres -d pv_restoretest -X -q < "$DUMP_FILE" >/dev/null
+
+ORIG_ROWS=$("${PSQL[@]}" -tAc "SELECT count(*) FROM pgbench_accounts;")
+RESTORED_ROWS=$("${PSQL[@]}" -d pv_restoretest -tAc "SELECT count(*) FROM pgbench_accounts;")
+if [ "$ORIG_ROWS" != "$RESTORED_ROWS" ]; then
+    echo "::error::Row count mismatch: original=$ORIG_ROWS restored=$RESTORED_ROWS"
+    exit 1
+fi
+rm -f "$DUMP_FILE"
+echo "  ✓ dumped $DUMP_SIZE bytes; restored row count matches ($ORIG_ROWS)"
+
+echo ""
+echo "== ALL CHECKS PASSED for $SERVER_VER =="


### PR DESCRIPTION
## Summary

Adds a `postgres` job to `build-artifacts.yml` that mirrors theseus-rs's PostgreSQL bundles (PG 17 + 18, macOS arm64), patches Homebrew-pinned openssl install_names to relative `@executable_path` references, smoke-tests the patched bundle, and publishes to the existing rolling `artifacts` release alongside FrankenPHP + PHP CLI assets.

- Runs in parallel with `build` (no `needs:` coupling to FrankenPHP version resolution)
- Bundles `libssl.3.dylib` + `libcrypto.3.dylib` from the runner's Homebrew openssl@3 into the archive's `lib/`
- `install_name_tool -change` rewrites every Mach-O reference of `/opt/homebrew/opt/openssl@3/lib/lib{ssl,crypto}.3.dylib` → `@executable_path/../lib/lib{ssl,crypto}.3.dylib` (plus `LC_ID_DYLIB` on the bundled openssl, plus libssl's internal Cellar-pinned libcrypto reference via `otool`-discovered path)
- Ad-hoc `codesign --force --sign -` over every Mach-O after patching (required because `install_name_tool` invalidates the prior signature)
- In-CI smoke test: `initdb` + start `postgres` + `psql SELECT version()` + clean teardown — catches runtime breakage before publishing
- Strips `share/doc/` (only); keeps `bin/`, `lib/`, `share/extension/`, `include/` for full client tools + extension compilation
- Weekly cron + manual dispatch, parallel to existing FrankenPHP build

Why theseus-rs over zonkyio: the latter ships only 3 binaries (postgres, initdb, pg_ctl) for the embedded testing use case. theseus ships all 37 (psql, pg_dump, pg_config, etc.) plus `include/` so users can compile pgvector etc. against this postgres.

Spec: `docs/superpowers/specs/2026-04-29-postgres-artifacts-design.md`
Plan: `docs/superpowers/plans/2026-04-29-postgres-artifacts.md`

## Test plan

- [x] Local end-to-end pipeline verified for both PG 17.9.0 and PG 18.3.0 on a real Mac (download → patch → codesign → initdb → postgres → psql roundtrip)
- [x] YAML validates with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Feature-branch workflow dispatch (run [25092726053](https://github.com/prvious/pv/actions/runs/25092726053)): both `PostgreSQL 17` and `PostgreSQL 18` jobs succeed in ~3 minutes
  - Smoke test inside CI confirms postgres starts and responds to psql
  - `release` job correctly skipped on feature branch (gated on `refs/heads/main`)
- [x] Workflow artifacts inspected: ~13 MB tarballs, flat root, all 37 binaries, `include/` present, `pg_trgm` extension files in `share/extension/`
- [x] `otool -L bin/postgres` on downloaded bundle shows zero `/opt/homebrew/*` references — only `@executable_path/../lib/*` and `/usr/lib/*` (system)
- [ ] After merge: first scheduled (or dispatched) run from `main` publishes `postgres-mac-arm64-17.tar.gz` and `postgres-mac-arm64-18.tar.gz` to the `artifacts` release