### PR TITLE
fix(binaries): pin RustFS to 1.0.0-beta.1 (upstream beta.2 has no assets)

### DIFF
--- a/internal/binaries/versions.go
+++ b/internal/binaries/versions.go
@@ -53,11 +53,21 @@ func (vs *VersionState) Set(name, version string) {
 	vs.Versions[name] = version
 }
 
+// rustfsPinnedVersion pins the RustFS download. The upstream release
+// 1.0.0-beta.2 was tagged with zero assets attached, breaking the
+// "fetch latest tag → download by URL pattern" flow. Pin to the last
+// known-good release until upstream uploads assets again or our
+// resolver grows asset-presence filtering.
+const rustfsPinnedVersion = "1.0.0-beta.1"
+
 // FetchLatestVersion queries GitHub API for the latest release tag.
 // For Composer, it returns "latest" (always re-downloaded).
 func FetchLatestVersion(client *http.Client, b Binary) (string, error) {
 	if b.Name == "composer" {
 		return "latest", nil
+	}
+	if b.Name == "rustfs" {
+		return rustfsPinnedVersion, nil
 	}
 
 	url := LatestVersionURL(b)


### PR DESCRIPTION
## Summary

Upstream tagged `1.0.0-beta.2` with zero assets attached, so pv's "fetch latest tag → download by URL pattern" resolver 404s on `rustfs-macos-aarch64-latest.zip`. This blocks the s3-binary e2e phase, which in turn blocks the postgres-binary phase (downstream in the workflow).

Pin to `1.0.0-beta.1` (30 assets, all platforms present) until upstream uploads assets to a newer release or the resolver grows asset-presence filtering.

Targets `feat/postgres-native-binaries` so once it merges into that branch, PR #75's e2e can actually run end-to-end.

## Test plan

- [x] Build clean, vet clean, all unit tests pass
- [ ] After merge into `feat/postgres-native-binaries`, the s3-binary phase no longer 404s and the postgres-binary phase reaches end of suite

## Why temporary

This is a one-line workaround. A more durable fix is filtering out releases with no assets in `fetchLatestVersionFromURL` for rustfs — but that's its own correctness change in a generic resolver, and out of scope here.