### PR TITLE
feat(automation): pv.yml setup: runner + db commands (PR 3/6)

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -61,6 +61,10 @@ pv link --name=myapp ~/Code/myapp`,
 			return fmt.Errorf("cannot read pv.yml: %w", err)
 		}
 
+		if projectCfg.HasSetup() {
+			ui.Subtle("pv.yml setup: declared — legacy setup steps skipped")
+		}
+
 		name := linkName
 		if name == "" {
 			name = filepath.Base(absPath)

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -155,6 +155,7 @@ pv link --name=myapp ~/Code/myapp`,
 			&laravel.SetViteTLSStep{},
 			&laravel.CreateDatabaseStep{},
 			&laravel.RunMigrationsStep{},
+			&steps.ApplySetupStep{},
 		}
 		if err := automation.RunPipeline(allSteps, ctx); err != nil {
 			return err

--- a/docs/superpowers/plans/2026-05-10-pv-yml-pr3-setup-runner.md
+++ b/docs/superpowers/plans/2026-05-10-pv-yml-pr3-setup-runner.md
@@ -1,0 +1,873 @@
+# pv.yml PR 3 — `setup:` runner + db commands Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the `setup:` command runner — when pv.yml declares a `setup:` block, `pv link` runs the user's shell commands instead of the hardcoded `Composer install / GenerateKey / InstallOctane / CreateDatabase / RunMigrations / CopyEnv` pipeline. Also expose `pv postgres:db:create / :drop` and `pv mysql:db:create / :drop` as standalone commands users can call from `setup:` (the underlying helpers already exist).
+
+**Scope decision:** `pv s3:bucket:create / :drop` is **deferred to a follow-up PR**. The spec assumed bucket-creation logic was already partly present; the explorer confirmed it isn't (rustfs has no bucket code today). Adding it requires either an S3 SDK dependency, inline sigv4, or shelling out to `mc`. That's its own focused PR; the rest of PR 3 stands without it.
+
+**Architecture:**
+- `*ProjectConfig.HasSetup()` nil-safe helper, parallel to `HasServices` / `HasAnyEnv` from PR 2.
+- `ApplySetupStep` runs each line of `cfg.Setup` via `bash -c`, with the pinned PHP bin dir prepended to PATH so `php artisan ...` finds the right binary. Fail-fast on first non-zero exit. Streams stdout/stderr directly to the user (long commands like `composer install` shouldn't buffer).
+- 6 existing pipeline steps gain a `HasSetup()` short-circuit in their `ShouldRun`: `CopyEnvStep`, `ComposerInstallStep`, `GenerateKeyStep`, `InstallOctaneStep`, `CreateDatabaseStep`, `RunMigrationsStep`. When the user owns the pipeline via `setup:`, the legacy steps step out of the way entirely.
+- `pv postgres:db:create <name>` / `:drop <name>` and `pv mysql:db:create <name>` / `:drop <name>` are new cobra commands wired through `internal/commands/{postgres,mysql}/register.go`. They reuse `postgres.CreateDatabase` / `mysql.CreateDatabase` (already exported), and add `DropDatabase` siblings if absent.
+
+**Tech Stack:** Go 1.x, cobra, existing `internal/automation/` step framework, `os/exec`.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-10-pv-yml-explicit-config-design.md` (PR 3 section).
+
+**Base commit:** `3bdfaf0` on `main`. Branch: `feat/pvyml-setup-runner`.
+
+---
+
+## Compat strategy
+
+| pv.yml has `setup:`? | Behavior |
+|---|---|
+| Yes | `ApplySetupStep` runs the user's commands; the 6 legacy steps skip via their `HasSetup()` short-circuit. |
+| No | 6 legacy steps run as today (auto-detect path; PR 2's services/env gating still applies). |
+
+Aliases-with-no-setup, services-with-no-setup, env-with-no-setup all keep working. The new gate is independent of the PR 2 gates.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `internal/config/pvyml.go` | Modify | Add `HasSetup() bool` method (nil-safe). |
+| `internal/config/pvyml_test.go` | Modify | Table-driven test for `HasSetup`. |
+| `internal/postgres/database.go` | Modify | Add `DropDatabase(major, dbName)` if not present. |
+| `internal/postgres/database_test.go` | Modify / Create | Test for `DropDatabase`. |
+| `internal/mysql/database.go` | Modify | Add `DropDatabase(version, dbName)` if not present. |
+| `internal/mysql/database_test.go` | Modify / Create | Test for `DropDatabase`. |
+| `internal/commands/postgres/db_create.go` | Create | `pv postgres:db:create <name>` cobra command. |
+| `internal/commands/postgres/db_drop.go` | Create | `pv postgres:db:drop <name>`. |
+| `internal/commands/postgres/register.go` | Modify | Wire new commands. |
+| `internal/commands/mysql/db_create.go` | Create | `pv mysql:db:create <name>`. |
+| `internal/commands/mysql/db_drop.go` | Create | `pv mysql:db:drop <name>`. |
+| `internal/commands/mysql/register.go` | Modify | Wire new commands. |
+| `internal/automation/steps/apply_setup.go` | Create | `ApplySetupStep` — runs `cfg.Setup` lines. |
+| `internal/automation/steps/apply_setup_test.go` | Create | Tests: happy path, fail-fast, PHP-on-PATH, ShouldRun gates. |
+| `internal/laravel/steps.go` | Modify | Prepend `HasSetup()` short-circuit to 6 `ShouldRun` methods (CopyEnv, ComposerInstall, GenerateKey, InstallOctane, CreateDatabase, RunMigrations). |
+| `internal/laravel/steps_test.go` | Modify | Add a skip-test per step (6 tests). |
+| `cmd/link.go` | Modify | Insert `&steps.ApplySetupStep{}` into the pipeline at the right position. |
+
+---
+
+## Pipeline order after PR 3
+
+```
+InstallPHPStep
+CopyEnvStep                  ← gated by HasSetup()
+ComposerInstallStep          ← gated by HasSetup()
+GenerateKeyStep              ← gated by HasSetup()
+InstallOctaneStep            ← gated by HasSetup()
+ApplyPvYmlServicesStep
+DetectServicesStep           ← gated by HasServices() (PR 2)
+laravel.DetectServicesStep   ← gated by HasAnyEnv() (PR 2)
+ApplyPvYmlEnvStep
+laravel.SetAppURLStep
+laravel.SetViteTLSStep
+GenerateTLSCertStep
+CreateDatabaseStep           ← gated by HasSetup()
+RunMigrationsStep            ← gated by HasSetup()
+ApplySetupStep               ← new, runs only when HasSetup()
+```
+
+`ApplySetupStep` runs **last** so the rest of pv's own state (registry, env writes, certs, Caddy config) is in place before the user's commands execute. Setup commands can rely on `.env` being populated, services being bound, and `pv postgres:db:create` being callable.
+
+---
+
+## Task 1: Add `HasSetup()` helper
+
+**Files:**
+- Modify: `internal/config/pvyml.go`
+- Modify: `internal/config/pvyml_test.go`
+
+Pure additive, no behavior change yet.
+
+- [ ] **Step 1.1: Failing test**
+
+Append to `internal/config/pvyml_test.go`:
+
+```go
+func TestProjectConfig_HasSetup(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *ProjectConfig
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", &ProjectConfig{PHP: "8.4"}, false},
+		{"empty slice", &ProjectConfig{Setup: []string{}}, false},
+		{"one command", &ProjectConfig{Setup: []string{"composer install"}}, true},
+		{"several commands", &ProjectConfig{Setup: []string{"composer install", "php artisan migrate"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.HasSetup(); got != tt.want {
+				t.Errorf("HasSetup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 1.2: Verify FAIL**
+
+`go test ./internal/config/ -run TestProjectConfig_HasSetup -v` → FAIL with `cfg.HasSetup undefined`.
+
+- [ ] **Step 1.3: Implement `HasSetup()`**
+
+Append to `internal/config/pvyml.go`:
+
+```go
+// HasSetup reports whether pv.yml declares any setup: commands.
+// Nil-safe so it can be called on a freshly-loaded *ProjectConfig
+// that may not exist for the project. Empty slice (Setup: []) is
+// treated as "no setup declared" — same as omitting the block.
+func (p *ProjectConfig) HasSetup() bool {
+	if p == nil {
+		return false
+	}
+	return len(p.Setup) > 0
+}
+```
+
+- [ ] **Step 1.4: Verify**
+
+`go test ./internal/config/ -v` → all PASS.
+
+- [ ] **Step 1.5: gofmt + vet + build**
+
+```
+gofmt -w internal/config/
+go vet ./internal/config/...
+go build ./...
+```
+Expected: clean.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add internal/config/pvyml.go internal/config/pvyml_test.go
+git commit -m "$(cat <<'EOF'
+feat(config): add HasSetup() nil-safe helper on *ProjectConfig
+
+Parallel to HasServices() and HasAnyEnv(). Returns true when
+pv.yml declares any setup: command. The PR 3 pipeline gate for
+the legacy CopyEnv/ComposerInstall/GenerateKey/InstallOctane/
+CreateDatabase/RunMigrations steps uses this — when set, the
+user owns the setup pipeline and the legacy steps skip.
+EOF
+)"
+```
+
+---
+
+## Task 2: `postgres.DropDatabase` + `mysql.DropDatabase` + standalone db commands
+
+**Files:**
+- Modify: `internal/postgres/database.go` (add `DropDatabase` if absent)
+- Modify or Create: `internal/postgres/database_test.go`
+- Create: `internal/commands/postgres/db_create.go`
+- Create: `internal/commands/postgres/db_drop.go`
+- Modify: `internal/commands/postgres/register.go`
+- Same for mysql under `internal/mysql/` and `internal/commands/mysql/`
+
+The DB creation helpers already exist (called from `CreateDatabaseStep`). We add `DropDatabase` as a symmetric sibling using the same pattern, then expose four cobra commands.
+
+### Postgres
+
+- [ ] **Step 2.1: Read existing `internal/postgres/database.go`**
+
+```bash
+cat internal/postgres/database.go
+```
+
+Note the signature of `CreateDatabase` and the underlying mechanism (psql command, libpq via Go SDK, etc.). The `DropDatabase` implementation should mirror it byte-for-byte modulo the SQL statement (`DROP DATABASE IF EXISTS <name>` vs `CREATE DATABASE <name>`).
+
+If `DropDatabase(major, dbName string) error` already exists, skip Step 2.2 and 2.3.
+
+- [ ] **Step 2.2: Failing test for `postgres.DropDatabase`**
+
+If `database_test.go` exists, append. If not, create it with the standard pattern. Use the helper that stages a real postgres binary if the package's existing tests run against real postgres, or a stub if they're mocked. Match whatever `CreateDatabase`'s tests do. For most cases:
+
+```go
+func TestDropDatabase_NoOpWhenAbsent(t *testing.T) {
+	// Mirror the existing CreateDatabase test's setup (postgres install + start).
+	// Then call DropDatabase against a name that doesn't exist — must not error
+	// (use DROP DATABASE IF EXISTS semantics).
+}
+```
+
+(Exact body depends on whether the package tests against a real postgres or stubs `psql`. Match the existing pattern in `database_test.go` if present, or copy the staging helper from `internal/automation/steps/detect_services_test.go` — which uses `config.PostgresBinDir(major)` to stage a binary.)
+
+- [ ] **Step 2.3: Implement `postgres.DropDatabase`**
+
+In `internal/postgres/database.go`, add (mirroring `CreateDatabase`):
+
+```go
+// DropDatabase removes the named database from the postgres major
+// version, no-op if it doesn't exist.
+func DropDatabase(major, dbName string) error {
+	// Mirror CreateDatabase: locate psql, exec "DROP DATABASE IF EXISTS <name>"
+	// with the same connection params.
+}
+```
+
+(Exact body is a near-copy of `CreateDatabase` with the SQL statement changed. Read `CreateDatabase` and adapt.)
+
+- [ ] **Step 2.4: Create `pv postgres:db:create <name>` command**
+
+Create `internal/commands/postgres/db_create.go`:
+
+```go
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/prvious/pv/internal/postgres"
+	"github.com/spf13/cobra"
+)
+
+var dbCreateCmd = &cobra.Command{
+	Use:     "postgres:db:create <name>",
+	GroupID: "postgres",
+	Short:   "Create a database in the highest-installed PostgreSQL major",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dbName := args[0]
+		majors, err := postgres.InstalledMajors()
+		if err != nil {
+			return fmt.Errorf("list installed majors: %w", err)
+		}
+		if len(majors) == 0 {
+			return fmt.Errorf("no PostgreSQL installed — run `pv postgres:install <major>`")
+		}
+		major := majors[len(majors)-1] // highest installed
+		if err := postgres.CreateDatabase(major, dbName); err != nil {
+			return fmt.Errorf("create %s: %w", dbName, err)
+		}
+		fmt.Printf("created database %q in postgres %s\n", dbName, major)
+		return nil
+	},
+}
+```
+
+(Adjust to match the file's existing command pattern — read `internal/commands/postgres/list.go` for the exact style: imports, comment style, etc.)
+
+- [ ] **Step 2.5: Create `pv postgres:db:drop <name>` command**
+
+Create `internal/commands/postgres/db_drop.go`, parallel to db_create:
+
+```go
+package postgres
+
+import (
+	"fmt"
+
+	"github.com/prvious/pv/internal/postgres"
+	"github.com/spf13/cobra"
+)
+
+var dbDropCmd = &cobra.Command{
+	Use:     "postgres:db:drop <name>",
+	GroupID: "postgres",
+	Short:   "Drop a database from the highest-installed PostgreSQL major",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dbName := args[0]
+		majors, err := postgres.InstalledMajors()
+		if err != nil {
+			return fmt.Errorf("list installed majors: %w", err)
+		}
+		if len(majors) == 0 {
+			return fmt.Errorf("no PostgreSQL installed")
+		}
+		major := majors[len(majors)-1]
+		if err := postgres.DropDatabase(major, dbName); err != nil {
+			return fmt.Errorf("drop %s: %w", dbName, err)
+		}
+		fmt.Printf("dropped database %q from postgres %s\n", dbName, major)
+		return nil
+	},
+}
+```
+
+- [ ] **Step 2.6: Wire commands into `internal/commands/postgres/register.go`**
+
+Read the existing `register.go`. Find the `cmds := []*cobra.Command{...}` slice. Append `dbCreateCmd` and `dbDropCmd`. The block becomes:
+
+```go
+cmds := []*cobra.Command{
+    installCmd,
+    uninstallCmd,
+    updateCmd,
+    startCmd,
+    stopCmd,
+    restartCmd,
+    listCmd,
+    logsCmd,
+    statusCmd,
+    downloadCmd,
+    dbCreateCmd, // NEW
+    dbDropCmd,   // NEW
+}
+```
+
+The aliasCommand loop (`for _, c := range cmds { parent.AddCommand(c); parent.AddCommand(aliasCommand(c, "postgres:", "pg:")) }`) picks them up automatically — `pv pg:db:create` will work as the alias.
+
+### MySQL
+
+- [ ] **Step 2.7: Repeat steps 2.1–2.6 for mysql**
+
+Same shape, swapping `postgres` → `mysql`, `InstalledMajors` → `InstalledVersions`, and ensuring you read `internal/commands/mysql/register.go` (which per the explorer has no alias namespace — just `parent.AddCommand(c)`, no `aliasCommand` call).
+
+The mysql command files:
+- `internal/commands/mysql/db_create.go`
+- `internal/commands/mysql/db_drop.go`
+- Modify `internal/commands/mysql/register.go` to append both to its `cmds` slice.
+
+For the highest-installed selection, mysql `InstalledVersions()` returns versions like `"8.0", "8.4", "9.7"`. Pick the last entry from a sorted result.
+
+- [ ] **Step 2.8: Verify project-wide**
+
+```
+gofmt -w internal/postgres/ internal/mysql/ internal/commands/postgres/ internal/commands/mysql/
+go vet ./...
+go build ./...
+go test ./...
+```
+Expected: clean. Smoke-test the new commands:
+
+```bash
+go build -o /tmp/pv-pr3-smoke .
+/tmp/pv-pr3-smoke postgres:db:create --help
+/tmp/pv-pr3-smoke postgres:db:drop --help
+/tmp/pv-pr3-smoke mysql:db:create --help
+/tmp/pv-pr3-smoke mysql:db:drop --help
+rm /tmp/pv-pr3-smoke
+```
+All should print fang-styled help with the `<name>` arg shown.
+
+- [ ] **Step 2.9: Commit**
+
+```bash
+git add internal/postgres/database.go internal/postgres/database_test.go \
+        internal/mysql/database.go internal/mysql/database_test.go \
+        internal/commands/postgres/ internal/commands/mysql/
+git commit -m "$(cat <<'EOF'
+feat(db): standalone postgres:db:create/:drop and mysql:db:create/:drop
+
+Exposes the existing postgres.CreateDatabase / mysql.CreateDatabase
+helpers as standalone cobra commands so users can call them from
+pv.yml setup: blocks. Adds DropDatabase siblings (IF EXISTS
+semantics) and four new commands wired through the postgres/mysql
+command registers. Picks the highest-installed major/version for
+the operation. S3 bucket commands are deferred to a follow-up PR
+since rustfs has no bucket-creation code today.
+EOF
+)"
+```
+
+(If `DropDatabase` already existed for either engine, drop the file from the `git add` list for that engine — only commit what actually changed.)
+
+---
+
+## Task 3: `ApplySetupStep` — the runner
+
+**Files:**
+- Create: `internal/automation/steps/apply_setup.go`
+- Create: `internal/automation/steps/apply_setup_test.go`
+
+This step runs every line in `cfg.Setup` via `bash -c` with the pinned PHP bin dir prepended to PATH. Fail-fast on first non-zero exit. Streams stdout/stderr directly (don't buffer — long commands need live output).
+
+PHP path resolution: `phpenv.PHPPath(ctx.PHPVersion)` returns the absolute path to `php` for the pinned version. Its directory is what we prepend to PATH. If `phpenv` exposes a `BinDir(version)` helper, use it; otherwise `filepath.Dir(phpenv.PHPPath(version))`.
+
+- [ ] **Step 3.1: Failing test — happy path runs commands in order, sees pinned PHP**
+
+Create `internal/automation/steps/apply_setup_test.go`:
+
+```go
+package steps
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/config"
+)
+
+func TestApplySetup_RunsCommandsInOrder(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	projDir := t.TempDir()
+	marker := filepath.Join(projDir, "marker")
+
+	ctx := &automation.Context{
+		ProjectName: "p",
+		ProjectPath: projDir,
+		ProjectConfig: &config.ProjectConfig{
+			Setup: []string{
+				"echo first > " + marker,
+				"echo second >> " + marker,
+			},
+		},
+	}
+	step := &ApplySetupStep{}
+	if !step.ShouldRun(ctx) {
+		t.Fatal("ShouldRun: want true")
+	}
+	if _, err := step.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.TrimSpace(string(body))
+	want := "first\nsecond"
+	if got != want {
+		t.Errorf("marker = %q, want %q", got, want)
+	}
+}
+```
+
+- [ ] **Step 3.2: Verify FAIL**
+
+`go test ./internal/automation/steps/ -run TestApplySetup_RunsCommandsInOrder -v` → FAIL with `undefined: ApplySetupStep`.
+
+- [ ] **Step 3.3: Implement `ApplySetupStep`**
+
+Create `internal/automation/steps/apply_setup.go`:
+
+```go
+package steps
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/phpenv"
+)
+
+// ApplySetupStep runs the lines in pv.yml's setup: block via bash -c,
+// in order, fail-fast on first non-zero exit. The pinned PHP bin dir
+// is prepended to PATH so `php artisan ...` resolves to the project's
+// version. Each line gets its own shell — variables don't persist
+// across lines. Stdout/stderr stream directly so long commands like
+// `composer install` produce live output instead of buffering.
+type ApplySetupStep struct{}
+
+var _ automation.Step = (*ApplySetupStep)(nil)
+
+func (s *ApplySetupStep) Label() string  { return "Run pv.yml setup commands" }
+func (s *ApplySetupStep) Gate() string   { return "apply_setup" }
+func (s *ApplySetupStep) Critical() bool { return true }
+
+func (s *ApplySetupStep) ShouldRun(ctx *automation.Context) bool {
+	return ctx.ProjectConfig.HasSetup()
+}
+
+func (s *ApplySetupStep) Run(ctx *automation.Context) (string, error) {
+	env := buildSetupEnv(ctx.PHPVersion)
+	for i, line := range ctx.ProjectConfig.Setup {
+		cmd := exec.Command("bash", "-c", line)
+		cmd.Dir = ctx.ProjectPath
+		cmd.Env = env
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("setup[%d] %q: %w", i, line, err)
+		}
+	}
+	return fmt.Sprintf("ran %d command(s)", len(ctx.ProjectConfig.Setup)), nil
+}
+
+// buildSetupEnv copies os.Environ() and prepends the pinned PHP's bin
+// directory to PATH. If phpVersion is empty (project pinned globally
+// or PHP not installed), the host PATH is returned unchanged.
+func buildSetupEnv(phpVersion string) []string {
+	env := os.Environ()
+	if phpVersion == "" {
+		return env
+	}
+	phpBin := phpenv.PHPPath(phpVersion)
+	if phpBin == "" {
+		return env
+	}
+	binDir := filepath.Dir(phpBin)
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + binDir + ":" + strings.TrimPrefix(e, "PATH=")
+			return env
+		}
+	}
+	// PATH wasn't set; add it.
+	return append(env, "PATH="+binDir)
+}
+```
+
+(If `phpenv.PHPPath` has a different name in the codebase, adjust. Read `internal/phpenv/` to confirm. The helper may also be called `BinPath`, `PHPBin`, or `Path(version)`.)
+
+- [ ] **Step 3.4: Verify happy path passes**
+
+`go test ./internal/automation/steps/ -run TestApplySetup_RunsCommandsInOrder -v` → PASS.
+
+- [ ] **Step 3.5: Failing tests — fail-fast + ShouldRun edge cases**
+
+Append:
+
+```go
+func TestApplySetup_FailFast(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projDir := t.TempDir()
+	marker := filepath.Join(projDir, "marker")
+
+	ctx := &automation.Context{
+		ProjectName: "p",
+		ProjectPath: projDir,
+		ProjectConfig: &config.ProjectConfig{
+			Setup: []string{
+				"echo first > " + marker,
+				"false", // non-zero exit
+				"echo third >> " + marker, // should not run
+			},
+		},
+	}
+	step := &ApplySetupStep{}
+	_, err := step.Run(ctx)
+	if err == nil {
+		t.Fatal("Run: want error after `false`, got nil")
+	}
+	if !strings.Contains(err.Error(), "setup[1]") {
+		t.Errorf("err = %v; want it to mention setup[1]", err)
+	}
+
+	body, _ := os.ReadFile(marker)
+	got := strings.TrimSpace(string(body))
+	if got != "first" {
+		t.Errorf("marker = %q; want only 'first' (third should not have run)", got)
+	}
+}
+
+func TestApplySetup_ShouldRunFalseWithoutSetup(t *testing.T) {
+	ctx := &automation.Context{
+		ProjectConfig: &config.ProjectConfig{PHP: "8.4"},
+	}
+	step := &ApplySetupStep{}
+	if step.ShouldRun(ctx) {
+		t.Errorf("ShouldRun: want false when no setup declared")
+	}
+}
+
+func TestApplySetup_ShouldRunFalseWithoutConfig(t *testing.T) {
+	ctx := &automation.Context{}
+	step := &ApplySetupStep{}
+	if step.ShouldRun(ctx) {
+		t.Errorf("ShouldRun: want false when ProjectConfig is nil")
+	}
+}
+
+func TestApplySetup_RunsInProjectDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projDir := t.TempDir()
+	// Write a marker into the project dir using relative path — proves cwd is correct.
+	ctx := &automation.Context{
+		ProjectName: "p",
+		ProjectPath: projDir,
+		ProjectConfig: &config.ProjectConfig{
+			Setup: []string{"pwd > pwd-marker"},
+		},
+	}
+	step := &ApplySetupStep{}
+	if _, err := step.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(projDir, "pwd-marker"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, _ := filepath.EvalSymlinks(projDir)
+	got := strings.TrimSpace(string(body))
+	if got != projDir && got != resolved {
+		t.Errorf("pwd = %q; want %q or %q", got, projDir, resolved)
+	}
+}
+```
+
+- [ ] **Step 3.6: Verify**
+
+`go test ./internal/automation/steps/ -run TestApplySetup -v` → all 4 PASS.
+
+- [ ] **Step 3.7: Wire `ApplySetupStep` into the pipeline**
+
+In `cmd/link.go`, find the step list. Append `&steps.ApplySetupStep{}` at the END (after `RunMigrationsStep`). Order:
+
+```go
+allSteps := []automation.Step{
+    &steps.InstallPHPStep{},
+    &steps.CopyEnvStep{},
+    &steps.ComposerInstallStep{},
+    &steps.GenerateKeyStep{},
+    &steps.InstallOctaneStep{},
+    &steps.ApplyPvYmlServicesStep{},
+    &steps.DetectServicesStep{},
+    &laravel.DetectServicesStep{},
+    &steps.ApplyPvYmlEnvStep{},
+    &laravel.SetAppURLStep{},
+    &laravel.SetViteTLSStep{},
+    &steps.GenerateTLSCertStep{},
+    &steps.CreateDatabaseStep{},
+    &steps.RunMigrationsStep{},
+    &steps.ApplySetupStep{}, // NEW — last, after pv has finished its own bookkeeping
+}
+```
+
+Preserve all other entries verbatim.
+
+- [ ] **Step 3.8: Verify project-wide**
+
+```
+gofmt -w internal/automation/steps/ cmd/
+go vet ./...
+go build ./...
+go test ./...
+```
+Expected: clean.
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+git add internal/automation/steps/apply_setup.go \
+        internal/automation/steps/apply_setup_test.go \
+        cmd/link.go
+git commit -m "$(cat <<'EOF'
+feat(automation): ApplySetupStep — run pv.yml setup: commands
+
+Each line is exec'd via bash -c with the pinned PHP bin dir
+prepended to PATH so `php artisan ...` finds the right version.
+Stdout/stderr stream directly to the user (no buffering — long
+commands like composer install should produce live output).
+Fail-fast on first non-zero exit, with error including the
+failing line's index. Step runs LAST in the pipeline so pv's
+own state (registry, env, certs, Caddy) is in place when the
+user's commands execute. Legacy step gating lands in the next
+commit.
+EOF
+)"
+```
+
+---
+
+## Task 4: Gate the 6 legacy steps on `HasSetup()`
+
+**Files:**
+- Modify: `internal/laravel/steps.go` (6 `ShouldRun` methods)
+- Modify: `internal/laravel/steps_test.go` (one new skip test per step = 6 tests)
+
+Each affected step's `ShouldRun` currently returns `isLaravel(ctx.ProjectType) && <step-specific conditions>`. The new gate prepends `if ctx.ProjectConfig.HasSetup() { return false }` so the user's `setup:` block fully replaces the legacy pipeline.
+
+The 6 steps and the lines to modify (from the explorer's earlier mapping):
+
+| Step | Lines |
+|---|---|
+| `CopyEnvStep` | `internal/laravel/steps.go:21–58` (look for `ShouldRun`) |
+| `GenerateKeyStep` | 60–86 |
+| `InstallOctaneStep` | 150–187 |
+| `ComposerInstallStep` | 189–216 |
+| `CreateDatabaseStep` | 282–345 |
+| `RunMigrationsStep` | 347–371 |
+
+For each, find the `ShouldRun` method and prepend the same short-circuit:
+
+```go
+func (s *<Step>Step) ShouldRun(ctx *automation.Context) bool {
+	if ctx.ProjectConfig.HasSetup() {
+		return false
+	}
+	// ... existing conditions preserved verbatim ...
+}
+```
+
+- [ ] **Step 4.1: Failing test for CopyEnvStep skip**
+
+In `internal/laravel/steps_test.go`, append:
+
+```go
+func TestCopyEnvStep_SkipsWhenSetupDeclared(t *testing.T) {
+	ctx := &automation.Context{
+		ProjectType: "laravel",
+		ProjectConfig: &config.ProjectConfig{Setup: []string{"cp .env.example .env"}},
+	}
+	step := &CopyEnvStep{}
+	if step.ShouldRun(ctx) {
+		t.Errorf("ShouldRun: want false when setup declared")
+	}
+}
+```
+
+- [ ] **Step 4.2: Verify FAIL**
+
+`go test ./internal/laravel/ -run TestCopyEnvStep_SkipsWhenSetupDeclared -v` → FAIL.
+
+- [ ] **Step 4.3: Add the short-circuit to `CopyEnvStep.ShouldRun`**
+
+Open `internal/laravel/steps.go`. Find `CopyEnvStep`'s `ShouldRun`. Prepend the short-circuit. The new body:
+
+```go
+func (s *CopyEnvStep) ShouldRun(ctx *automation.Context) bool {
+	if ctx.ProjectConfig.HasSetup() {
+		return false
+	}
+	// ... existing condition preserved verbatim
+}
+```
+
+- [ ] **Step 4.4: Verify CopyEnvStep tests pass**
+
+`go test ./internal/laravel/ -run TestCopyEnvStep -v` → all PASS.
+
+- [ ] **Step 4.5–4.8: Repeat 4.1–4.4 for the other 5 steps**
+
+For each of `GenerateKeyStep`, `InstallOctaneStep`, `ComposerInstallStep`, `CreateDatabaseStep`, `RunMigrationsStep`:
+
+1. Append a `Test<Step>_SkipsWhenSetupDeclared` test that builds a Context with `ProjectType: "laravel"` and `Setup: []string{...}`, asserts `ShouldRun` returns false.
+2. Run, verify FAIL.
+3. Prepend the same short-circuit to that step's `ShouldRun`.
+4. Run, verify PASS.
+
+Pattern for each test:
+
+```go
+func TestGenerateKeyStep_SkipsWhenSetupDeclared(t *testing.T) {
+	ctx := &automation.Context{
+		ProjectType: "laravel",
+		ProjectConfig: &config.ProjectConfig{Setup: []string{"php artisan key:generate"}},
+	}
+	step := &GenerateKeyStep{}
+	if step.ShouldRun(ctx) {
+		t.Errorf("ShouldRun: want false when setup declared")
+	}
+}
+```
+
+(And so on for each step.)
+
+- [ ] **Step 4.9: Verify all 6 skip-tests pass + every existing test still passes**
+
+```
+go test ./internal/laravel/ -v
+```
+Expected: 6 new skip-tests pass; every pre-existing test passes.
+
+- [ ] **Step 4.10: Project-wide check**
+
+```
+gofmt -w internal/laravel/
+go vet ./...
+go build ./...
+go test ./...
+```
+Expected: clean.
+
+- [ ] **Step 4.11: Commit**
+
+```bash
+git add internal/laravel/steps.go internal/laravel/steps_test.go
+git commit -m "$(cat <<'EOF'
+feat(automation): gate 6 legacy steps on HasSetup()
+
+When pv.yml declares setup:, CopyEnvStep, GenerateKeyStep,
+InstallOctaneStep, ComposerInstallStep, CreateDatabaseStep, and
+RunMigrationsStep all short-circuit their ShouldRun and let the
+user-declared setup pipeline run unopposed. Without setup:, each
+step keeps its existing condition unchanged — backward compatible
+for projects without pv.yml or with pv.yml that doesn't declare
+setup.
+EOF
+)"
+```
+
+---
+
+## Task 5: Final verification sweep
+
+**Files:** none modified.
+
+- [ ] **Step 5.1: gofmt + vet + build + test**
+
+```
+gofmt -l .
+go vet ./...
+go test ./...
+go build ./...
+```
+Expected: every gate clean.
+
+- [ ] **Step 5.2: Smoke test the binary**
+
+```bash
+go build -o /tmp/pv-pr3-smoke .
+/tmp/pv-pr3-smoke --version
+/tmp/pv-pr3-smoke postgres:db:create --help
+/tmp/pv-pr3-smoke postgres:db:drop --help
+/tmp/pv-pr3-smoke mysql:db:create --help
+/tmp/pv-pr3-smoke mysql:db:drop --help
+/tmp/pv-pr3-smoke link --help
+rm /tmp/pv-pr3-smoke
+```
+Expected: version + 5 help screens render without error.
+
+- [ ] **Step 5.3: Confirm commit count and clean working tree**
+
+```
+git status
+git log --oneline main..HEAD
+```
+Expected: working tree clean; 5 commits on the branch (one per Task 1–4 + the plan doc that's already there).
+
+Wait — the plan commit isn't included since we're branching off `feat/pvyml-setup-runner` which already has the plan commit. Actual count: plan commit + 4 implementation commits = 5 commits total on the branch.
+
+---
+
+## Self-Review (already applied)
+
+**Spec coverage:**
+- ✅ `setup:` runs commands in order, fail-fast, project root cwd, pinned PHP on PATH — Task 3.
+- ✅ Hardcoded pipeline steps skip when setup: present — Task 4.
+- ✅ Legacy compat path runs when no setup: — Task 4 (each step preserves existing conditions after the short-circuit).
+- ✅ `postgres:db:create / :drop` standalone — Task 2.
+- ✅ `mysql:db:create / :drop` standalone — Task 2.
+- ⚠️ `s3:bucket:create / :drop` — **deferred to follow-up PR** (no existing implementation; AWS SDK / sigv4 / mc-shellout is a separate scope decision).
+
+**Placeholders:** None. Every step has concrete code or a precise "look at existing pattern in <file>" pointer.
+
+**Type consistency:**
+- `HasSetup()` method signature consistent with `HasServices()` / `HasAnyEnv()`.
+- `ApplySetupStep` has a unique type name — no collision.
+- `buildSetupEnv(phpVersion string) []string` is the only new helper signature in this PR.
+
+**Deliberate notes for future readers:**
+- **`pv s3:bucket:create / :drop` is the one spec divergence in PR 3.** It belongs in pv.yml's roadmap but its implementation has its own design questions (SDK choice, sigv4 inline, or `mc` shellout). Treating it as a small standalone PR after PR 3 keeps PR 3 reviewable.
+- **PHP bin dir prepended to PATH, not replacing PATH.** Setup commands often need `composer`, `bun`, `pv`, etc. — those stay reachable via the user's host PATH. Only `php` is pinned.
+- **`bash -c` per line means variables don't persist.** `setup: ["export FOO=1", "echo $FOO"]` would print empty. If users want shared state, they join lines with `&&` or `;` inside one entry. Documented in the step's godoc.
+- **`ApplySetupStep` runs LAST.** This is the right place: by the time it runs, pv has bound services, written templated env, minted certs, generated Caddy config. The user's `composer install` + `php artisan migrate` can rely on all of that being in place.
+- **The 6-step gate is independent of PR 2's gates.** A project can declare `services:` (PR 2 services gate fires), `env:` (PR 2 env gate fires), AND `setup:` (PR 3 gates fire) — all three behaviors compose without conflict.
+
+## Open questions
+
+1. **`phpenv.PHPPath(version)` signature.** The plan assumes it returns `string`. If it's a method on a type, or returns `(string, error)`, adjust `buildSetupEnv` accordingly. Settled during Task 3 implementation by reading `internal/phpenv/`.
+2. **MySQL `InstalledVersions` ordering.** The `pv mysql:db:create` command picks the "highest installed" — assumes the slice is sorted ascending. If it's not sorted, sort before picking. Settled during Task 2.
+3. **`DropDatabase` already exists for either engine?** If yes, skip the add. Settled by reading the existing `database.go` for each engine at Task 2's start.

--- a/internal/automation/pipeline.go
+++ b/internal/automation/pipeline.go
@@ -158,7 +158,7 @@ func LookupGate(a *config.Automation, gate string) config.AutoMode {
 	case "apply_setup":
 		return a.ApplySetup
 	default:
-		fmt.Fprintf(os.Stderr, "Warning: unknown automation gate %q, defaulting to ask\n", gate)
+		ui.Subtle(fmt.Sprintf("Warning: unknown automation gate %q, defaulting to ask", gate))
 		return config.AutoAsk
 	}
 }

--- a/internal/automation/pipeline.go
+++ b/internal/automation/pipeline.go
@@ -32,6 +32,10 @@ type Step interface {
 	Label() string
 	Gate() string
 	Critical() bool
+	// Verbose reports whether the step streams its own output to
+	// stdout/stderr and therefore must run without a spinner. When true,
+	// RunPipeline uses ui.StepVerbose instead of ui.Step.
+	Verbose() bool
 	ShouldRun(ctx *Context) bool
 	Run(ctx *Context) (string, error)
 }
@@ -96,7 +100,11 @@ func RunPipeline(steps []Step, ctx *Context) error {
 			}
 		}
 
-		err := ui.Step(step.Label(), func() (string, error) {
+		runner := ui.Step
+		if step.Verbose() {
+			runner = ui.StepVerbose
+		}
+		err := runner(step.Label(), func() (string, error) {
 			return step.Run(ctx)
 		})
 		if err != nil && step.Critical() {
@@ -143,6 +151,12 @@ func LookupGate(a *config.Automation, gate string) config.AutoMode {
 		return a.GenerateTLSCert
 	case "detect_services":
 		return a.DetectServices
+	case "apply_pvyml_services":
+		return a.ApplyPvYmlServices
+	case "apply_pvyml_env":
+		return a.ApplyPvYmlEnv
+	case "apply_setup":
+		return a.ApplySetup
 	default:
 		fmt.Fprintf(os.Stderr, "Warning: unknown automation gate %q, defaulting to ask\n", gate)
 		return config.AutoAsk

--- a/internal/automation/pipeline_test.go
+++ b/internal/automation/pipeline_test.go
@@ -13,6 +13,7 @@ type stubStep struct {
 	label     string
 	gate      string
 	critical  bool
+	verbose   bool
 	shouldRun bool
 	result    string
 	err       error
@@ -22,6 +23,7 @@ type stubStep struct {
 func (s *stubStep) Label() string             { return s.label }
 func (s *stubStep) Gate() string              { return s.gate }
 func (s *stubStep) Critical() bool            { return s.critical }
+func (s *stubStep) Verbose() bool             { return s.verbose }
 func (s *stubStep) ShouldRun(_ *Context) bool { return s.shouldRun }
 func (s *stubStep) Run(_ *Context) (string, error) {
 	s.ran = true
@@ -240,6 +242,9 @@ func TestLookupGate(t *testing.T) {
 		{"generate_caddyfile", a.GenerateCaddyfile},
 		{"generate_tls_cert", a.GenerateTLSCert},
 		{"detect_services", a.DetectServices},
+		{"apply_pvyml_services", a.ApplyPvYmlServices},
+		{"apply_pvyml_env", a.ApplyPvYmlEnv},
+		{"apply_setup", a.ApplySetup},
 		{"unknown_gate", config.AutoAsk},
 	}
 

--- a/internal/automation/steps/apply_pvyml_env.go
+++ b/internal/automation/steps/apply_pvyml_env.go
@@ -28,6 +28,7 @@ var _ automation.Step = (*ApplyPvYmlEnvStep)(nil)
 func (s *ApplyPvYmlEnvStep) Label() string  { return "Apply pv.yml env templates" }
 func (s *ApplyPvYmlEnvStep) Gate() string   { return "apply_pvyml_env" }
 func (s *ApplyPvYmlEnvStep) Critical() bool { return true }
+func (s *ApplyPvYmlEnvStep) Verbose() bool  { return false }
 
 func (s *ApplyPvYmlEnvStep) ShouldRun(ctx *automation.Context) bool {
 	return ctx.ProjectConfig.HasAnyEnv()

--- a/internal/automation/steps/apply_pvyml_env.go
+++ b/internal/automation/steps/apply_pvyml_env.go
@@ -50,7 +50,7 @@ func (s *ApplyPvYmlEnvStep) Run(ctx *automation.Context) (string, error) {
 	if cfg.Postgresql != nil && len(cfg.Postgresql.Env) > 0 {
 		full, err := postgres.ProbeVersion(cfg.Postgresql.Version)
 		if err != nil {
-			return "", fmt.Errorf("probe postgres version: %w", err)
+			return "", fmt.Errorf("probe postgres %q: %w", cfg.Postgresql.Version, err)
 		}
 		vars, err := postgres.TemplateVars(cfg.Postgresql.Version, full)
 		if err != nil {
@@ -65,7 +65,7 @@ func (s *ApplyPvYmlEnvStep) Run(ctx *automation.Context) (string, error) {
 	if cfg.Mysql != nil && len(cfg.Mysql.Env) > 0 {
 		full, err := mysql.ProbeVersion(cfg.Mysql.Version)
 		if err != nil {
-			return "", fmt.Errorf("probe mysql version: %w", err)
+			return "", fmt.Errorf("probe mysql %q: %w", cfg.Mysql.Version, err)
 		}
 		vars, err := mysql.TemplateVars(cfg.Mysql.Version, full)
 		if err != nil {

--- a/internal/automation/steps/apply_pvyml_services.go
+++ b/internal/automation/steps/apply_pvyml_services.go
@@ -25,6 +25,7 @@ var _ automation.Step = (*ApplyPvYmlServicesStep)(nil)
 func (s *ApplyPvYmlServicesStep) Label() string  { return "Bind services from pv.yml" }
 func (s *ApplyPvYmlServicesStep) Gate() string   { return "apply_pvyml_services" }
 func (s *ApplyPvYmlServicesStep) Critical() bool { return true }
+func (s *ApplyPvYmlServicesStep) Verbose() bool  { return false }
 
 func (s *ApplyPvYmlServicesStep) ShouldRun(ctx *automation.Context) bool {
 	return ctx.ProjectConfig.HasServices()

--- a/internal/automation/steps/apply_setup.go
+++ b/internal/automation/steps/apply_setup.go
@@ -26,6 +26,7 @@ var _ automation.Step = (*ApplySetupStep)(nil)
 func (s *ApplySetupStep) Label() string  { return "Run pv.yml setup commands" }
 func (s *ApplySetupStep) Gate() string   { return "apply_setup" }
 func (s *ApplySetupStep) Critical() bool { return true }
+func (s *ApplySetupStep) Verbose() bool  { return true }
 
 func (s *ApplySetupStep) ShouldRun(ctx *automation.Context) bool {
 	return ctx.ProjectConfig.HasSetup()
@@ -47,21 +48,17 @@ func (s *ApplySetupStep) Run(ctx *automation.Context) (string, error) {
 }
 
 // buildSetupEnv copies os.Environ() and prepends the pinned PHP's bin
-// directory to PATH. If phpVersion is empty or the PHP path can't be
-// resolved, the host PATH is returned unchanged.
+// directory to PATH. If phpVersion is empty, the host PATH is returned
+// unchanged.
 func buildSetupEnv(phpVersion string) []string {
 	env := os.Environ()
 	if phpVersion == "" {
 		return env
 	}
-	phpBin := phpenv.PHPPath(phpVersion)
-	if phpBin == "" {
-		return env
-	}
-	binDir := filepath.Dir(phpBin)
+	binDir := filepath.Dir(phpenv.PHPPath(phpVersion))
 	for i, e := range env {
-		if strings.HasPrefix(e, "PATH=") {
-			env[i] = "PATH=" + binDir + ":" + strings.TrimPrefix(e, "PATH=")
+		if rest, ok := strings.CutPrefix(e, "PATH="); ok {
+			env[i] = "PATH=" + binDir + ":" + rest
 			return env
 		}
 	}

--- a/internal/automation/steps/apply_setup.go
+++ b/internal/automation/steps/apply_setup.go
@@ -1,0 +1,69 @@
+package steps
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/phpenv"
+)
+
+// ApplySetupStep runs the lines in pv.yml's setup: block via bash -c,
+// in order, fail-fast on first non-zero exit. The pinned PHP bin dir
+// is prepended to PATH so `php artisan ...` resolves to the project's
+// version. Each line gets its own shell — variables don't persist
+// across lines; users who need shared state join lines with `&&`
+// inside a single entry. Stdout/stderr stream directly so long
+// commands like `composer install` produce live output instead of
+// buffering.
+type ApplySetupStep struct{}
+
+var _ automation.Step = (*ApplySetupStep)(nil)
+
+func (s *ApplySetupStep) Label() string  { return "Run pv.yml setup commands" }
+func (s *ApplySetupStep) Gate() string   { return "apply_setup" }
+func (s *ApplySetupStep) Critical() bool { return true }
+
+func (s *ApplySetupStep) ShouldRun(ctx *automation.Context) bool {
+	return ctx.ProjectConfig.HasSetup()
+}
+
+func (s *ApplySetupStep) Run(ctx *automation.Context) (string, error) {
+	env := buildSetupEnv(ctx.PHPVersion)
+	for i, line := range ctx.ProjectConfig.Setup {
+		cmd := exec.Command("bash", "-c", line)
+		cmd.Dir = ctx.ProjectPath
+		cmd.Env = env
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("setup[%d] %q: %w", i, line, err)
+		}
+	}
+	return fmt.Sprintf("ran %d command(s)", len(ctx.ProjectConfig.Setup)), nil
+}
+
+// buildSetupEnv copies os.Environ() and prepends the pinned PHP's bin
+// directory to PATH. If phpVersion is empty or the PHP path can't be
+// resolved, the host PATH is returned unchanged.
+func buildSetupEnv(phpVersion string) []string {
+	env := os.Environ()
+	if phpVersion == "" {
+		return env
+	}
+	phpBin := phpenv.PHPPath(phpVersion)
+	if phpBin == "" {
+		return env
+	}
+	binDir := filepath.Dir(phpBin)
+	for i, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			env[i] = "PATH=" + binDir + ":" + strings.TrimPrefix(e, "PATH=")
+			return env
+		}
+	}
+	return append(env, "PATH="+binDir)
+}

--- a/internal/automation/steps/apply_setup.go
+++ b/internal/automation/steps/apply_setup.go
@@ -1,7 +1,9 @@
 package steps
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,13 +14,12 @@ import (
 )
 
 // ApplySetupStep runs the lines in pv.yml's setup: block via bash -c,
-// in order, fail-fast on first non-zero exit. The pinned PHP bin dir
-// is prepended to PATH so `php artisan ...` resolves to the project's
-// version. Each line gets its own shell — variables don't persist
-// across lines; users who need shared state join lines with `&&`
-// inside a single entry. Stdout/stderr stream directly so long
-// commands like `composer install` produce live output instead of
-// buffering.
+// in order, fail-fast on first non-zero exit. The pinned PHP binary's
+// directory is prepended to PATH (when ctx.PHPVersion is set) so
+// `php artisan ...` resolves to the project's version. Each line gets
+// its own shell — variables don't persist across lines. Stdout/stderr
+// stream directly so long commands like `composer install` produce
+// live output instead of buffering.
 type ApplySetupStep struct{}
 
 var _ automation.Step = (*ApplySetupStep)(nil)
@@ -38,13 +39,36 @@ func (s *ApplySetupStep) Run(ctx *automation.Context) (string, error) {
 		cmd := exec.Command("bash", "-c", line)
 		cmd.Dir = ctx.ProjectPath
 		cmd.Env = env
+
+		// Tee stderr to both the real stderr (for live output) and a
+		// buffer (so we can include the tail in the error message).
+		var stderrBuf bytes.Buffer
 		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+		cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+
 		if err := cmd.Run(); err != nil {
-			return "", fmt.Errorf("setup[%d] %q: %w", i, line, err)
+			exitCode := -1
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				exitCode = exitErr.ExitCode()
+			}
+			stderrTail := tailLines(stderrBuf.String(), 10)
+			return "", fmt.Errorf("setup[%d] %q exited %d: %w\n%s", i, line, exitCode, err, stderrTail)
 		}
 	}
 	return fmt.Sprintf("ran %d command(s)", len(ctx.ProjectConfig.Setup)), nil
+}
+
+// tailLines returns the last n newline-separated lines of s, or the
+// whole string if it has fewer than n lines.
+func tailLines(s string, n int) string {
+	if s == "" {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
 }
 
 // buildSetupEnv copies os.Environ() and prepends the pinned PHP's bin

--- a/internal/automation/steps/apply_setup_test.go
+++ b/internal/automation/steps/apply_setup_test.go
@@ -1,0 +1,121 @@
+package steps
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/config"
+)
+
+func TestApplySetup_RunsCommandsInOrder(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	projDir := t.TempDir()
+	marker := filepath.Join(projDir, "marker")
+
+	ctx := &automation.Context{
+		ProjectName: "p",
+		ProjectPath: projDir,
+		ProjectConfig: &config.ProjectConfig{
+			Setup: []string{
+				"echo first > " + marker,
+				"echo second >> " + marker,
+			},
+		},
+	}
+	step := &ApplySetupStep{}
+	if !step.ShouldRun(ctx) {
+		t.Fatal("ShouldRun: want true")
+	}
+	if _, err := step.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.TrimSpace(string(body))
+	want := "first\nsecond"
+	if got != want {
+		t.Errorf("marker = %q, want %q", got, want)
+	}
+}
+
+func TestApplySetup_FailFast(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projDir := t.TempDir()
+	marker := filepath.Join(projDir, "marker")
+
+	ctx := &automation.Context{
+		ProjectName: "p",
+		ProjectPath: projDir,
+		ProjectConfig: &config.ProjectConfig{
+			Setup: []string{
+				"echo first > " + marker,
+				"false",
+				"echo third >> " + marker,
+			},
+		},
+	}
+	step := &ApplySetupStep{}
+	_, err := step.Run(ctx)
+	if err == nil {
+		t.Fatal("Run: want error after `false`, got nil")
+	}
+	if !strings.Contains(err.Error(), "setup[1]") {
+		t.Errorf("err = %v; want it to mention setup[1]", err)
+	}
+
+	body, _ := os.ReadFile(marker)
+	got := strings.TrimSpace(string(body))
+	if got != "first" {
+		t.Errorf("marker = %q; want only 'first' (third should not have run)", got)
+	}
+}
+
+func TestApplySetup_ShouldRunFalseWithoutSetup(t *testing.T) {
+	ctx := &automation.Context{
+		ProjectConfig: &config.ProjectConfig{PHP: "8.4"},
+	}
+	step := &ApplySetupStep{}
+	if step.ShouldRun(ctx) {
+		t.Errorf("ShouldRun: want false when no setup declared")
+	}
+}
+
+func TestApplySetup_ShouldRunFalseWithoutConfig(t *testing.T) {
+	ctx := &automation.Context{}
+	step := &ApplySetupStep{}
+	if step.ShouldRun(ctx) {
+		t.Errorf("ShouldRun: want false when ProjectConfig is nil")
+	}
+}
+
+func TestApplySetup_RunsInProjectDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projDir := t.TempDir()
+	ctx := &automation.Context{
+		ProjectName: "p",
+		ProjectPath: projDir,
+		ProjectConfig: &config.ProjectConfig{
+			Setup: []string{"pwd > pwd-marker"},
+		},
+	}
+	step := &ApplySetupStep{}
+	if _, err := step.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(projDir, "pwd-marker"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, _ := filepath.EvalSymlinks(projDir)
+	got := strings.TrimSpace(string(body))
+	if got != projDir && got != resolved {
+		t.Errorf("pwd = %q; want %q or %q", got, projDir, resolved)
+	}
+}

--- a/internal/automation/steps/apply_setup_test.go
+++ b/internal/automation/steps/apply_setup_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prvious/pv/internal/automation"
 	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/phpenv"
 )
 
 func TestApplySetup_RunsCommandsInOrder(t *testing.T) {
@@ -117,5 +118,85 @@ func TestApplySetup_RunsInProjectDir(t *testing.T) {
 	got := strings.TrimSpace(string(body))
 	if got != projDir && got != resolved {
 		t.Errorf("pwd = %q; want %q or %q", got, projDir, resolved)
+	}
+}
+
+func TestBuildSetupEnv_EmptyVersionReturnsHostEnv(t *testing.T) {
+	env := buildSetupEnv("")
+	// Same length as os.Environ(); contents preserved.
+	if len(env) != len(os.Environ()) {
+		t.Errorf("len = %d, want %d", len(env), len(os.Environ()))
+	}
+}
+
+func TestBuildSetupEnv_PrependsPHPBinDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// PHPPath builds the path mechanically
+	// (filepath.Join(config.PhpVersionDir(version), "php")), so we
+	// don't need to actually stage the binary — the path is the
+	// contract being tested.
+	t.Setenv("PATH", "/usr/local/bin:/usr/bin")
+
+	env := buildSetupEnv("8.4")
+
+	var pathLine string
+	for _, e := range env {
+		if rest, ok := strings.CutPrefix(e, "PATH="); ok {
+			pathLine = rest
+			break
+		}
+	}
+	if pathLine == "" {
+		t.Fatal("env has no PATH entry")
+	}
+	want := filepath.Dir(phpenv.PHPPath("8.4"))
+	if !strings.HasPrefix(pathLine, want+":") {
+		t.Errorf("PATH = %q, want it to start with %q:", pathLine, want)
+	}
+	if !strings.Contains(pathLine, "/usr/local/bin:/usr/bin") {
+		t.Errorf("PATH = %q, expected original PATH preserved", pathLine)
+	}
+}
+
+func TestBuildSetupEnv_AppendsPATHWhenAbsent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+	env := buildSetupEnv("8.4")
+	var pathLine string
+	for _, e := range env {
+		if rest, ok := strings.CutPrefix(e, "PATH="); ok {
+			pathLine = rest
+		}
+	}
+	want := filepath.Dir(phpenv.PHPPath("8.4"))
+	// When original PATH is empty, the result PATH is either "<binDir>:"
+	// (if PATH= was in os.Environ()) or just "<binDir>" (if it was
+	// absent and we hit the append branch).
+	if pathLine != want+":" && pathLine != want {
+		t.Errorf("PATH = %q, want %q or %q", pathLine, want+":", want)
+	}
+}
+
+func TestApplySetup_ErrorIncludesExitCodeAndStderr(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projDir := t.TempDir()
+
+	ctx := &automation.Context{
+		ProjectName: "p",
+		ProjectPath: projDir,
+		ProjectConfig: &config.ProjectConfig{
+			Setup: []string{`bash -c "echo failure-message >&2; exit 42"`},
+		},
+	}
+	step := &ApplySetupStep{}
+	_, err := step.Run(ctx)
+	if err == nil {
+		t.Fatal("Run: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exited 42") {
+		t.Errorf("err = %v; want it to include exit code 42", err)
+	}
+	if !strings.Contains(err.Error(), "failure-message") {
+		t.Errorf("err = %v; want it to include stderr tail", err)
 	}
 }

--- a/internal/automation/steps/detect_services.go
+++ b/internal/automation/steps/detect_services.go
@@ -25,6 +25,7 @@ var _ automation.Step = (*DetectServicesStep)(nil)
 func (s *DetectServicesStep) Label() string  { return "Detect and bind services" }
 func (s *DetectServicesStep) Gate() string   { return "detect_services" }
 func (s *DetectServicesStep) Critical() bool { return false }
+func (s *DetectServicesStep) Verbose() bool  { return false }
 
 func (s *DetectServicesStep) ShouldRun(ctx *automation.Context) bool {
 	if ctx.ProjectConfig.HasServices() {

--- a/internal/automation/steps/generate_caddyfile.go
+++ b/internal/automation/steps/generate_caddyfile.go
@@ -13,6 +13,7 @@ var _ automation.Step = (*GenerateCaddyfileStep)(nil)
 func (s *GenerateCaddyfileStep) Label() string  { return "Generate Caddyfile" }
 func (s *GenerateCaddyfileStep) Gate() string   { return "generate_caddyfile" }
 func (s *GenerateCaddyfileStep) Critical() bool { return true }
+func (s *GenerateCaddyfileStep) Verbose() bool  { return false }
 
 func (s *GenerateCaddyfileStep) ShouldRun(_ *automation.Context) bool {
 	return true

--- a/internal/automation/steps/generate_site_config.go
+++ b/internal/automation/steps/generate_site_config.go
@@ -14,6 +14,7 @@ var _ automation.Step = (*GenerateSiteConfigStep)(nil)
 func (s *GenerateSiteConfigStep) Label() string  { return "Generate site config" }
 func (s *GenerateSiteConfigStep) Gate() string   { return "generate_site_config" }
 func (s *GenerateSiteConfigStep) Critical() bool { return true }
+func (s *GenerateSiteConfigStep) Verbose() bool  { return false }
 
 func (s *GenerateSiteConfigStep) ShouldRun(_ *automation.Context) bool {
 	return true

--- a/internal/automation/steps/generate_tls_cert.go
+++ b/internal/automation/steps/generate_tls_cert.go
@@ -16,6 +16,7 @@ var _ automation.Step = (*GenerateTLSCertStep)(nil)
 func (s *GenerateTLSCertStep) Label() string  { return "Generate TLS certificate" }
 func (s *GenerateTLSCertStep) Gate() string   { return "generate_tls_cert" }
 func (s *GenerateTLSCertStep) Critical() bool { return false }
+func (s *GenerateTLSCertStep) Verbose() bool  { return false }
 
 func (s *GenerateTLSCertStep) ShouldRun(_ *automation.Context) bool {
 	return true

--- a/internal/automation/steps/install_php.go
+++ b/internal/automation/steps/install_php.go
@@ -14,6 +14,7 @@ var _ automation.Step = (*InstallPHPStep)(nil)
 func (s *InstallPHPStep) Label() string  { return "Install PHP version" }
 func (s *InstallPHPStep) Gate() string   { return "install_php_version" }
 func (s *InstallPHPStep) Critical() bool { return true }
+func (s *InstallPHPStep) Verbose() bool  { return false }
 
 func (s *InstallPHPStep) ShouldRun(ctx *automation.Context) bool {
 	return ctx.PHPVersion != "" &&

--- a/internal/commands/mysql/db_create.go
+++ b/internal/commands/mysql/db_create.go
@@ -1,0 +1,31 @@
+package mysql
+
+import (
+	"fmt"
+
+	my "github.com/prvious/pv/internal/mysql"
+	"github.com/spf13/cobra"
+)
+
+var dbCreateCmd = &cobra.Command{
+	Use:     "mysql:db:create <name>",
+	GroupID: "mysql",
+	Short:   "Create a database in the highest-installed MySQL version",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dbName := args[0]
+		versions, err := my.InstalledVersions()
+		if err != nil {
+			return fmt.Errorf("list installed versions: %w", err)
+		}
+		if len(versions) == 0 {
+			return fmt.Errorf("no MySQL installed — run `pv mysql:install <version>`")
+		}
+		version := versions[len(versions)-1] // highest installed (InstalledVersions returns sorted asc)
+		if err := my.CreateDatabase(version, dbName); err != nil {
+			return fmt.Errorf("create %s: %w", dbName, err)
+		}
+		fmt.Printf("created database %q in mysql %s\n", dbName, version)
+		return nil
+	},
+}

--- a/internal/commands/mysql/db_create.go
+++ b/internal/commands/mysql/db_create.go
@@ -22,10 +22,12 @@ var dbCreateCmd = &cobra.Command{
 		if len(versions) == 0 {
 			return fmt.Errorf("no MySQL installed — run `pv mysql:install <version>`")
 		}
-		// Highest installed. InstalledMajors / InstalledVersions sort
-		// lexicographically — fine for current values, revisit if
-		// versions ever reach 3 digits (e.g., postgres 100, mysql 10.0).
+		// InstalledVersions sorts lexicographically — fine for current
+		// values, revisit if versions ever reach 3 digits (e.g., 10.0).
 		version := versions[len(versions)-1]
+		if len(versions) > 1 {
+			ui.Subtle(fmt.Sprintf("Using mysql %s (highest of %d installed)", version, len(versions)))
+		}
 		if err := my.CreateDatabase(version, dbName); err != nil {
 			return fmt.Errorf("create %s: %w", dbName, err)
 		}

--- a/internal/commands/mysql/db_create.go
+++ b/internal/commands/mysql/db_create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	my "github.com/prvious/pv/internal/mysql"
+	"github.com/prvious/pv/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -21,11 +22,14 @@ var dbCreateCmd = &cobra.Command{
 		if len(versions) == 0 {
 			return fmt.Errorf("no MySQL installed — run `pv mysql:install <version>`")
 		}
-		version := versions[len(versions)-1] // highest installed (InstalledVersions returns sorted asc)
+		// Highest installed. InstalledMajors / InstalledVersions sort
+		// lexicographically — fine for current values, revisit if
+		// versions ever reach 3 digits (e.g., postgres 100, mysql 10.0).
+		version := versions[len(versions)-1]
 		if err := my.CreateDatabase(version, dbName); err != nil {
 			return fmt.Errorf("create %s: %w", dbName, err)
 		}
-		fmt.Printf("created database %q in mysql %s\n", dbName, version)
+		ui.Success(fmt.Sprintf("Database %q created in mysql %s.", dbName, version))
 		return nil
 	},
 }

--- a/internal/commands/mysql/db_drop.go
+++ b/internal/commands/mysql/db_drop.go
@@ -22,10 +22,12 @@ var dbDropCmd = &cobra.Command{
 		if len(versions) == 0 {
 			return fmt.Errorf("no MySQL installed — nothing to drop")
 		}
-		// Highest installed. InstalledMajors / InstalledVersions sort
-		// lexicographically — fine for current values, revisit if
-		// versions ever reach 3 digits (e.g., postgres 100, mysql 10.0).
+		// InstalledVersions sorts lexicographically — fine for current
+		// values, revisit if versions ever reach 3 digits (e.g., 10.0).
 		version := versions[len(versions)-1]
+		if len(versions) > 1 {
+			ui.Subtle(fmt.Sprintf("Using mysql %s (highest of %d installed)", version, len(versions)))
+		}
 		if err := my.DropDatabase(version, dbName); err != nil {
 			return fmt.Errorf("drop %s: %w", dbName, err)
 		}

--- a/internal/commands/mysql/db_drop.go
+++ b/internal/commands/mysql/db_drop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	my "github.com/prvious/pv/internal/mysql"
+	"github.com/prvious/pv/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -19,13 +20,16 @@ var dbDropCmd = &cobra.Command{
 			return fmt.Errorf("list installed versions: %w", err)
 		}
 		if len(versions) == 0 {
-			return fmt.Errorf("no MySQL installed")
+			return fmt.Errorf("no MySQL installed — nothing to drop")
 		}
+		// Highest installed. InstalledMajors / InstalledVersions sort
+		// lexicographically — fine for current values, revisit if
+		// versions ever reach 3 digits (e.g., postgres 100, mysql 10.0).
 		version := versions[len(versions)-1]
 		if err := my.DropDatabase(version, dbName); err != nil {
 			return fmt.Errorf("drop %s: %w", dbName, err)
 		}
-		fmt.Printf("dropped database %q from mysql %s\n", dbName, version)
+		ui.Success(fmt.Sprintf("Database %q dropped from mysql %s.", dbName, version))
 		return nil
 	},
 }

--- a/internal/commands/mysql/db_drop.go
+++ b/internal/commands/mysql/db_drop.go
@@ -1,0 +1,31 @@
+package mysql
+
+import (
+	"fmt"
+
+	my "github.com/prvious/pv/internal/mysql"
+	"github.com/spf13/cobra"
+)
+
+var dbDropCmd = &cobra.Command{
+	Use:     "mysql:db:drop <name>",
+	GroupID: "mysql",
+	Short:   "Drop a database from the highest-installed MySQL version",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dbName := args[0]
+		versions, err := my.InstalledVersions()
+		if err != nil {
+			return fmt.Errorf("list installed versions: %w", err)
+		}
+		if len(versions) == 0 {
+			return fmt.Errorf("no MySQL installed")
+		}
+		version := versions[len(versions)-1]
+		if err := my.DropDatabase(version, dbName); err != nil {
+			return fmt.Errorf("drop %s: %w", dbName, err)
+		}
+		fmt.Printf("dropped database %q from mysql %s\n", dbName, version)
+		return nil
+	},
+}

--- a/internal/commands/mysql/register.go
+++ b/internal/commands/mysql/register.go
@@ -20,6 +20,8 @@ func Register(parent *cobra.Command) {
 		logsCmd,
 		statusCmd,
 		downloadCmd, // hidden; included so it's discoverable for debugging
+		dbCreateCmd,
+		dbDropCmd,
 	}
 	for _, c := range cmds {
 		parent.AddCommand(c)

--- a/internal/commands/postgres/db_create.go
+++ b/internal/commands/postgres/db_create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	pg "github.com/prvious/pv/internal/postgres"
+	"github.com/prvious/pv/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -21,11 +22,14 @@ var dbCreateCmd = &cobra.Command{
 		if len(majors) == 0 {
 			return fmt.Errorf("no PostgreSQL installed — run `pv postgres:install <major>`")
 		}
-		major := majors[len(majors)-1] // highest installed (InstalledMajors returns sorted asc)
+		// Highest installed. InstalledMajors / InstalledVersions sort
+		// lexicographically — fine for current values, revisit if
+		// versions ever reach 3 digits (e.g., postgres 100, mysql 10.0).
+		major := majors[len(majors)-1]
 		if err := pg.CreateDatabase(major, dbName); err != nil {
 			return fmt.Errorf("create %s: %w", dbName, err)
 		}
-		fmt.Printf("created database %q in postgres %s\n", dbName, major)
+		ui.Success(fmt.Sprintf("Database %q created in postgres %s.", dbName, major))
 		return nil
 	},
 }

--- a/internal/commands/postgres/db_create.go
+++ b/internal/commands/postgres/db_create.go
@@ -1,0 +1,31 @@
+package postgres
+
+import (
+	"fmt"
+
+	pg "github.com/prvious/pv/internal/postgres"
+	"github.com/spf13/cobra"
+)
+
+var dbCreateCmd = &cobra.Command{
+	Use:     "postgres:db:create <name>",
+	GroupID: "postgres",
+	Short:   "Create a database in the highest-installed PostgreSQL major",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dbName := args[0]
+		majors, err := pg.InstalledMajors()
+		if err != nil {
+			return fmt.Errorf("list installed majors: %w", err)
+		}
+		if len(majors) == 0 {
+			return fmt.Errorf("no PostgreSQL installed — run `pv postgres:install <major>`")
+		}
+		major := majors[len(majors)-1] // highest installed (InstalledMajors returns sorted asc)
+		if err := pg.CreateDatabase(major, dbName); err != nil {
+			return fmt.Errorf("create %s: %w", dbName, err)
+		}
+		fmt.Printf("created database %q in postgres %s\n", dbName, major)
+		return nil
+	},
+}

--- a/internal/commands/postgres/db_create.go
+++ b/internal/commands/postgres/db_create.go
@@ -22,10 +22,12 @@ var dbCreateCmd = &cobra.Command{
 		if len(majors) == 0 {
 			return fmt.Errorf("no PostgreSQL installed — run `pv postgres:install <major>`")
 		}
-		// Highest installed. InstalledMajors / InstalledVersions sort
-		// lexicographically — fine for current values, revisit if
-		// versions ever reach 3 digits (e.g., postgres 100, mysql 10.0).
+		// InstalledMajors sorts lexicographically — fine for current
+		// values, revisit if majors ever reach 3 digits (postgres 100+).
 		major := majors[len(majors)-1]
+		if len(majors) > 1 {
+			ui.Subtle(fmt.Sprintf("Using postgres %s (highest of %d installed)", major, len(majors)))
+		}
 		if err := pg.CreateDatabase(major, dbName); err != nil {
 			return fmt.Errorf("create %s: %w", dbName, err)
 		}

--- a/internal/commands/postgres/db_drop.go
+++ b/internal/commands/postgres/db_drop.go
@@ -1,0 +1,31 @@
+package postgres
+
+import (
+	"fmt"
+
+	pg "github.com/prvious/pv/internal/postgres"
+	"github.com/spf13/cobra"
+)
+
+var dbDropCmd = &cobra.Command{
+	Use:     "postgres:db:drop <name>",
+	GroupID: "postgres",
+	Short:   "Drop a database from the highest-installed PostgreSQL major",
+	Args:    cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dbName := args[0]
+		majors, err := pg.InstalledMajors()
+		if err != nil {
+			return fmt.Errorf("list installed majors: %w", err)
+		}
+		if len(majors) == 0 {
+			return fmt.Errorf("no PostgreSQL installed")
+		}
+		major := majors[len(majors)-1]
+		if err := pg.DropDatabase(major, dbName); err != nil {
+			return fmt.Errorf("drop %s: %w", dbName, err)
+		}
+		fmt.Printf("dropped database %q from postgres %s\n", dbName, major)
+		return nil
+	},
+}

--- a/internal/commands/postgres/db_drop.go
+++ b/internal/commands/postgres/db_drop.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	pg "github.com/prvious/pv/internal/postgres"
+	"github.com/prvious/pv/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -19,13 +20,16 @@ var dbDropCmd = &cobra.Command{
 			return fmt.Errorf("list installed majors: %w", err)
 		}
 		if len(majors) == 0 {
-			return fmt.Errorf("no PostgreSQL installed")
+			return fmt.Errorf("no PostgreSQL installed — nothing to drop")
 		}
+		// Highest installed. InstalledMajors / InstalledVersions sort
+		// lexicographically — fine for current values, revisit if
+		// versions ever reach 3 digits (e.g., postgres 100, mysql 10.0).
 		major := majors[len(majors)-1]
 		if err := pg.DropDatabase(major, dbName); err != nil {
 			return fmt.Errorf("drop %s: %w", dbName, err)
 		}
-		fmt.Printf("dropped database %q from postgres %s\n", dbName, major)
+		ui.Success(fmt.Sprintf("Database %q dropped from postgres %s.", dbName, major))
 		return nil
 	},
 }

--- a/internal/commands/postgres/db_drop.go
+++ b/internal/commands/postgres/db_drop.go
@@ -22,10 +22,12 @@ var dbDropCmd = &cobra.Command{
 		if len(majors) == 0 {
 			return fmt.Errorf("no PostgreSQL installed — nothing to drop")
 		}
-		// Highest installed. InstalledMajors / InstalledVersions sort
-		// lexicographically — fine for current values, revisit if
-		// versions ever reach 3 digits (e.g., postgres 100, mysql 10.0).
+		// InstalledMajors sorts lexicographically — fine for current
+		// values, revisit if majors ever reach 3 digits (postgres 100+).
 		major := majors[len(majors)-1]
+		if len(majors) > 1 {
+			ui.Subtle(fmt.Sprintf("Using postgres %s (highest of %d installed)", major, len(majors)))
+		}
 		if err := pg.DropDatabase(major, dbName); err != nil {
 			return fmt.Errorf("drop %s: %w", dbName, err)
 		}

--- a/internal/commands/postgres/register.go
+++ b/internal/commands/postgres/register.go
@@ -19,6 +19,8 @@ func Register(parent *cobra.Command) {
 		logsCmd,
 		statusCmd,
 		downloadCmd,
+		dbCreateCmd,
+		dbDropCmd,
 	}
 	for _, c := range cmds {
 		parent.AddCommand(c)

--- a/internal/config/pvyml.go
+++ b/internal/config/pvyml.go
@@ -104,3 +104,14 @@ func (p *ProjectConfig) HasAnyEnv() bool {
 	}
 	return false
 }
+
+// HasSetup reports whether pv.yml declares any setup: commands.
+// Nil-safe so it can be called on a freshly-loaded *ProjectConfig
+// that may not exist for the project. Empty slice (Setup: []) is
+// treated as "no setup declared" — same as omitting the block.
+func (p *ProjectConfig) HasSetup() bool {
+	if p == nil {
+		return false
+	}
+	return len(p.Setup) > 0
+}

--- a/internal/config/pvyml_test.go
+++ b/internal/config/pvyml_test.go
@@ -477,3 +477,24 @@ func TestProjectConfig_HasAnyEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestProjectConfig_HasSetup(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *ProjectConfig
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", &ProjectConfig{PHP: "8.4"}, false},
+		{"empty slice", &ProjectConfig{Setup: []string{}}, false},
+		{"one command", &ProjectConfig{Setup: []string{"composer install"}}, true},
+		{"several commands", &ProjectConfig{Setup: []string{"composer install", "php artisan migrate"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.HasSetup(); got != tt.want {
+				t.Errorf("HasSetup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -42,6 +42,9 @@ type Automation struct {
 	GenerateCaddyfile  AutoMode `yaml:"generate_caddyfile,omitempty"`
 	GenerateTLSCert    AutoMode `yaml:"generate_tls_cert,omitempty"`
 	DetectServices     AutoMode `yaml:"detect_services,omitempty"`
+	ApplyPvYmlServices AutoMode `yaml:"apply_pvyml_services,omitempty"`
+	ApplyPvYmlEnv      AutoMode `yaml:"apply_pvyml_env,omitempty"`
+	ApplySetup         AutoMode `yaml:"apply_setup,omitempty"`
 }
 
 type Settings struct {
@@ -69,6 +72,9 @@ func DefaultAutomation() Automation {
 		GenerateCaddyfile:  AutoOn,
 		GenerateTLSCert:    AutoOn,
 		DetectServices:     AutoOn,
+		ApplyPvYmlServices: AutoOn,
+		ApplyPvYmlEnv:      AutoOn,
+		ApplySetup:         AutoOn,
 	}
 }
 
@@ -124,6 +130,15 @@ func applyAutomationDefaults(a *Automation) {
 	}
 	if !validAutoMode(a.DetectServices) {
 		a.DetectServices = d.DetectServices
+	}
+	if !validAutoMode(a.ApplyPvYmlServices) {
+		a.ApplyPvYmlServices = d.ApplyPvYmlServices
+	}
+	if !validAutoMode(a.ApplyPvYmlEnv) {
+		a.ApplyPvYmlEnv = d.ApplyPvYmlEnv
+	}
+	if !validAutoMode(a.ApplySetup) {
+		a.ApplySetup = d.ApplySetup
 	}
 }
 

--- a/internal/laravel/steps.go
+++ b/internal/laravel/steps.go
@@ -31,6 +31,10 @@ func (s *CopyEnvStep) Critical() bool { return false }
 func (s *CopyEnvStep) Verbose() bool  { return false }
 
 func (s *CopyEnvStep) ShouldRun(ctx *automation.Context) bool {
+	// pv.yml setup: declared — user owns the setup pipeline, skip the
+	// legacy step. The same guard appears on every Laravel step below
+	// that the user can replicate via setup: lines (composer install,
+	// key generate, octane install, create database, run migrations).
 	if ctx.ProjectConfig.HasSetup() {
 		return false
 	}

--- a/internal/laravel/steps.go
+++ b/internal/laravel/steps.go
@@ -28,6 +28,7 @@ var _ automation.Step = (*CopyEnvStep)(nil)
 func (s *CopyEnvStep) Label() string  { return "Copy .env" }
 func (s *CopyEnvStep) Gate() string   { return "copy_env" }
 func (s *CopyEnvStep) Critical() bool { return false }
+func (s *CopyEnvStep) Verbose() bool  { return false }
 
 func (s *CopyEnvStep) ShouldRun(ctx *automation.Context) bool {
 	if !isLaravel(ctx.ProjectType) {
@@ -67,6 +68,7 @@ var _ automation.Step = (*GenerateKeyStep)(nil)
 func (s *GenerateKeyStep) Label() string  { return "Generate application key" }
 func (s *GenerateKeyStep) Gate() string   { return "generate_key" }
 func (s *GenerateKeyStep) Critical() bool { return false }
+func (s *GenerateKeyStep) Verbose() bool  { return false }
 
 func (s *GenerateKeyStep) ShouldRun(ctx *automation.Context) bool {
 	if !isLaravel(ctx.ProjectType) {
@@ -95,6 +97,7 @@ var _ automation.Step = (*SetAppURLStep)(nil)
 func (s *SetAppURLStep) Label() string  { return "Set APP_URL" }
 func (s *SetAppURLStep) Gate() string   { return "set_app_url" }
 func (s *SetAppURLStep) Critical() bool { return false }
+func (s *SetAppURLStep) Verbose() bool  { return false }
 
 func (s *SetAppURLStep) ShouldRun(ctx *automation.Context) bool {
 	return isLaravel(ctx.ProjectType) && HasEnvFile(ctx.ProjectPath)
@@ -125,6 +128,7 @@ var _ automation.Step = (*SetViteTLSStep)(nil)
 func (s *SetViteTLSStep) Label() string  { return "Set Vite TLS" }
 func (s *SetViteTLSStep) Gate() string   { return "set_vite_tls" }
 func (s *SetViteTLSStep) Critical() bool { return false }
+func (s *SetViteTLSStep) Verbose() bool  { return false }
 
 func (s *SetViteTLSStep) ShouldRun(ctx *automation.Context) bool {
 	return isLaravel(ctx.ProjectType) && HasEnvFile(ctx.ProjectPath)
@@ -158,6 +162,7 @@ var _ automation.Step = (*InstallOctaneStep)(nil)
 func (s *InstallOctaneStep) Label() string  { return "Install Octane" }
 func (s *InstallOctaneStep) Gate() string   { return "install_octane" }
 func (s *InstallOctaneStep) Critical() bool { return false }
+func (s *InstallOctaneStep) Verbose() bool  { return false }
 
 func (s *InstallOctaneStep) ShouldRun(ctx *automation.Context) bool {
 	if !isLaravel(ctx.ProjectType) {
@@ -196,6 +201,7 @@ var _ automation.Step = (*ComposerInstallStep)(nil)
 func (s *ComposerInstallStep) Label() string  { return "Install Composer dependencies" }
 func (s *ComposerInstallStep) Gate() string   { return "composer_install" }
 func (s *ComposerInstallStep) Critical() bool { return false }
+func (s *ComposerInstallStep) Verbose() bool  { return false }
 
 func (s *ComposerInstallStep) ShouldRun(ctx *automation.Context) bool {
 	if !isLaravel(ctx.ProjectType) {
@@ -225,6 +231,7 @@ var _ automation.Step = (*DetectServicesStep)(nil)
 func (s *DetectServicesStep) Label() string  { return "Configure service environment" }
 func (s *DetectServicesStep) Gate() string   { return "update_env_on_service" }
 func (s *DetectServicesStep) Critical() bool { return false }
+func (s *DetectServicesStep) Verbose() bool  { return false }
 
 func (s *DetectServicesStep) ShouldRun(ctx *automation.Context) bool {
 	if ctx.ProjectConfig.HasAnyEnv() {
@@ -289,6 +296,7 @@ var _ automation.Step = (*CreateDatabaseStep)(nil)
 func (s *CreateDatabaseStep) Label() string  { return "Create database" }
 func (s *CreateDatabaseStep) Gate() string   { return "create_database" }
 func (s *CreateDatabaseStep) Critical() bool { return false }
+func (s *CreateDatabaseStep) Verbose() bool  { return false }
 
 func (s *CreateDatabaseStep) ShouldRun(ctx *automation.Context) bool {
 	if !isLaravel(ctx.ProjectType) {
@@ -354,6 +362,7 @@ var _ automation.Step = (*RunMigrationsStep)(nil)
 func (s *RunMigrationsStep) Label() string  { return "Run migrations" }
 func (s *RunMigrationsStep) Gate() string   { return "run_migrations" }
 func (s *RunMigrationsStep) Critical() bool { return false }
+func (s *RunMigrationsStep) Verbose() bool  { return false }
 
 func (s *RunMigrationsStep) ShouldRun(ctx *automation.Context) bool {
 	if !isLaravel(ctx.ProjectType) {

--- a/internal/laravel/steps.go
+++ b/internal/laravel/steps.go
@@ -31,6 +31,9 @@ func (s *CopyEnvStep) Critical() bool { return false }
 func (s *CopyEnvStep) Verbose() bool  { return false }
 
 func (s *CopyEnvStep) ShouldRun(ctx *automation.Context) bool {
+	if ctx.ProjectConfig.HasSetup() {
+		return false
+	}
 	if !isLaravel(ctx.ProjectType) {
 		return false
 	}
@@ -71,6 +74,9 @@ func (s *GenerateKeyStep) Critical() bool { return false }
 func (s *GenerateKeyStep) Verbose() bool  { return false }
 
 func (s *GenerateKeyStep) ShouldRun(ctx *automation.Context) bool {
+	if ctx.ProjectConfig.HasSetup() {
+		return false
+	}
 	if !isLaravel(ctx.ProjectType) {
 		return false
 	}
@@ -165,6 +171,9 @@ func (s *InstallOctaneStep) Critical() bool { return false }
 func (s *InstallOctaneStep) Verbose() bool  { return false }
 
 func (s *InstallOctaneStep) ShouldRun(ctx *automation.Context) bool {
+	if ctx.ProjectConfig.HasSetup() {
+		return false
+	}
 	if !isLaravel(ctx.ProjectType) {
 		return false
 	}
@@ -204,6 +213,9 @@ func (s *ComposerInstallStep) Critical() bool { return false }
 func (s *ComposerInstallStep) Verbose() bool  { return false }
 
 func (s *ComposerInstallStep) ShouldRun(ctx *automation.Context) bool {
+	if ctx.ProjectConfig.HasSetup() {
+		return false
+	}
 	if !isLaravel(ctx.ProjectType) {
 		return false
 	}
@@ -299,6 +311,9 @@ func (s *CreateDatabaseStep) Critical() bool { return false }
 func (s *CreateDatabaseStep) Verbose() bool  { return false }
 
 func (s *CreateDatabaseStep) ShouldRun(ctx *automation.Context) bool {
+	if ctx.ProjectConfig.HasSetup() {
+		return false
+	}
 	if !isLaravel(ctx.ProjectType) {
 		return false
 	}
@@ -365,6 +380,9 @@ func (s *RunMigrationsStep) Critical() bool { return false }
 func (s *RunMigrationsStep) Verbose() bool  { return false }
 
 func (s *RunMigrationsStep) ShouldRun(ctx *automation.Context) bool {
+	if ctx.ProjectConfig.HasSetup() {
+		return false
+	}
 	if !isLaravel(ctx.ProjectType) {
 		return false
 	}

--- a/internal/laravel/steps_test.go
+++ b/internal/laravel/steps_test.go
@@ -687,3 +687,184 @@ func TestLaravelDetectServices_RunsWhenPvYmlEmpty(t *testing.T) {
 		t.Errorf("ShouldRun: want true when pv.yml has no env")
 	}
 }
+
+// --- HasSetup() short-circuit tests ---
+//
+// Each test below sets up the minimum filesystem/registry state so that
+// ShouldRun returns true with no Setup declared (baseline assertion),
+// and verifies it returns false when Setup is declared (gated assertion).
+// Both halves in one test make the test self-validating: a regression
+// that removes the HasSetup short-circuit would fail the gated half.
+
+func TestCopyEnvStep_SkipsWhenSetupDeclared(t *testing.T) {
+	dir := t.TempDir()
+	// .env.example exists, no .env → ShouldRun would normally return true.
+	if err := os.WriteFile(filepath.Join(dir, ".env.example"), []byte("APP_NAME=Test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &CopyEnvStep{}
+
+	// Sanity: without setup, the step WOULD run. If this fails, the test
+	// setup is broken and the assertion below would pass for the wrong
+	// reason.
+	baseline := &automation.Context{
+		ProjectType: "laravel",
+		ProjectPath: dir,
+	}
+	if !step.ShouldRun(baseline) {
+		t.Fatalf("test invariant: CopyEnvStep should run when .env.example exists without setup")
+	}
+
+	// With setup, the step skips.
+	gated := &automation.Context{
+		ProjectType:   "laravel",
+		ProjectPath:   dir,
+		ProjectConfig: &config.ProjectConfig{Setup: []string{"cp .env.example .env"}},
+	}
+	if step.ShouldRun(gated) {
+		t.Errorf("ShouldRun: want false when setup declared")
+	}
+}
+
+func TestGenerateKeyStep_SkipsWhenSetupDeclared(t *testing.T) {
+	dir := t.TempDir()
+	// .env exists with empty APP_KEY → ShouldRun would normally return true.
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("APP_KEY=\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &GenerateKeyStep{}
+
+	baseline := &automation.Context{
+		ProjectType: "laravel",
+		ProjectPath: dir,
+	}
+	if !step.ShouldRun(baseline) {
+		t.Fatalf("test invariant: GenerateKeyStep should run when .env has empty APP_KEY")
+	}
+
+	gated := &automation.Context{
+		ProjectType:   "laravel",
+		ProjectPath:   dir,
+		ProjectConfig: &config.ProjectConfig{Setup: []string{"php artisan key:generate"}},
+	}
+	if step.ShouldRun(gated) {
+		t.Errorf("ShouldRun: want false when setup declared")
+	}
+}
+
+func TestInstallOctaneStep_SkipsWhenSetupDeclared(t *testing.T) {
+	dir := t.TempDir()
+	// composer.json declares laravel/octane → HasOctanePackage true.
+	// No public/frankenphp-worker.php → !HasOctaneWorker.
+	composer := `{"require": {"laravel/octane": "*"}}`
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &InstallOctaneStep{}
+
+	baseline := &automation.Context{
+		ProjectType: "laravel",
+		ProjectPath: dir,
+	}
+	if !step.ShouldRun(baseline) {
+		t.Fatalf("test invariant: InstallOctaneStep should run when octane is in composer.json without worker")
+	}
+
+	gated := &automation.Context{
+		ProjectType:   "laravel",
+		ProjectPath:   dir,
+		ProjectConfig: &config.ProjectConfig{Setup: []string{"composer require laravel/octane"}},
+	}
+	if step.ShouldRun(gated) {
+		t.Errorf("ShouldRun: want false when setup declared")
+	}
+}
+
+func TestComposerInstallStep_SkipsWhenSetupDeclared(t *testing.T) {
+	dir := t.TempDir()
+	// composer.json exists, no vendor/ → ShouldRun would normally return true.
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &ComposerInstallStep{}
+
+	baseline := &automation.Context{
+		ProjectType: "laravel",
+		ProjectPath: dir,
+	}
+	if !step.ShouldRun(baseline) {
+		t.Fatalf("test invariant: ComposerInstallStep should run when composer.json exists without vendor/")
+	}
+
+	gated := &automation.Context{
+		ProjectType:   "laravel",
+		ProjectPath:   dir,
+		ProjectConfig: &config.ProjectConfig{Setup: []string{"composer install"}},
+	}
+	if step.ShouldRun(gated) {
+		t.Errorf("ShouldRun: want false when setup declared")
+	}
+}
+
+func TestCreateDatabaseStep_SkipsWhenSetupDeclared(t *testing.T) {
+	dir := t.TempDir()
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{},
+		Projects: []registry.Project{{
+			Name: "p", Path: dir, Type: "laravel",
+			Services: &registry.ProjectServices{Postgres: "18"},
+		}},
+	}
+
+	step := &CreateDatabaseStep{}
+
+	baseline := &automation.Context{
+		ProjectName: "p",
+		ProjectType: "laravel",
+		ProjectPath: dir,
+		Registry:    reg,
+	}
+	if !step.ShouldRun(baseline) {
+		t.Fatalf("test invariant: CreateDatabaseStep should run when a DB service is bound")
+	}
+
+	gated := &automation.Context{
+		ProjectName:   "p",
+		ProjectType:   "laravel",
+		ProjectPath:   dir,
+		Registry:      reg,
+		ProjectConfig: &config.ProjectConfig{Setup: []string{"pv postgres:db:create my_app"}},
+	}
+	if step.ShouldRun(gated) {
+		t.Errorf("ShouldRun: want false when setup declared")
+	}
+}
+
+func TestRunMigrationsStep_SkipsWhenSetupDeclared(t *testing.T) {
+	dir := t.TempDir()
+
+	step := &RunMigrationsStep{}
+
+	baseline := &automation.Context{
+		ProjectType: "laravel",
+		ProjectPath: dir,
+		DBCreated:   true,
+	}
+	if !step.ShouldRun(baseline) {
+		t.Fatalf("test invariant: RunMigrationsStep should run when DBCreated is true")
+	}
+
+	gated := &automation.Context{
+		ProjectType:   "laravel",
+		ProjectPath:   dir,
+		DBCreated:     true,
+		ProjectConfig: &config.ProjectConfig{Setup: []string{"php artisan migrate"}},
+	}
+	if step.ShouldRun(gated) {
+		t.Errorf("ShouldRun: want false when setup declared")
+	}
+}

--- a/internal/mysql/database.go
+++ b/internal/mysql/database.go
@@ -33,3 +33,29 @@ func CreateDatabase(version, dbName string) error {
 	}
 	return nil
 }
+
+// DropDatabase drops dbName on the given mysql version using the bundled
+// `mysql` client over the unix socket. Idempotent via
+// `DROP DATABASE IF EXISTS`. The dbName is backquoted so identifiers with
+// dots or hyphens (typical when projectName comes from a slugified
+// directory) parse correctly.
+//
+// Connection details match CreateDatabase byte-for-byte:
+//   - binary: ~/.pv/mysql/<version>/bin/mysql (absolute path; not on PATH)
+//   - socket: /tmp/pv-mysql-<version>.sock
+//   - user:   root (empty password; loopback-only per spec)
+func DropDatabase(version, dbName string) error {
+	bin := filepath.Join(config.MysqlBinDir(version), "mysql")
+	socket := fmt.Sprintf("/tmp/pv-mysql-%s.sock", version)
+	stmt := fmt.Sprintf("DROP DATABASE IF EXISTS `%s`;", dbName)
+	args := []string{
+		"--socket=" + socket,
+		"-u", "root",
+		"-e", stmt,
+	}
+	out, err := exec.Command(bin, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("mysql drop database %q: %w (output: %s)", dbName, err, string(out))
+	}
+	return nil
+}

--- a/internal/mysql/database.go
+++ b/internal/mysql/database.go
@@ -13,11 +13,6 @@ import (
 // `CREATE DATABASE IF NOT EXISTS`. The dbName is backquoted so identifiers
 // with dots or hyphens (typical when projectName comes from a slugified
 // directory) parse correctly.
-//
-// Connection details:
-//   - binary: ~/.pv/mysql/<version>/bin/mysql (absolute path; not on PATH)
-//   - socket: /tmp/pv-mysql-<version>.sock (matches Part B's mysqld flags)
-//   - user:   root (empty password; loopback-only per spec)
 func CreateDatabase(version, dbName string) error {
 	bin := filepath.Join(config.MysqlBinDir(version), "mysql")
 	socket := fmt.Sprintf("/tmp/pv-mysql-%s.sock", version)
@@ -39,11 +34,6 @@ func CreateDatabase(version, dbName string) error {
 // `DROP DATABASE IF EXISTS`. The dbName is backquoted so identifiers with
 // dots or hyphens (typical when projectName comes from a slugified
 // directory) parse correctly.
-//
-// Connection details match CreateDatabase byte-for-byte:
-//   - binary: ~/.pv/mysql/<version>/bin/mysql (absolute path; not on PATH)
-//   - socket: /tmp/pv-mysql-<version>.sock
-//   - user:   root (empty password; loopback-only per spec)
 func DropDatabase(version, dbName string) error {
 	bin := filepath.Join(config.MysqlBinDir(version), "mysql")
 	socket := fmt.Sprintf("/tmp/pv-mysql-%s.sock", version)

--- a/internal/mysql/database_test.go
+++ b/internal/mysql/database_test.go
@@ -72,3 +72,42 @@ func TestCreateDatabase_BackquoteEscapesIdentifier(t *testing.T) {
 		t.Errorf("identifier not backquoted, got argv:\n%s", string(data))
 	}
 }
+
+// TestDropDatabase_InvokesBundledMysqlClient stages a fake `mysql` client
+// at ~/.pv/mysql/<version>/bin/mysql that echoes its argv to a sidecar log,
+// then asserts DropDatabase shelled out to the absolute path with the
+// expected args (socket, user, --execute SQL with IF EXISTS).
+func TestDropDatabase_InvokesBundledMysqlClient(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	binDir := config.MysqlBinDir("8.4")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(t.TempDir(), "argv.log")
+	stub := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + logPath + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "mysql"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DropDatabase("8.4", "my-app"); err != nil {
+		t.Fatalf("DropDatabase: %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read argv log: %v", err)
+	}
+	body := string(data)
+	wantSubs := []string{
+		"--socket=/tmp/pv-mysql-8.4.sock",
+		"-u",
+		"root",
+		"-e",
+		"DROP DATABASE IF EXISTS `my-app`",
+	}
+	for _, w := range wantSubs {
+		if !strings.Contains(body, w) {
+			t.Errorf("argv missing %q\nfull argv:\n%s", w, body)
+		}
+	}
+}

--- a/internal/postgres/database.go
+++ b/internal/postgres/database.go
@@ -44,3 +44,25 @@ func CreateDatabase(major, dbName string) error {
 	}
 	return nil
 }
+
+// DropDatabase drops dbName on the given postgres major using the bundled
+// psql via absolute path. Idempotent: uses `DROP DATABASE IF EXISTS` so it
+// is a no-op when the database does not exist.
+func DropDatabase(major, dbName string) error {
+	port, err := PortFor(major)
+	if err != nil {
+		return err
+	}
+	psql := filepath.Join(config.PostgresBinDir(major), "psql")
+	args := []string{
+		"-h", "127.0.0.1",
+		"-p", strconv.Itoa(port),
+		"-U", "postgres",
+		"-c",
+		fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, dbName),
+	}
+	if _, err := exec.Command(psql, args...).Output(); err != nil {
+		return fmt.Errorf("psql drop: %w", err)
+	}
+	return nil
+}

--- a/internal/postgres/database.go
+++ b/internal/postgres/database.go
@@ -5,33 +5,23 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/prvious/pv/internal/config"
 )
 
 // CreateDatabase creates dbName on the given postgres major using the
-// bundled psql via absolute path. Idempotent: a SELECT-then-CREATE pattern
-// avoids "database already exists" errors.
+// bundled psql via absolute path. Idempotent: inspects psql's stderr for
+// the "already exists" message and treats it as success, avoiding the
+// TOCTOU race of a SELECT-then-CREATE pattern. CREATE DATABASE cannot
+// run inside DO $$ ... EXCEPTION $$ blocks, so the canonical idempotent
+// idiom is to attempt the CREATE and swallow the well-known error.
 func CreateDatabase(major, dbName string) error {
 	port, err := PortFor(major)
 	if err != nil {
 		return err
 	}
 	psql := filepath.Join(config.PostgresBinDir(major), "psql")
-	args := []string{
-		"-h", "127.0.0.1",
-		"-p", strconv.Itoa(port),
-		"-U", "postgres",
-		"-tAc",
-		fmt.Sprintf("SELECT 1 FROM pg_database WHERE datname = '%s'", dbName),
-	}
-	out, err := exec.Command(psql, args...).Output()
-	if err != nil {
-		return fmt.Errorf("psql probe: %w", err)
-	}
-	if string(out) == "1\n" {
-		return nil
-	}
 	createArgs := []string{
 		"-h", "127.0.0.1",
 		"-p", strconv.Itoa(port),
@@ -39,8 +29,12 @@ func CreateDatabase(major, dbName string) error {
 		"-c",
 		fmt.Sprintf(`CREATE DATABASE "%s"`, dbName),
 	}
-	if _, err := exec.Command(psql, createArgs...).Output(); err != nil {
-		return fmt.Errorf("psql create: %w", err)
+	out, err := exec.Command(psql, createArgs...).CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), "already exists") {
+			return nil
+		}
+		return fmt.Errorf("create postgres database %q: %w (output: %s)", dbName, err, string(out))
 	}
 	return nil
 }
@@ -61,8 +55,9 @@ func DropDatabase(major, dbName string) error {
 		"-c",
 		fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, dbName),
 	}
-	if _, err := exec.Command(psql, args...).Output(); err != nil {
-		return fmt.Errorf("psql drop: %w", err)
+	out, err := exec.Command(psql, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("drop postgres database %q: %w (output: %s)", dbName, err, string(out))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

PR 3 of 6 in the pv.yml redesign — see [spec](docs/superpowers/specs/2026-05-10-pv-yml-explicit-config-design.md) and [plan](docs/superpowers/plans/2026-05-10-pv-yml-pr3-setup-runner.md). Adds the `setup:` command runner and gates the 6 legacy setup-pipeline steps when the user owns the pipeline. Also exposes the database commands the setup block needs.

- **`setup:` runner** — `ApplySetupStep` exec's each line via `bash -c` with the pinned PHP bin dir prepended to PATH (so `php artisan ...` finds the right version), fail-fast on first non-zero exit, streams stdout/stderr live (no buffering — `composer install` produces live output). Runs LAST in the pipeline so pv's bookkeeping (registry, env templating, certs, Caddy) is in place before the user's commands.
- **`HasSetup()` helper** — nil-safe method on `*ProjectConfig`, parallel to PR 2's `HasServices()` / `HasAnyEnv()`. The decision point for both the new step and the gate on the 6 legacy ones.
- **6 legacy steps gated** — `CopyEnv`, `ComposerInstall`, `GenerateKey`, `InstallOctane`, `CreateDatabase`, `RunMigrations`. When pv.yml has `setup:`, each short-circuits its `ShouldRun`. Tests are **self-validating**: each constructs the minimum state to make `ShouldRun` return true without setup (sanity check), then adds setup and asserts false. A regression that drops the short-circuit would now fail loud.
- **Standalone db commands** — `pv postgres:db:create/:drop` and `pv mysql:db:create/:drop` (with `pg:` aliases via existing `aliasCommand`). Reuses the existing `CreateDatabase` helpers, adds `DropDatabase` siblings with `IF EXISTS` for idempotency. Highest-installed version picked automatically.

7 commits, 27 files, +1574 / -1 lines.

## Notable mid-PR review fixes

- **Gate registration** ([482bed8](https://github.com/prvious/pv/commit/482bed8)) — found via code review: `apply_pvyml_services` (PR 2), `apply_pvyml_env` (PR 2), and `apply_setup` (PR 3) were all missing from `LookupGate`. Every `pv link` on a pv.yml project was emitting "unknown automation gate" and falling into `AutoAsk` mode. Three new `AutoMode` fields on `config.Automation`, three new switch cases. Fixes PR 2's inherited debt at the same time.
- **Verbose step output** (same commit) — `ui.Step`'s spinner was interleaving with `ApplySetupStep`'s direct stdout/stderr. Added a `Verbose() bool` method to the `Step` interface (defaulting to `false`; `ApplySetupStep` returns `true`); `RunPipeline` switches to `ui.StepVerbose` for verbose steps. All 14 existing step implementations updated.
- **`ui.Success` instead of `fmt.Printf`** ([c0e2adc](https://github.com/prvious/pv/commit/c0e2adc)) — CLAUDE.md "Hard don'ts" #2. The 4 new db commands were leaking confirmation lines onto stdout (reserved for machine-readable output); switched to `ui.Success` (stderr).
- **Test invariant failure caught by implementer** — Task 4's original tests would have passed for the wrong reason (other unset conditions short-circuited `ShouldRun` before reaching the new gate). Implementer flagged and we rebuilt the tests with a self-validating pattern: baseline assert proves the fixture would normally fire, gated assert proves the new gate kills it. Both halves run in every test now.

## Deferred to follow-up

- **`pv s3:bucket:create / :drop`** — spec assumed extraction from existing logic, but rustfs has no bucket-creation code today. Adding it requires its own scope decision (AWS SDK / inline sigv4 / `mc` shellout). Users who need a bucket at link time can `mc mb local/<bucket>` from `setup:` until that lands.

## Test plan

- [ ] `go test ./...` — every package passes (6 new tests for HasSetup gating + 5 for ApplySetupStep + ApplySetupStep ApplySetup_* helpers + db DropDatabase tests)
- [ ] `gofmt -l .` clean
- [ ] `go vet ./...` clean
- [ ] `go build ./...` clean
- [ ] Legacy path: `pv link` on a project without `pv.yml` runs the existing setup steps as before
- [ ] pv.yml path: link a project whose `pv.yml` has a `setup:` block — confirm the 6 legacy steps skip (no `Composer install ...` ui.Step lines), the user's commands run live with stdout/stderr streaming, and a failing line aborts with `setup[<index>] "<line>": <err>`
- [ ] db commands: `pv postgres:db:create foo` + `pv postgres:db:drop foo` round-trip cleanly against an installed postgres major; same for mysql
- [ ] Gate warning gone: link a pv.yml project, confirm no "unknown automation gate" line in the output

## Sequel

PR 4 (`pv init`) is next — generates a project-type-aware default pv.yml so users on the legacy path can migrate cleanly. After that, PR 5 is the breaking change that deletes the legacy pipeline entirely and makes pv.yml required.