### PR TITLE
ci: add Mailpit, RustFS, Redis artifact jobs

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -601,11 +601,18 @@ jobs:
           compression-level: 0
 
   release:
-    needs: [frankenphp, postgres, mysql]
+    needs: [frankenphp, postgres, mysql, mailpit, rustfs, redis]
     # Only publish from main, and only when every build family ran. A skipped
     # build job reports as "success" to its dependents, so without these extra
     # clauses a dispatch with skip_* flags would publish a half-baked release.
-    if: ${{ github.ref == 'refs/heads/main' && inputs.skip_frankenphp != true && inputs.skip_postgres != true && inputs.skip_mysql != true }}
+    if: >-
+      ${{ github.ref == 'refs/heads/main'
+      && inputs.skip_frankenphp != true
+      && inputs.skip_postgres != true
+      && inputs.skip_mysql != true
+      && inputs.skip_mailpit != true
+      && inputs.skip_rustfs != true
+      && inputs.skip_redis != true }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -628,6 +635,21 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           pattern: mysql-mac-arm64-*
+          path: artifacts
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: mailpit-mac-*
+          path: artifacts
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: rustfs-mac-*
+          path: artifacts
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: redis-mac-*
           path: artifacts
 
       - name: Prepare release assets
@@ -676,6 +698,24 @@ jobs:
             exit 1
           fi
 
+          # Mailpit: single artifact (no version matrix).
+          if [ ! -d "artifacts/mailpit-mac-arm64" ]; then
+            echo "::error::Missing mailpit artifact"
+            exit 1
+          fi
+
+          # RustFS: single artifact (no version matrix).
+          if [ ! -d "artifacts/rustfs-mac-arm64" ]; then
+            echo "::error::Missing rustfs artifact"
+            exit 1
+          fi
+
+          # Redis: single artifact (no version matrix).
+          if [ ! -d "artifacts/redis-mac-arm64" ]; then
+            echo "::error::Missing redis artifact"
+            exit 1
+          fi
+
           mkdir -p release
           # FrankenPHP binaries: artifact dir name matches the binary name.
           for dir in "${fp_dirs[@]}"; do
@@ -695,6 +735,13 @@ jobs:
           for dir in "${mysql_dirs[@]}"; do
             cp "$dir"/* "release/"
           done
+          # Mailpit tarball: copy as-is (no chmod needed).
+          cp artifacts/mailpit-mac-arm64/* "release/"
+          # RustFS binary: bare binary (like FrankenPHP).
+          cp artifacts/rustfs-mac-arm64/* "release/"
+          chmod +x "release/rustfs-mac-arm64"
+          # Redis tarball: copy as-is (no chmod needed).
+          cp artifacts/redis-mac-arm64/* "release/"
           ls -la release/
 
       - name: Upload to artifacts release
@@ -712,8 +759,8 @@ jobs:
             echo "Creating $TAG release"
             gh release create "$TAG" \
               --repo "${{ github.repository }}" \
-              --title "pv binaries (FrankenPHP, PHP CLI, PostgreSQL, MySQL)" \
-              --notes "Rolling release of binaries used by pv: FrankenPHP, static PHP CLI, PostgreSQL, and MySQL. Rebuilt weekly by build-artifacts.yml. Not a versioned pv release." \
+              --title "pv binaries (FrankenPHP, PHP CLI, PostgreSQL, MySQL, Mailpit, RustFS, Redis)" \
+              --notes "Rolling release of binaries used by pv: FrankenPHP, static PHP CLI, PostgreSQL, MySQL, Mailpit, RustFS, and Redis. Rebuilt weekly by build-artifacts.yml. Not a versioned pv release." \
               --latest=false
           fi
 

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -752,8 +752,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          # All FrankenPHP + PHP CLI binaries live in a single non-versioned
-          # "artifacts" release, independent of pv's own versioned (v*) releases.
+          # All built binaries (FrankenPHP, PHP CLI, PostgreSQL, MySQL, Mailpit,
+          # RustFS, Redis) live in a single non-versioned "artifacts" release,
+          # independent of pv's own versioned (v*) releases.
           # Create it on first run, then clobber on every rebuild.
           TAG="artifacts"
 

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -472,7 +472,9 @@ jobs:
           mkdir -p staging
           tar -xzf mailpit.tar.gz -C staging
           chmod +x staging/mailpit
-          staging/mailpit version
+          # "mailpit version" auto-checks for updates (HTTP call that 403s
+          # without auth), so allow it to fail — the smoke test validates the binary.
+          staging/mailpit version || true
 
       - name: Smoke test
         run: bash scripts/test-mailpit-bundle.sh staging/mailpit

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -15,6 +15,18 @@ on:
         description: "Skip the MySQL bundle matrix (8.0 + 8.4 + 9.7)"
         type: boolean
         default: false
+      skip_mailpit:
+        description: "Skip the Mailpit build"
+        type: boolean
+        default: false
+      skip_rustfs:
+        description: "Skip the RustFS build"
+        type: boolean
+        default: false
+      skip_redis:
+        description: "Skip the Redis build"
+        type: boolean
+        default: false
   schedule:
     - cron: "0 0 * * 1"
 
@@ -423,6 +435,169 @@ jobs:
         with:
           name: mysql-mac-arm64-${{ matrix.major }}
           path: mysql-mac-arm64-${{ matrix.major }}.tar.gz
+          compression-level: 0
+
+  mailpit:
+    if: ${{ inputs.skip_mailpit != true }}
+    name: Mailpit
+    runs-on: macos-15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout pv (for scripts/test-mailpit-bundle.sh)
+        uses: actions/checkout@v4
+
+      - name: Resolve latest release
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh api repos/axllent/mailpit/releases/latest --jq '.tag_name')
+          echo "Resolved Mailpit → $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Download
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.resolve.outputs.tag }}"
+          URL="https://github.com/axllent/mailpit/releases/download/${TAG}/mailpit-darwin-arm64.tar.gz"
+          echo "Downloading $URL"
+          curl -fsSL -o mailpit.tar.gz "$URL"
+          ls -lh mailpit.tar.gz
+
+      - name: Extract
+        run: |
+          set -euo pipefail
+          mkdir -p staging
+          tar -xzf mailpit.tar.gz -C staging
+          chmod +x staging/mailpit
+          staging/mailpit version
+
+      - name: Smoke test
+        run: bash scripts/test-mailpit-bundle.sh staging/mailpit
+
+      - name: Repack
+        run: |
+          set -euo pipefail
+          tar -czf mailpit-mac-arm64.tar.gz -C staging mailpit
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mailpit-mac-arm64
+          path: mailpit-mac-arm64.tar.gz
+          compression-level: 0
+
+  rustfs:
+    if: ${{ inputs.skip_rustfs != true }}
+    name: RustFS
+    runs-on: macos-15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout pv (for scripts/test-rustfs-bundle.sh)
+        uses: actions/checkout@v4
+
+      - name: Download pinned release
+        run: |
+          set -euo pipefail
+          # Pinned: 1.0.0-beta.2 has no release assets. Remove pin when fixed.
+          VERSION="1.0.0-beta.1"
+          URL="https://github.com/rustfs/rustfs/releases/download/${VERSION}/rustfs-macos-aarch64-v${VERSION}.zip"
+          echo "Downloading $URL"
+          curl -fsSL -o rustfs.zip "$URL"
+          ls -lh rustfs.zip
+
+      - name: Extract
+        run: |
+          set -euo pipefail
+          mkdir -p staging
+          unzip -o rustfs.zip -d staging
+          chmod +x staging/rustfs
+          staging/rustfs --version
+
+      - name: Smoke test
+        run: bash scripts/test-rustfs-bundle.sh staging/rustfs
+
+      - name: Rename binary
+        run: mv staging/rustfs rustfs-mac-arm64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rustfs-mac-arm64
+          path: rustfs-mac-arm64
+          compression-level: 0
+
+  redis:
+    if: ${{ inputs.skip_redis != true }}
+    name: Redis
+    runs-on: macos-15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout pv (for scripts/test-redis-bundle.sh)
+        uses: actions/checkout@v4
+
+      - name: Resolve latest stable version
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh api repos/redis/redis/releases/latest --jq '.tag_name')
+          echo "Resolved Redis → $TAG"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Download source
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.resolve.outputs.tag }}"
+          URL="https://github.com/redis/redis/archive/refs/tags/${TAG}.tar.gz"
+          echo "Downloading $URL"
+          curl -fsSL -o redis-src.tar.gz "$URL"
+          tar -xzf redis-src.tar.gz
+          echo "SRC_DIR=redis-${TAG}" >> "$GITHUB_ENV"
+
+      - name: Build
+        run: |
+          set -euo pipefail
+          cd "$SRC_DIR"
+          make -j$(sysctl -n hw.ncpu) MALLOC=libc BUILD_TLS=no USE_SYSTEMD=no
+
+      - name: Verify no external deps
+        run: |
+          set -euo pipefail
+          for bin in "$SRC_DIR/src/redis-server" "$SRC_DIR/src/redis-cli"; do
+            echo "=== $(basename "$bin") ==="
+            otool -L "$bin"
+            bad=$(otool -L "$bin" | tail -n +2 | awk '{print $1}' | grep -vE '^(/usr/lib/|@)' || true)
+            if [ -n "$bad" ]; then
+              echo "::error::$(basename "$bin") links against non-system libraries:"
+              echo "$bad"
+              exit 1
+            fi
+          done
+          echo "All binaries link only against system libraries."
+
+      - name: Smoke test
+        run: |
+          set -euo pipefail
+          mkdir -p staging
+          cp "$SRC_DIR/src/redis-server" staging/
+          cp "$SRC_DIR/src/redis-cli" staging/
+          chmod +x staging/redis-server staging/redis-cli
+          bash scripts/test-redis-bundle.sh staging
+
+      - name: Package
+        run: tar -czf redis-mac-arm64.tar.gz -C staging redis-server redis-cli
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: redis-mac-arm64
+          path: redis-mac-arm64.tar.gz
           compression-level: 0
 
   release:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,8 @@ Example:
 
 ```bash
 gh workflow run build-artifacts.yml --ref <branch> \
-  -f skip_frankenphp=true -f skip_postgres=true
+  -f skip_frankenphp=true -f skip_postgres=true \
+  -f skip_mailpit=true -f skip_rustfs=true -f skip_redis=true
 ```
 
 The `release` job is gated on all six skip flags being false, so a partial dispatch never publishes a half-baked release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ A full dispatch runs the FrankenPHP matrix (3 PHP versions, ~30 min each), Postg
 
 If the affected family is ambiguous from the diff, ask before dispatching. Never dispatch with no skip flags "just to be safe" — that's the failure mode this convention exists to prevent.
 
-Example:
+Example (MySQL-only dispatch):
 
 ```bash
 gh workflow run build-artifacts.yml --ref <branch> \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,15 +155,18 @@ The CLI uses a layered Charm stack:
 
 ### Dispatching `build-artifacts.yml` manually
 
-A full dispatch runs the FrankenPHP matrix (3 PHP versions, ~30 min each), Postgres (17 + 18), and MySQL (8.0 + 8.4 + 9.7). That's ~90 min of macOS runner time per push and almost always more than the change under test needs.
+A full dispatch runs the FrankenPHP matrix (3 PHP versions, ~30 min each), Postgres (17 + 18), MySQL (8.0 + 8.4 + 9.7), Mailpit, RustFS, and Redis. That's significant macOS runner time per push and almost always more than the change under test needs.
 
 **Always pass `skip_*` flags scoped to the change.** Infer from context — don't run families unrelated to the work:
 
 | Working on… | Dispatch with |
 |---|---|
-| MySQL artifacts / `mysql:` job / `scripts/test-mysql-bundle.sh` | `-f skip_frankenphp=true -f skip_postgres=true` |
-| Postgres artifacts / `postgres:` job / `scripts/test-postgres-bundle.sh` | `-f skip_frankenphp=true -f skip_mysql=true` |
-| FrankenPHP build / `static-php-cli` extensions | `-f skip_postgres=true -f skip_mysql=true` |
+| MySQL artifacts / `mysql:` job / `scripts/test-mysql-bundle.sh` | `-f skip_frankenphp=true -f skip_postgres=true -f skip_mailpit=true -f skip_rustfs=true -f skip_redis=true` |
+| Postgres artifacts / `postgres:` job / `scripts/test-postgres-bundle.sh` | `-f skip_frankenphp=true -f skip_mysql=true -f skip_mailpit=true -f skip_rustfs=true -f skip_redis=true` |
+| FrankenPHP build / `static-php-cli` extensions | `-f skip_postgres=true -f skip_mysql=true -f skip_mailpit=true -f skip_rustfs=true -f skip_redis=true` |
+| Mailpit artifacts / `mailpit:` job / `scripts/test-mailpit-bundle.sh` | `-f skip_frankenphp=true -f skip_postgres=true -f skip_mysql=true -f skip_rustfs=true -f skip_redis=true` |
+| RustFS artifacts / `rustfs:` job / `scripts/test-rustfs-bundle.sh` | `-f skip_frankenphp=true -f skip_postgres=true -f skip_mysql=true -f skip_mailpit=true -f skip_redis=true` |
+| Redis artifacts / `redis:` job / `scripts/test-redis-bundle.sh` | `-f skip_frankenphp=true -f skip_postgres=true -f skip_mysql=true -f skip_mailpit=true -f skip_rustfs=true` |
 | Release-job wiring / artifacts upload logic | run the family that produces the artifacts in question; skip the others |
 | Truly cross-cutting (e.g. concurrency-group changes) | no skips — needs the full matrix |
 
@@ -176,7 +179,7 @@ gh workflow run build-artifacts.yml --ref <branch> \
   -f skip_frankenphp=true -f skip_postgres=true
 ```
 
-The `release` job is gated on all three skip flags being false, so a partial dispatch never publishes a half-baked release.
+The `release` job is gated on all six skip flags being false, so a partial dispatch never publishes a half-baked release.
 
 ## Multi-version PHP
 

--- a/scripts/test-mailpit-bundle.sh
+++ b/scripts/test-mailpit-bundle.sh
@@ -49,8 +49,8 @@ echo "  $MAILPIT_VER"
 # 2. start mailpit
 echo "== 2. start mailpit =="
 "$MAILPIT" \
-    --smtp 0.0.0.0:$SMTP_PORT \
-    --listen 0.0.0.0:$HTTP_PORT \
+    --smtp 127.0.0.1:$SMTP_PORT \
+    --listen 127.0.0.1:$HTTP_PORT \
     --database "$WORK_DIR/mailpit.db" \
     >"$WORK_DIR/mailpit.log" 2>&1 &
 MAILPIT_PID=$!

--- a/scripts/test-mailpit-bundle.sh
+++ b/scripts/test-mailpit-bundle.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# test-mailpit-bundle.sh — smoke test for a Mailpit binary.
+#
+# Verifies that mailpit starts, accepts SMTP connections, receives an
+# email, and exposes it via the HTTP API.
+#
+# Usage:
+#     scripts/test-mailpit-bundle.sh <path-to-mailpit-binary>
+#
+# Used by .github/workflows/build-artifacts.yml against the downloaded
+# binary, and locally by passing an extracted CI artifact.
+#
+# Exit code: 0 = all checks passed; non-zero = at least one failed.
+
+set -euo pipefail
+
+MAILPIT="${1:?usage: $0 <path-to-mailpit-binary>}"
+SMTP_PORT="${MAILPIT_TEST_SMTP_PORT:-10025}"
+HTTP_PORT="${MAILPIT_TEST_HTTP_PORT:-18025}"
+
+if [ ! -x "$MAILPIT" ]; then
+    echo "::error::No executable at $MAILPIT"
+    exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+MAILPIT_PID=""
+
+cleanup() {
+    local rc=$?
+    if [ -n "$MAILPIT_PID" ]; then
+        kill "$MAILPIT_PID" 2>/dev/null || true
+        wait "$MAILPIT_PID" 2>/dev/null || true
+    fi
+    if [ "$rc" -ne 0 ] && [ -s "$WORK_DIR/mailpit.log" ]; then
+        echo "::group::mailpit.log (script exited $rc)" >&2
+        cat "$WORK_DIR/mailpit.log" >&2
+        echo "::endgroup::" >&2
+    fi
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# 1. version
+echo "== 1. mailpit version =="
+MAILPIT_VER=$("$MAILPIT" version 2>&1 || true)
+echo "  $MAILPIT_VER"
+
+# 2. start mailpit
+echo "== 2. start mailpit =="
+"$MAILPIT" \
+    --smtp 0.0.0.0:$SMTP_PORT \
+    --listen 0.0.0.0:$HTTP_PORT \
+    --database "$WORK_DIR/mailpit.db" \
+    >"$WORK_DIR/mailpit.log" 2>&1 &
+MAILPIT_PID=$!
+
+for i in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:$HTTP_PORT/livez" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+if ! curl -sf "http://127.0.0.1:$HTTP_PORT/livez" >/dev/null 2>&1; then
+    echo "::error::mailpit did not become ready within 30s"
+    exit 1
+fi
+echo "  ✓ accepting connections (SMTP :$SMTP_PORT, HTTP :$HTTP_PORT)"
+
+# 3. send a test email via SMTP
+echo "== 3. send test email via SMTP =="
+# Use curl's SMTP upload capability to send a raw email.
+MESSAGE_ID="pv-ci-test-$(date +%s)@test.local"
+cat > "$WORK_DIR/email.txt" <<EOF
+From: ci@test.local
+To: user@test.local
+Subject: pv CI smoke test
+Message-ID: <$MESSAGE_ID>
+Date: $(date -R 2>/dev/null || date)
+Content-Type: text/plain
+
+This is a smoke test email from the pv CI pipeline.
+EOF
+
+curl -sf --url "smtp://127.0.0.1:$SMTP_PORT" \
+    --mail-from "ci@test.local" \
+    --mail-rcpt "user@test.local" \
+    --upload-file "$WORK_DIR/email.txt"
+echo "  ✓ email sent via SMTP"
+
+# 4. verify email appears in the HTTP API
+echo "== 4. verify email via HTTP API =="
+# Give mailpit a moment to index the message.
+sleep 1
+
+MSG_COUNT=$(curl -sf "http://127.0.0.1:$HTTP_PORT/api/v1/messages" | grep -o '"messages_count":[0-9]*' | cut -d: -f2)
+if [ -z "$MSG_COUNT" ] || [ "$MSG_COUNT" -lt 1 ]; then
+    echo "::error::Expected at least 1 message in API, got '$MSG_COUNT'"
+    exit 1
+fi
+echo "  ✓ $MSG_COUNT message(s) in inbox"
+
+# Verify our specific message by searching for the subject.
+SEARCH_HITS=$(curl -sf "http://127.0.0.1:$HTTP_PORT/api/v1/search?query=subject%3A%22pv+CI+smoke+test%22" | grep -o '"messages_count":[0-9]*' | cut -d: -f2)
+if [ -z "$SEARCH_HITS" ] || [ "$SEARCH_HITS" -lt 1 ]; then
+    echo "::error::Search for test email returned '$SEARCH_HITS' hits, expected >=1"
+    exit 1
+fi
+echo "  ✓ test email found via search API"
+
+# 5. clean shutdown
+echo "== 5. shutdown =="
+kill "$MAILPIT_PID"
+wait "$MAILPIT_PID" 2>/dev/null || true
+MAILPIT_PID=""
+echo "  ✓ clean shutdown"
+
+echo ""
+echo "== ALL CHECKS PASSED for $MAILPIT_VER =="

--- a/scripts/test-mailpit-bundle.sh
+++ b/scripts/test-mailpit-bundle.sh
@@ -59,6 +59,10 @@ for i in $(seq 1 30); do
     if curl -sf "http://127.0.0.1:$HTTP_PORT/livez" >/dev/null 2>&1; then
         break
     fi
+    if ! kill -0 "$MAILPIT_PID" 2>/dev/null; then
+        echo "::error::mailpit process exited prematurely"
+        exit 1
+    fi
     sleep 1
 done
 

--- a/scripts/test-redis-bundle.sh
+++ b/scripts/test-redis-bundle.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# test-redis-bundle.sh — smoke test for a built Redis bundle.
+#
+# Verifies that redis-server starts, accepts connections, handles basic
+# SET/GET operations, and shuts down cleanly.
+#
+# Usage:
+#     scripts/test-redis-bundle.sh <path-to-staging-dir>
+#
+# The path argument should be the directory containing redis-server and
+# redis-cli. Used by .github/workflows/build-artifacts.yml against the
+# staged binaries, and locally by passing an extracted CI artifact.
+#
+# Exit code: 0 = all checks passed; non-zero = at least one failed.
+
+set -euo pipefail
+
+STAGING="${1:?usage: $0 <path-to-staging-dir>}"
+PORT="${REDIS_TEST_PORT:-16399}"
+
+SERVER="$STAGING/redis-server"
+CLI="$STAGING/redis-cli"
+
+if [ ! -x "$SERVER" ]; then
+    echo "::error::No redis-server at $SERVER"
+    exit 1
+fi
+if [ ! -x "$CLI" ]; then
+    echo "::error::No redis-cli at $CLI"
+    exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+REDIS_PID=""
+
+cleanup() {
+    local rc=$?
+    if [ -n "$REDIS_PID" ]; then
+        "$CLI" -p "$PORT" SHUTDOWN NOSAVE 2>/dev/null || \
+            kill "$REDIS_PID" 2>/dev/null || true
+        wait "$REDIS_PID" 2>/dev/null || true
+    fi
+    if [ "$rc" -ne 0 ] && [ -s "$WORK_DIR/redis.log" ]; then
+        echo "::group::redis.log (script exited $rc)" >&2
+        cat "$WORK_DIR/redis.log" >&2
+        echo "::endgroup::" >&2
+    fi
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# 1. server version
+echo "== 1. redis-server version =="
+SERVER_VER=$("$SERVER" --version | head -1)
+echo "  $SERVER_VER"
+
+# 2. start redis-server
+echo "== 2. start redis-server =="
+"$SERVER" \
+    --port "$PORT" \
+    --bind 127.0.0.1 \
+    --dir "$WORK_DIR" \
+    --save "" \
+    --appendonly no \
+    --daemonize yes \
+    --logfile "$WORK_DIR/redis.log" \
+    --pidfile "$WORK_DIR/redis.pid"
+
+# daemonize writes the pid file; read it so cleanup can target it.
+for i in $(seq 1 15); do
+    if "$CLI" -p "$PORT" PING 2>/dev/null | grep -q PONG; then
+        break
+    fi
+    sleep 1
+done
+
+if ! "$CLI" -p "$PORT" PING 2>/dev/null | grep -q PONG; then
+    echo "::error::redis-server did not become ready within 15s"
+    exit 1
+fi
+REDIS_PID=$(cat "$WORK_DIR/redis.pid" 2>/dev/null || true)
+echo "  ✓ accepting connections on 127.0.0.1:$PORT (pid $REDIS_PID)"
+
+# 3. PING
+echo "== 3. PING =="
+PONG=$("$CLI" -p "$PORT" PING)
+if [ "$PONG" != "PONG" ]; then
+    echo "::error::PING returned '$PONG', expected 'PONG'"
+    exit 1
+fi
+echo "  ✓ PONG"
+
+# 4. SET / GET roundtrip
+echo "== 4. SET / GET roundtrip =="
+"$CLI" -p "$PORT" SET pv:test:key "hello-from-ci" >/dev/null
+GOT=$("$CLI" -p "$PORT" GET pv:test:key)
+if [ "$GOT" != "hello-from-ci" ]; then
+    echo "::error::GET returned '$GOT', expected 'hello-from-ci'"
+    exit 1
+fi
+echo "  ✓ SET/GET roundtrip"
+
+# 5. basic data structures (hash, list)
+echo "== 5. data structures (hash, list) =="
+"$CLI" -p "$PORT" HSET pv:test:hash field1 val1 field2 val2 >/dev/null
+HGET=$("$CLI" -p "$PORT" HGET pv:test:hash field1)
+if [ "$HGET" != "val1" ]; then
+    echo "::error::HGET returned '$HGET', expected 'val1'"
+    exit 1
+fi
+
+"$CLI" -p "$PORT" RPUSH pv:test:list a b c >/dev/null
+LLEN=$("$CLI" -p "$PORT" LLEN pv:test:list)
+if [ "$LLEN" != "3" ]; then
+    echo "::error::LLEN returned '$LLEN', expected '3'"
+    exit 1
+fi
+echo "  ✓ HSET/HGET + RPUSH/LLEN"
+
+# 6. INFO (exercises stats subsystem)
+echo "== 6. INFO server =="
+REDIS_VERSION=$("$CLI" -p "$PORT" INFO server | grep "redis_version:" | cut -d: -f2 | tr -d '[:space:]')
+echo "  redis_version=$REDIS_VERSION"
+
+# 7. clean shutdown
+echo "== 7. shutdown =="
+"$CLI" -p "$PORT" SHUTDOWN NOSAVE
+wait "$REDIS_PID" 2>/dev/null || true
+REDIS_PID=""
+echo "  ✓ clean shutdown"
+
+echo ""
+echo "== ALL CHECKS PASSED for Redis $REDIS_VERSION =="

--- a/scripts/test-redis-bundle.sh
+++ b/scripts/test-redis-bundle.sh
@@ -35,6 +35,10 @@ REDIS_PID=""
 
 cleanup() {
     local rc=$?
+    # Try to read PID from pidfile if we don't have it yet (daemonized server).
+    if [ -z "$REDIS_PID" ] && [ -f "$WORK_DIR/redis.pid" ]; then
+        REDIS_PID=$(cat "$WORK_DIR/redis.pid" 2>/dev/null || true)
+    fi
     if [ -n "$REDIS_PID" ]; then
         "$CLI" -p "$PORT" SHUTDOWN NOSAVE 2>/dev/null || \
             kill "$REDIS_PID" 2>/dev/null || true

--- a/scripts/test-rustfs-bundle.sh
+++ b/scripts/test-rustfs-bundle.sh
@@ -76,7 +76,7 @@ echo "  ✓ accepting connections (API :$API_PORT, Console :$CONSOLE_PORT)"
 
 # 3. create a bucket
 echo "== 3. create bucket =="
-# RustFS supports MinIO-compatible API. Use curl with AWS SigV4 via --aws-sigv4.
+# Use curl with AWS SigV4 via --aws-sigv4.
 # First, create a bucket named "pv-ci-test".
 BUCKET="pv-ci-test"
 curl -sf -X PUT \

--- a/scripts/test-rustfs-bundle.sh
+++ b/scripts/test-rustfs-bundle.sh
@@ -46,7 +46,7 @@ trap cleanup EXIT
 
 # 1. version
 echo "== 1. rustfs version =="
-RUSTFS_VER=$("$RUSTFS" --version 2>&1 || true)
+RUSTFS_VER=$("$RUSTFS" --version 2>&1)
 echo "  $RUSTFS_VER"
 
 # 2. start rustfs
@@ -55,15 +55,19 @@ mkdir -p "$WORK_DIR/data"
 RUSTFS_ACCESS_KEY="$ACCESS_KEY" \
 RUSTFS_SECRET_KEY="$SECRET_KEY" \
 "$RUSTFS" server "$WORK_DIR/data" \
-    --address ":$API_PORT" \
+    --address "127.0.0.1:$API_PORT" \
     --console-enable \
-    --console-address ":$CONSOLE_PORT" \
+    --console-address "127.0.0.1:$CONSOLE_PORT" \
     >"$WORK_DIR/rustfs.log" 2>&1 &
 RUSTFS_PID=$!
 
 for i in $(seq 1 30); do
     if nc -z 127.0.0.1 "$API_PORT" 2>/dev/null; then
         break
+    fi
+    if ! kill -0 "$RUSTFS_PID" 2>/dev/null; then
+        echo "::error::rustfs process exited prematurely"
+        exit 1
     fi
     sleep 1
 done

--- a/scripts/test-rustfs-bundle.sh
+++ b/scripts/test-rustfs-bundle.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# test-rustfs-bundle.sh — smoke test for a RustFS binary.
+#
+# Verifies that rustfs starts, accepts S3 API connections, and handles
+# basic PUT/GET object operations.
+#
+# Usage:
+#     scripts/test-rustfs-bundle.sh <path-to-rustfs-binary>
+#
+# Used by .github/workflows/build-artifacts.yml against the downloaded
+# binary, and locally by passing an extracted CI artifact.
+#
+# Exit code: 0 = all checks passed; non-zero = at least one failed.
+
+set -euo pipefail
+
+RUSTFS="${1:?usage: $0 <path-to-rustfs-binary>}"
+API_PORT="${RUSTFS_TEST_API_PORT:-19000}"
+CONSOLE_PORT="${RUSTFS_TEST_CONSOLE_PORT:-19001}"
+
+if [ ! -x "$RUSTFS" ]; then
+    echo "::error::No executable at $RUSTFS"
+    exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+RUSTFS_PID=""
+
+ACCESS_KEY="rstfsadmin"
+SECRET_KEY="rstfsadmin"
+
+cleanup() {
+    local rc=$?
+    if [ -n "$RUSTFS_PID" ]; then
+        kill "$RUSTFS_PID" 2>/dev/null || true
+        wait "$RUSTFS_PID" 2>/dev/null || true
+    fi
+    if [ "$rc" -ne 0 ] && [ -s "$WORK_DIR/rustfs.log" ]; then
+        echo "::group::rustfs.log (script exited $rc)" >&2
+        cat "$WORK_DIR/rustfs.log" >&2
+        echo "::endgroup::" >&2
+    fi
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+# 1. version
+echo "== 1. rustfs version =="
+RUSTFS_VER=$("$RUSTFS" --version 2>&1 || true)
+echo "  $RUSTFS_VER"
+
+# 2. start rustfs
+echo "== 2. start rustfs =="
+RUSTFS_ACCESS_KEY="$ACCESS_KEY" \
+RUSTFS_SECRET_KEY="$SECRET_KEY" \
+"$RUSTFS" server "$WORK_DIR/data" \
+    --address ":$API_PORT" \
+    --console-enable \
+    --console-address ":$CONSOLE_PORT" \
+    >"$WORK_DIR/rustfs.log" 2>&1 &
+RUSTFS_PID=$!
+
+for i in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:$API_PORT/minio/health/live" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+
+if ! curl -sf "http://127.0.0.1:$API_PORT/minio/health/live" >/dev/null 2>&1; then
+    echo "::error::rustfs did not become ready within 30s"
+    exit 1
+fi
+echo "  ✓ accepting connections (API :$API_PORT, Console :$CONSOLE_PORT)"
+
+# 3. create a bucket
+echo "== 3. create bucket =="
+# RustFS supports MinIO-compatible API. Use curl with AWS SigV4 via --aws-sigv4.
+# First, create a bucket named "pv-ci-test".
+BUCKET="pv-ci-test"
+curl -sf -X PUT \
+    --aws-sigv4 "aws:amz:us-east-1:s3" \
+    --user "$ACCESS_KEY:$SECRET_KEY" \
+    "http://127.0.0.1:$API_PORT/$BUCKET" >/dev/null
+echo "  ✓ bucket '$BUCKET' created"
+
+# 4. PUT an object
+echo "== 4. PUT object =="
+OBJECT_CONTENT="hello from pv CI pipeline — $(date)"
+echo -n "$OBJECT_CONTENT" > "$WORK_DIR/testfile.txt"
+curl -sf -X PUT \
+    --aws-sigv4 "aws:amz:us-east-1:s3" \
+    --user "$ACCESS_KEY:$SECRET_KEY" \
+    --upload-file "$WORK_DIR/testfile.txt" \
+    "http://127.0.0.1:$API_PORT/$BUCKET/test-object.txt" >/dev/null
+echo "  ✓ object uploaded"
+
+# 5. GET the object back and verify content
+echo "== 5. GET object and verify =="
+GOT=$(curl -sf \
+    --aws-sigv4 "aws:amz:us-east-1:s3" \
+    --user "$ACCESS_KEY:$SECRET_KEY" \
+    "http://127.0.0.1:$API_PORT/$BUCKET/test-object.txt")
+if [ "$GOT" != "$OBJECT_CONTENT" ]; then
+    echo "::error::GET returned unexpected content"
+    echo "  expected: $OBJECT_CONTENT"
+    echo "  got:      $GOT"
+    exit 1
+fi
+echo "  ✓ content matches"
+
+# 6. DELETE the object
+echo "== 6. DELETE object =="
+curl -sf -X DELETE \
+    --aws-sigv4 "aws:amz:us-east-1:s3" \
+    --user "$ACCESS_KEY:$SECRET_KEY" \
+    "http://127.0.0.1:$API_PORT/$BUCKET/test-object.txt" >/dev/null
+echo "  ✓ object deleted"
+
+# 7. clean shutdown
+echo "== 7. shutdown =="
+kill "$RUSTFS_PID"
+wait "$RUSTFS_PID" 2>/dev/null || true
+RUSTFS_PID=""
+echo "  ✓ clean shutdown"
+
+echo ""
+echo "== ALL CHECKS PASSED for $RUSTFS_VER =="

--- a/scripts/test-rustfs-bundle.sh
+++ b/scripts/test-rustfs-bundle.sh
@@ -51,6 +51,7 @@ echo "  $RUSTFS_VER"
 
 # 2. start rustfs
 echo "== 2. start rustfs =="
+mkdir -p "$WORK_DIR/data"
 RUSTFS_ACCESS_KEY="$ACCESS_KEY" \
 RUSTFS_SECRET_KEY="$SECRET_KEY" \
 "$RUSTFS" server "$WORK_DIR/data" \

--- a/scripts/test-rustfs-bundle.sh
+++ b/scripts/test-rustfs-bundle.sh
@@ -62,13 +62,13 @@ RUSTFS_SECRET_KEY="$SECRET_KEY" \
 RUSTFS_PID=$!
 
 for i in $(seq 1 30); do
-    if curl -sf "http://127.0.0.1:$API_PORT/minio/health/live" >/dev/null 2>&1; then
+    if nc -z 127.0.0.1 "$API_PORT" 2>/dev/null; then
         break
     fi
     sleep 1
 done
 
-if ! curl -sf "http://127.0.0.1:$API_PORT/minio/health/live" >/dev/null 2>&1; then
+if ! nc -z 127.0.0.1 "$API_PORT" 2>/dev/null; then
     echo "::error::rustfs did not become ready within 30s"
     exit 1
 fi


### PR DESCRIPTION
## Summary

- Add three new jobs to `build-artifacts.yml` for **Mailpit** (download pre-built binary), **RustFS** (download pinned release), and **Redis** (build from source)
- Each job has a smoke test script (`scripts/test-{mailpit,rustfs,redis}-bundle.sh`) and a `skip_*` dispatch flag
- Release job updated to aggregate all six artifact families with validation and guard checks
- CLAUDE.md dispatch table updated for six skip flags

## Details

| Service | Source | Artifact | Size |
|---|---|---|---|
| Mailpit | Pre-built from `axllent/mailpit` releases | `mailpit-mac-arm64.tar.gz` | ~10 MB |
| RustFS | Pinned `1.0.0-beta.1` from `rustfs/rustfs` | `rustfs-mac-arm64` (bare binary) | ~80 MB |
| Redis | Built from source (`redis/redis` latest stable) | `redis-mac-arm64.tar.gz` (server + cli) | ~3 MB |

All three produce self-contained macOS arm64 binaries with no external dependencies.

## Test plan

- [ ] Dispatch workflow with `-f skip_frankenphp=true -f skip_postgres=true -f skip_mysql=true` — [run link](https://github.com/prvious/pv/actions/runs/25536476776)
- [ ] Mailpit job: downloads, extracts, smoke test (SMTP send + HTTP API verify)
- [ ] RustFS job: downloads, extracts, smoke test (S3 PUT/GET roundtrip)
- [ ] Redis job: builds from source, `otool -L` verify, smoke test (PING + SET/GET + data structures)
- [ ] Verify release job skips correctly (not on main + skip flags set)