### PR TITLE
ci: add skip_* dispatch flags to build-artifacts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -2,6 +2,19 @@ name: Build artifacts
 
 on:
   workflow_dispatch:
+    inputs:
+      skip_frankenphp:
+        description: "Skip the FrankenPHP build matrix (3 PHP versions, ~30 min each)"
+        type: boolean
+        default: false
+      skip_postgres:
+        description: "Skip the PostgreSQL bundle matrix (PG 17 + 18)"
+        type: boolean
+        default: false
+      skip_mysql:
+        description: "Skip the MySQL bundle matrix (8.0 + 8.4 + 9.7)"
+        type: boolean
+        default: false
   schedule:
     - cron: "0 0 * * 1"
 
@@ -14,6 +27,7 @@ env:
 
 jobs:
   frankenphp:
+    if: ${{ inputs.skip_frankenphp != true }}
     strategy:
       fail-fast: false
       matrix:
@@ -134,6 +148,7 @@ jobs:
           compression-level: 0
 
   postgres:
+    if: ${{ inputs.skip_postgres != true }}
     strategy:
       fail-fast: false
       matrix:
@@ -283,6 +298,7 @@ jobs:
           compression-level: 0
 
   mysql:
+    if: ${{ inputs.skip_mysql != true }}
     strategy:
       fail-fast: false
       matrix:
@@ -402,10 +418,10 @@ jobs:
 
   release:
     needs: [frankenphp, postgres, mysql]
-    # Only publish from main. Dispatching from a feature branch runs the build
-    # matrix as a test of the PHP/FrankenPHP binary builds without touching
-    # the published release.
-    if: github.ref == 'refs/heads/main'
+    # Only publish from main, and only when every build family ran. A skipped
+    # build job reports as "success" to its dependents, so without these extra
+    # clauses a dispatch with skip_* flags would publish a half-baked release.
+    if: ${{ github.ref == 'refs/heads/main' && inputs.skip_frankenphp != true && inputs.skip_postgres != true && inputs.skip_mysql != true }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,33 @@ The CLI uses a layered Charm stack:
 - **Registry**: in-memory + explicit save. `Load()` → mutate → `Save()`.
 - **E2E tests**: live in `scripts/e2e/`, run on GitHub Actions (macOS). Source `scripts/e2e/helpers.sh`. Use these for anything needing real binaries, network, DNS, or HTTPS. Add new phases to `.github/workflows/e2e.yml`.
 
+## CI workflows
+
+### Dispatching `build-artifacts.yml` manually
+
+A full dispatch runs the FrankenPHP matrix (3 PHP versions, ~30 min each), Postgres (17 + 18), and MySQL (8.0 + 8.4 + 9.7). That's ~90 min of macOS runner time per push and almost always more than the change under test needs.
+
+**Always pass `skip_*` flags scoped to the change.** Infer from context — don't run families unrelated to the work:
+
+| Working on… | Dispatch with |
+|---|---|
+| MySQL artifacts / `mysql:` job / `scripts/test-mysql-bundle.sh` | `-f skip_frankenphp=true -f skip_postgres=true` |
+| Postgres artifacts / `postgres:` job / `scripts/test-postgres-bundle.sh` | `-f skip_frankenphp=true -f skip_mysql=true` |
+| FrankenPHP build / `static-php-cli` extensions | `-f skip_postgres=true -f skip_mysql=true` |
+| Release-job wiring / artifacts upload logic | run the family that produces the artifacts in question; skip the others |
+| Truly cross-cutting (e.g. concurrency-group changes) | no skips — needs the full matrix |
+
+If the affected family is ambiguous from the diff, ask before dispatching. Never dispatch with no skip flags "just to be safe" — that's the failure mode this convention exists to prevent.
+
+Example:
+
+```bash
+gh workflow run build-artifacts.yml --ref <branch> \
+  -f skip_frankenphp=true -f skip_postgres=true
+```
+
+The `release` job is gated on all three skip flags being false, so a partial dispatch never publishes a half-baked release.
+
 ## Multi-version PHP
 
 - Main FrankenPHP serves on :443/:80, proxies non-global versions via `reverse_proxy`.


### PR DESCRIPTION
## Summary
- Adds three boolean `workflow_dispatch` inputs to `.github/workflows/build-artifacts.yml`: `skip_frankenphp`, `skip_postgres`, `skip_mysql`.
- Each build job gates on its matching flag (\`if: \${{ inputs.skip_<name> != true }}\`). Skipping a build family means: don't burn ~30 min × 3 of FrankenPHP runner time when testing one MySQL change.
- The \`release\` job gates on **all three** flags being false — a skipped build job reports as \`success\` to its dependents by default, so without this extra clause a dispatch with any skip flag set would publish a half-baked release.
- Schedule trigger is unaffected: \`inputs.skip_*\` is \`null\` on schedule events, and \`null != true\` is \`true\`, so weekly runs build everything as before.

## How to use
GitHub UI: Actions → Build artifacts → Run workflow → tick whichever build families to skip.

CLI:
\`\`\`bash
gh workflow run build-artifacts.yml --ref <branch> \\
  -f skip_frankenphp=true -f skip_postgres=true
\`\`\`

## Test plan
- [x] All-skip dispatch (\`skip_frankenphp=true skip_postgres=true skip_mysql=true\`) on this branch: completed in 3 s, every job marked \`skipped\`. Run: https://github.com/prvious/pv/actions/runs/25348354958
- [ ] After merge: weekly schedule on \`main\` builds everything as before (no inputs supplied).