### PR TITLE
fix(e2e): set up PATH in php-ini.sh

### DIFF
--- a/scripts/e2e/php-ini.sh
+++ b/scripts/e2e/php-ini.sh
@@ -4,6 +4,11 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 # shellcheck source=helpers.sh
 source "$SCRIPT_DIR/helpers.sh"
 
+# Each GHA step is a fresh shell; ~/.pv/bin isn't on PATH unless we export it.
+# Mirror what verify-install.sh does so the `php -r ...` invocations below
+# resolve via the shim.
+eval "$(pv env)"
+
 PHP_VERSION="${PHP_VERSION:-8.4}"
 ETC_DIR="$HOME/.pv/php/$PHP_VERSION/etc"
 CONFD_DIR="$HOME/.pv/php/$PHP_VERSION/conf.d"


### PR DESCRIPTION
## Summary

`scripts/e2e/php-ini.sh` calls `php -r ...` directly but doesn't export `~/.pv/bin` onto PATH first. Each GitHub Actions step runs in a fresh shell — the `eval "$(pv env)"` from a prior step's `verify-install.sh` doesn't carry over. Result: every CI run since #74 fails at this phase with `php: command not found`.

The fix is a 3-line addition: mirror what `verify-install.sh` does at the top of the script.

## Why this PR targets `feat/postgres-native-binaries`

Once it merges into that branch, the postgres-binary phase added by #75 can actually be exercised in CI. Keeping it small and scoped so it's easy to review separately from the larger postgres work.

## Test plan

- [x] `bash -n scripts/e2e/php-ini.sh` syntax-clean
- [ ] CI: php-ini phase no longer fails with "command not found" (merge-then-watch)
- [ ] CI: postgres-binary phase added by #75 actually runs after this fix is in place