### PR TITLE
feat: label pv-managed env writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Common adjustments after `pv init`:
 - **No database**: remove the `postgresql:` / `mysql:` block and the `pv <engine>:db:create` + `php artisan migrate` lines from `setup:`.
 - **Custom migrate command**: replace `php artisan migrate` with whatever your team uses (e.g., `php artisan x-migrate` for multi-database setups).
 - **Custom env keys**: add to the top-level `env:` block or per-service `env:` map. Values can be plain strings or templates. Top-level `env:` exposes project vars like `{{ .site_url }}` and `{{ .tls_cert_path }}`; per-service `env:` maps expose service vars like `{{ .host }}` and `{{ .port }}`. See [the spec](docs/superpowers/specs/2026-05-10-pv-yml-explicit-config-design.md) for the full template variable reference.
+- **pv-managed labels**: keys written from `pv.yml` are labeled with `# pv-managed` in `.env`. Removing a key from `pv.yml` stops future pv updates for that key, but leaves the existing `.env` line for you to edit or remove.
 - **Aliases**: uncomment the `aliases:` line and add hostnames; each alias gets its own TLS cert.
 
 ## What's no longer automatic
@@ -185,7 +186,7 @@ The following used to happen invisibly during `pv link` and related commands. Af
     VITE_DEV_SERVER_CERT: "{{ .tls_cert_path }}"
   ```
 
-The trade-off: a one-time `pv init` per project in exchange for never seeing a mystery `.env` write again.
+The trade-off: a one-time `pv init` per project in exchange for explicit, labeled `.env` writes.
 
 ## Architecture
 

--- a/docs/superpowers/specs/2026-05-10-pv-yml-explicit-config-design.md
+++ b/docs/superpowers/specs/2026-05-10-pv-yml-explicit-config-design.md
@@ -204,7 +204,7 @@ After this change, `pv link` runs the following ordered steps. The list is final
 1. **Resolve PHP version** from pv.yml `php:`. If not installed, run `pv php:install <version>` (existing behavior).
 2. **Start declared services.** For each service block in pv.yml, ensure it's installed at the requested version. If not installed, `pv link` errors with a clear message pointing at `pv <service>:install <version>`. No silent installs.
 3. **Render env templates.** Top-level `env:` resolves against project-level vars; per-service `env:` resolves against service-specific vars. Values that aren't templates are passed through as literal strings.
-4. **Merge into `.env`.** Rendered keys are written to the project's `.env` via the existing `MergeDotEnv`. A `.pv-backup` is written before any modification (current behavior, retained). Keys not declared in pv.yml are not touched.
+4. **Merge into `.env`.** Rendered keys are written to the project's `.env` via `MergeManagedDotEnv`, which labels each written key with a preceding `# pv-managed` comment. A `.pv-backup` is written before any modification (current behavior, retained). Keys not declared in pv.yml are not touched.
 5. **Wire Caddy site.** The primary host + every alias gets a SAN entry in one Caddy site block. pv mints a cert for each.
 6. **Run `setup:` commands.** Each command runs in order, fail-fast, from the project root, with pinned PHP on PATH. The first non-zero exit aborts.
 7. **Register / update registry. Signal daemon.** (Existing behavior, unchanged.)
@@ -252,7 +252,7 @@ Other types get analogous templates. `pv init` refuses to overwrite an existing 
 ### Conflict policy
 
 - pv.yml is the source of truth while a key remains declared there. Templated env values overwrite existing `.env` values on every `pv link` and are labeled with `# pv-managed`. A user who edits a currently declared pv-managed key in `.env` will see their edit clobbered on next link; the right place to change that value is pv.yml (either the literal, or by overriding the template result).
-- `.pv-backup` is written before any merge (current `MergeDotEnv` behavior).
+- `.pv-backup` is written before any merge.
 - Keys not declared in pv.yml are untouched. Comments and blank lines are preserved (current behavior).
 
 ### `pv unlink` does not touch `.env`
@@ -327,7 +327,7 @@ Pure additive. No runtime behavior change.
 ### PR 2 — `pv link` honors `services:`, `env:`, `aliases:` from pv.yml
 
 - When pv.yml declares one or more service blocks, bind those services for the project (replacing what the auto-detect step would have inferred). Auto-detect remains as a fallback when no service blocks are declared, so existing users are not broken.
-- Render top-level `env:` and per-service `env:` against template vars. Merge results into `.env` via `MergeDotEnv`.
+- Render top-level `env:` and per-service `env:` against template vars. Merge results into `.env` via `MergeManagedDotEnv`.
 - Add `aliases:` support to Caddy site generation: primary host + every alias appear as SANs in one site block, all certed by pv's local CA.
 - Tests for: service-block-honored path, env-template-rendering path, alias-cert path, fallback-to-auto-detect path.
 

--- a/docs/superpowers/specs/2026-05-10-pv-yml-explicit-config-design.md
+++ b/docs/superpowers/specs/2026-05-10-pv-yml-explicit-config-design.md
@@ -251,7 +251,7 @@ Other types get analogous templates. `pv init` refuses to overwrite an existing 
 
 ### Conflict policy
 
-- pv.yml is the source of truth. Templated env values overwrite existing `.env` values on every `pv link`. A user who edits a pv-managed key in `.env` will see their edit clobbered on next link; the right place to change that value is pv.yml (either the literal, or by overriding the template result).
+- pv.yml is the source of truth while a key remains declared there. Templated env values overwrite existing `.env` values on every `pv link` and are labeled with `# pv-managed`. A user who edits a currently declared pv-managed key in `.env` will see their edit clobbered on next link; the right place to change that value is pv.yml (either the literal, or by overriding the template result).
 - `.pv-backup` is written before any merge (current `MergeDotEnv` behavior).
 - Keys not declared in pv.yml are untouched. Comments and blank lines are preserved (current behavior).
 
@@ -261,25 +261,18 @@ Unlink is administrative — it removes the project from pv's registry and tears
 
 - Unlink is often temporary (the project is being archived, moved, or will be re-linked later). Clobbering env values forces the user to re-derive them on next link.
 - Env values written by pv are still valid strings; they just point at services that aren't running for this project. A re-link refreshes them from pv.yml anyway.
-- Anything destructive must be invoked explicitly. Users who want to drop databases / buckets call `pv postgres:db:drop` etc. themselves; users who want to clear pv-managed env keys edit pv.yml + relink (covered by managed-key tracking below).
+- Anything destructive must be invoked explicitly. Users who want to drop databases / buckets call `pv postgres:db:drop` etc. themselves; users who want to clear pv-managed env keys remove them from pv.yml, relink to stop future updates, then edit or remove the existing `.env` lines manually.
 
-### Removing a key from pv.yml — managed-key tracking
+### Removing a key from pv.yml — managed labels
 
-Between PR 5 (when pv.yml becomes mandatory) and PR 6, removing a key from pv.yml leaves the old value sitting in `.env` as a dead var. PR 6 closes this gap by recording which keys pv has written, and removing the corresponding `.env` line when its declaration disappears from pv.yml.
+PR 6 labels keys pv writes from pv.yml with an adjacent comment:
 
-Two viable mechanisms; final choice is made during PR 6 design:
+```dotenv
+# pv-managed
+APP_URL=https://myapp.test
+```
 
-1. Sentinel-comment block in `.env`:
-   ```
-   # pv-managed:start
-   DB_HOST=127.0.0.1
-   DB_PORT=5418
-   # pv-managed:end
-   ```
-   Simple but reorders managed keys to a block.
-2. Separate `.pv-state` file mapping project → managed keys. Keeps `.env` untouched in layout. Adds a state file the user shouldn't edit.
-
-Both are workable. The tradeoff is visibility (sentinel-comment is in the user's face) vs `.env` cleanliness (state file leaves `.env` alone).
+Removing a key from pv.yml does not delete the existing `.env` line. It stops future pv updates for that key; the user owns cleanup.
 
 ### Service installed check
 
@@ -367,18 +360,18 @@ This is the cut-over. `pv.yml` becomes mandatory for `pv link`.
 - README + CLAUDE.md updates. Add a migration guide ("if you were on pv ≤ X, run `pv init` in each linked project, review the generated pv.yml, commit it") to README.
 - E2E tests updated to cover the new flow. Old auto-detect e2e tests deleted.
 
-### PR 6 — `.env` managed-key tracking
+### PR 6 — `.env` managed labels
 
-Closes the dead-var gap from PR 5.
+Makes pv.yml-driven `.env` writes visible without hidden state or automatic cleanup.
 
-- Implement the tracking mechanism (sentinel comments vs `.pv-state` — decided in this PR's design).
-- On `pv link`, compare the previously-tracked managed-key set against the newly-rendered set. Keys that disappeared from pv.yml are removed from `.env`.
-- Tests for: add key + relink writes it, remove key from pv.yml + relink removes it, manually-edited (non-pv-managed) keys are never touched.
+- Label keys written from pv.yml with an adjacent `# pv-managed` comment.
+- On `pv link`, update currently declared pv.yml env keys and preserve/add their labels.
+- Do not delete keys that disappear from pv.yml; removing a key from pv.yml stops future pv updates and leaves cleanup to the user.
+- Tests for: add key + relink writes the label, update existing key adds or preserves the label, removing a key from pv.yml does not delete it, manually-edited non-pv keys are never touched.
 
 ## Open questions
 
 The following are deliberately not nailed down in this spec and are settled inside the relevant PR's implementation:
 
-1. **Managed-key tracking mechanism** — sentinel comments in `.env` vs separate `.pv-state` file. Decided in PR 6.
-2. **Exact `pv init` output per project type** beyond Laravel. Decided in PR 4 alongside detection tests.
-3. **Whether `pv setup` keeps its own command after PR 5**, or is merged into `pv link --force-rerun-setup`. Decided in PR 5; preserving the command is the lower-risk default.
+1. **Exact `pv init` output per project type** beyond Laravel. Decided in PR 4 alongside detection tests.
+2. **Whether `pv setup` keeps its own command after PR 5**, or is merged into `pv link --force-rerun-setup`. Decided in PR 5; preserving the command is the lower-risk default.

--- a/docs/superpowers/specs/2026-05-12-pvyml-managed-env-labels-design.md
+++ b/docs/superpowers/specs/2026-05-12-pvyml-managed-env-labels-design.md
@@ -1,0 +1,130 @@
+# pv.yml Managed Env Labels Design
+
+**Date:** 2026-05-12
+**Status:** Proposed
+**Target:** PR 6 of the pv.yml rollout
+
+## Goal
+
+Make `.env` keys written from `pv.yml` visibly identifiable without introducing hidden state and without deleting keys that disappear from `pv.yml`.
+
+PR 5 made `pv.yml` mandatory and removed the legacy silent env writers. PR 6 should now make pv's remaining explicit env writes transparent to users: if pv writes a key from `pv.yml`, the `.env` file should show that the key was pv-managed.
+
+## Non-Goals
+
+- Do not remove stale `.env` keys when a key disappears from `pv.yml`.
+- Do not create a separate state file for managed keys.
+- Do not group managed keys into a dedicated block.
+- Do not add commands for listing or cleaning managed keys.
+- Do not change the `pv.yml` schema.
+
+## User Model
+
+`pv.yml` is the source of truth only while a key remains declared there. Removing a key from `pv.yml` is like unsubscribing from pv management for that key: pv stops updating it, and the user can edit or remove the existing `.env` entry manually.
+
+Example before relink:
+
+```yaml
+env:
+  APP_URL: "{{ .site_url }}"
+postgresql:
+  version: "18"
+  env:
+    DB_HOST: "{{ .host }}"
+```
+
+Resulting `.env`:
+
+```dotenv
+# pv-managed
+APP_URL=https://myapp.test
+
+# pv-managed
+DB_HOST=127.0.0.1
+
+CUSTOM_THING=keep-me
+```
+
+If the user later removes `APP_URL` from `pv.yml`, `pv link` leaves the existing `.env` line alone:
+
+```dotenv
+# pv-managed
+APP_URL=https://myapp.test
+
+# pv-managed
+DB_HOST=127.0.0.1
+
+CUSTOM_THING=keep-me
+```
+
+From that point on, pv no longer updates `APP_URL`; the user owns cleanup.
+
+## Marker Format
+
+Use an adjacent comment immediately above each key pv writes:
+
+```dotenv
+# pv-managed
+KEY=value
+```
+
+Do not use inline comments like `KEY=value # pv-managed`. Dotenv parsers differ on whether inline comments are stripped or treated as part of the value. A preceding full-line comment is safer and readable.
+
+## Merge Behavior
+
+`ApplyPvYmlEnvStep` currently renders all top-level and per-service `env:` declarations into a `map[string]string`, then calls `projectenv.MergeDotEnv`. PR 6 changes that write path to label rendered keys as pv-managed.
+
+The merge rules are:
+
+1. When pv appends a new rendered key, write `# pv-managed` immediately before `KEY=value`.
+2. When pv updates an existing rendered key, ensure the previous line is `# pv-managed`.
+3. If the existing key already has the marker immediately above it, do not duplicate the marker.
+4. If an existing rendered key has comments above it, preserve those comments and insert `# pv-managed` directly above the key unless the marker is already there.
+5. If a key is not in the newly rendered pv.yml env set, leave it untouched even if it has an old `# pv-managed` marker.
+6. Keep the existing `.pv-backup` behavior before modifying `.env`.
+
+This preserves the user's file layout as much as possible while making pv's writes explicit.
+
+## File Responsibilities
+
+- `internal/projectenv/dotenv.go` owns `.env` parsing and merging. Add the managed-label merge helper here so dotenv formatting concerns stay in one package.
+- `internal/automation/steps/apply_pvyml_env.go` owns rendering pv.yml env templates. It should call the managed-label helper instead of the generic merge helper for pv.yml writes.
+- `internal/laravel/env.go` still uses the generic `MergeDotEnv` for uninstall fallback hooks. Those fallback writes are not pv.yml-managed declarations and should not receive `# pv-managed` labels in this PR.
+
+## Error Handling
+
+Use the existing error model:
+
+- File read/write errors bubble up from `projectenv`.
+- `ApplyPvYmlEnvStep` wraps merge failures as `merge .env: ...`.
+- Backup write failure remains fatal, matching current `MergeDotEnv` behavior.
+
+## Testing
+
+Add tests around the projectenv merge helper and the automation step integration.
+
+Required behavior tests:
+
+- Appending new pv.yml env keys writes `# pv-managed` before each key.
+- Updating an existing key adds the marker when missing.
+- Updating an already-marked key does not duplicate `# pv-managed`.
+- Removing a key from `pv.yml` does not remove the existing `.env` key or marker.
+- Non-pv keys remain untouched.
+- `.pv-backup` is still written before modifications.
+
+The tests should avoid relying on map iteration order where possible. If testing appended output, use a single rendered key or assert substrings instead of exact full-file order.
+
+## Documentation
+
+Update the README migration/env section to say pv labels env keys it writes with `# pv-managed`, and that removing a key from `pv.yml` stops future updates but does not delete the existing `.env` line.
+
+Update the original pv.yml explicit config spec's PR 6 section to replace managed-key cleanup with managed-labeling behavior.
+
+## Acceptance Criteria
+
+- `pv link` writes pv.yml-rendered env keys with adjacent `# pv-managed` comments.
+- `pv link` keeps updating currently declared pv.yml env keys.
+- Removing a key from `pv.yml` leaves the existing `.env` entry untouched.
+- No separate managed-key state file is created.
+- Existing non-pv `.env` keys are not marked, edited, or removed.
+- `go test ./...`, `go vet ./...`, and `go build ./...` pass.

--- a/internal/automation/steps/apply_pvyml_env.go
+++ b/internal/automation/steps/apply_pvyml_env.go
@@ -41,7 +41,7 @@ func (s *ApplyPvYmlEnvStep) Run(ctx *automation.Context) (string, error) {
 	// Top-level env: project-level vars.
 	if len(cfg.Env) > 0 {
 		vars := projectenv.ProjectTemplateVars(ctx.ProjectName, ctx.TLD)
-		if err := renderInto(rendered, cfg.Env, vars, "env"); err != nil {
+		if err := renderIntoMap(rendered, cfg.Env, vars, "env"); err != nil {
 			return "", err
 		}
 	}
@@ -56,7 +56,7 @@ func (s *ApplyPvYmlEnvStep) Run(ctx *automation.Context) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("postgres template vars: %w", err)
 		}
-		if err := renderInto(rendered, cfg.Postgresql.Env, vars, "postgresql.env"); err != nil {
+		if err := renderIntoMap(rendered, cfg.Postgresql.Env, vars, "postgresql.env"); err != nil {
 			return "", err
 		}
 	}
@@ -71,28 +71,28 @@ func (s *ApplyPvYmlEnvStep) Run(ctx *automation.Context) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("mysql template vars: %w", err)
 		}
-		if err := renderInto(rendered, cfg.Mysql.Env, vars, "mysql.env"); err != nil {
+		if err := renderIntoMap(rendered, cfg.Mysql.Env, vars, "mysql.env"); err != nil {
 			return "", err
 		}
 	}
 
 	// redis.env
 	if cfg.Redis != nil && len(cfg.Redis.Env) > 0 {
-		if err := renderInto(rendered, cfg.Redis.Env, redis.TemplateVars(), "redis.env"); err != nil {
+		if err := renderIntoMap(rendered, cfg.Redis.Env, redis.TemplateVars(), "redis.env"); err != nil {
 			return "", err
 		}
 	}
 
 	// mailpit.env
 	if cfg.Mailpit != nil && len(cfg.Mailpit.Env) > 0 {
-		if err := renderInto(rendered, cfg.Mailpit.Env, mailpit.TemplateVars(), "mailpit.env"); err != nil {
+		if err := renderIntoMap(rendered, cfg.Mailpit.Env, mailpit.TemplateVars(), "mailpit.env"); err != nil {
 			return "", err
 		}
 	}
 
 	// rustfs.env
 	if cfg.Rustfs != nil && len(cfg.Rustfs.Env) > 0 {
-		if err := renderInto(rendered, cfg.Rustfs.Env, rustfs.TemplateVars(), "rustfs.env"); err != nil {
+		if err := renderIntoMap(rendered, cfg.Rustfs.Env, rustfs.TemplateVars(), "rustfs.env"); err != nil {
 			return "", err
 		}
 	}
@@ -105,10 +105,14 @@ func (s *ApplyPvYmlEnvStep) Run(ctx *automation.Context) (string, error) {
 	return fmt.Sprintf("wrote %d key(s) to .env", len(rendered)), nil
 }
 
-// renderInto renders each template in src against vars and accumulates
+// renderIntoMap renders each template in src against vars and accumulates
 // the result into dst. scope is used only for error messages.
-func renderInto(dst, src, vars map[string]string, scope string) error {
+// Returns an error if a key already exists in dst (duplicate across scopes).
+func renderIntoMap(dst, src, vars map[string]string, scope string) error {
 	for key, tmpl := range src {
+		if _, exists := dst[key]; exists {
+			return fmt.Errorf("%s[%s]: duplicate env key across scopes", scope, key)
+		}
 		out, err := projectenv.Render(tmpl, vars)
 		if err != nil {
 			return fmt.Errorf("%s[%s]: %w", scope, key, err)

--- a/internal/automation/steps/apply_pvyml_env.go
+++ b/internal/automation/steps/apply_pvyml_env.go
@@ -15,7 +15,7 @@ import (
 
 // ApplyPvYmlEnvStep renders pv.yml's top-level env: and per-service
 // env: templates against their respective variable maps and merges
-// the rendered keys into the project's .env via MergeDotEnv.
+// the rendered keys into the project's .env with pv-managed markers.
 //
 // Runs when ctx.ProjectConfig.HasAnyEnv(). For version-bearing
 // services (postgres/mysql), probes the installed binary to populate
@@ -99,7 +99,7 @@ func (s *ApplyPvYmlEnvStep) Run(ctx *automation.Context) (string, error) {
 
 	envPath := filepath.Join(ctx.ProjectPath, ".env")
 	backupPath := filepath.Join(ctx.ProjectPath, ".pv-backup")
-	if err := projectenv.MergeDotEnv(envPath, backupPath, rendered); err != nil {
+	if err := projectenv.MergeManagedDotEnv(envPath, backupPath, rendered); err != nil {
 		return "", fmt.Errorf("merge .env: %w", err)
 	}
 	return fmt.Sprintf("wrote %d key(s) to .env", len(rendered)), nil

--- a/internal/automation/steps/apply_pvyml_env_test.go
+++ b/internal/automation/steps/apply_pvyml_env_test.go
@@ -53,6 +53,39 @@ func TestApplyPvYmlEnv_RendersTopLevelEnv(t *testing.T) {
 	}
 }
 
+func TestApplyPvYmlEnv_LabelsRenderedKeysAsManaged(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	projDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projDir, ".env"), []byte("APP_URL=http://old.test\nCUSTOM_THING=keep-me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &automation.Context{
+		ProjectName: "myapp",
+		ProjectPath: projDir,
+		TLD:         "test",
+		ProjectConfig: &config.ProjectConfig{
+			Env: map[string]string{
+				"APP_URL": "{{ .site_url }}",
+			},
+		},
+	}
+	step := &ApplyPvYmlEnvStep{}
+	if _, err := step.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(projDir, ".env"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# pv-managed\nAPP_URL=https://myapp.test\nCUSTOM_THING=keep-me\n"
+	if string(body) != want {
+		t.Errorf(".env = %q, want %q", string(body), want)
+	}
+}
+
 func TestApplyPvYmlEnv_RendersRedisEnv(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/automation/steps/apply_pvyml_env_test.go
+++ b/internal/automation/steps/apply_pvyml_env_test.go
@@ -90,7 +90,7 @@ func TestApplyPvYmlEnv_RendersRedisEnv(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	projDir := t.TempDir()
-	// No pre-existing .env — MergeDotEnv should create it.
+	// No pre-existing .env — MergeManagedDotEnv should create it.
 
 	ctx := &automation.Context{
 		ProjectName: "myapp",
@@ -162,5 +162,67 @@ func TestApplyPvYmlEnv_ErrorsOnUnknownTemplateVar(t *testing.T) {
 	step := &ApplyPvYmlEnvStep{}
 	if _, err := step.Run(ctx); err == nil {
 		t.Fatal("Run: want error on unknown template var, got nil")
+	}
+}
+
+func TestApplyPvYmlEnv_LabelsServiceEnvAsManaged(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	projDir := t.TempDir()
+	// No pre-existing .env — MergeManagedDotEnv should create it.
+
+	ctx := &automation.Context{
+		ProjectName: "myapp",
+		ProjectPath: projDir,
+		TLD:         "test",
+		ProjectConfig: &config.ProjectConfig{
+			Redis: &config.ServiceConfig{
+				Env: map[string]string{
+					"REDIS_HOST": "{{ .host }}",
+				},
+			},
+		},
+	}
+	step := &ApplyPvYmlEnvStep{}
+	if _, err := step.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(projDir, ".env"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(body)
+	if !strings.Contains(s, "# pv-managed\nREDIS_HOST=127.0.0.1") {
+		t.Errorf(".env missing managed marker for service key\n%s", s)
+	}
+}
+
+func TestApplyPvYmlEnv_ErrorsOnDuplicateKeyAcrossScopes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	projDir := t.TempDir()
+
+	ctx := &automation.Context{
+		ProjectName: "myapp",
+		ProjectPath: projDir,
+		TLD:         "test",
+		ProjectConfig: &config.ProjectConfig{
+			Env: map[string]string{
+				"APP_URL": "{{ .site_url }}",
+			},
+			Redis: &config.ServiceConfig{
+				Env: map[string]string{
+					"APP_URL": "{{ .host }}",
+				},
+			},
+		},
+	}
+	step := &ApplyPvYmlEnvStep{}
+	_, err := step.Run(ctx)
+	if err == nil {
+		t.Fatal("Run: want error on duplicate key across scopes, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate env key") {
+		t.Errorf("err = %v; want it to contain 'duplicate env key'", err)
 	}
 }

--- a/internal/projectenv/dotenv.go
+++ b/internal/projectenv/dotenv.go
@@ -1,7 +1,10 @@
 package projectenv
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -28,16 +31,50 @@ func ReadDotEnv(path string) (map[string]string, error) {
 }
 
 // MergeDotEnv reads an existing .env file, replaces matching keys in-place,
-// appends new keys, and writes the result. Creates a backup at backupPath.
+// appends new keys, and writes the result. Creates a backup at backupPath
+// only if one does not already exist. Preserves the original file's
+// permission bits and writes atomically via temp-file + rename.
 func MergeDotEnv(envPath, backupPath string, newVars map[string]string) error {
+	return mergeDotEnv(envPath, backupPath, newVars, false)
+}
+
+// MergeManagedDotEnv reads an existing .env file, replaces matching keys
+// in-place, appends new keys, and labels every key it writes with a
+// preceding # pv-managed marker. Existing keys that are not present in newVars
+// are left untouched, including any old markers they already have.
+// Creates a backup at backupPath only if one does not already exist.
+// Preserves the original file's permission bits and writes atomically.
+func MergeManagedDotEnv(envPath, backupPath string, newVars map[string]string) error {
+	return mergeDotEnv(envPath, backupPath, newVars, true)
+}
+
+func mergeDotEnv(envPath, backupPath string, newVars map[string]string, managed bool) error {
+	// Validate keys and values.
+	for key, val := range newVars {
+		if key == "" || strings.ContainsAny(key, "\n\r=") || strings.ContainsAny(val, "\n\r") {
+			return fmt.Errorf("invalid env key or value: %q", key)
+		}
+	}
+
 	existing, err := os.ReadFile(envPath)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
+	// Preserve original file permissions.
+	var mode os.FileMode = 0o644
+	if err == nil {
+		if info, statErr := os.Stat(envPath); statErr == nil {
+			mode = info.Mode().Perm()
+		}
+	}
+
+	// Create backup only if one does not already exist.
 	if err == nil && backupPath != "" {
-		if err := os.WriteFile(backupPath, existing, 0644); err != nil {
-			return err
+		if _, statErr := os.Stat(backupPath); os.IsNotExist(statErr) {
+			if writeErr := os.WriteFile(backupPath, existing, mode); writeErr != nil {
+				return writeErr
+			}
 		}
 	}
 
@@ -45,13 +82,22 @@ func MergeDotEnv(envPath, backupPath string, newVars map[string]string) error {
 	var lines []string
 
 	if len(existing) > 0 {
-		for _, line := range strings.Split(string(existing), "\n") {
+		raw := strings.TrimSuffix(string(existing), "\n")
+		for _, line := range strings.Split(raw, "\n") {
 			trimmed := strings.TrimSpace(line)
 			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
 				parts := strings.SplitN(trimmed, "=", 2)
 				if len(parts) == 2 {
 					key := parts[0]
 					if val, ok := newVars[key]; ok {
+						if replaced[key] {
+							// Already updated the first occurrence; preserve duplicates as-is.
+							lines = append(lines, line)
+							continue
+						}
+						if managed && !hasManagedMarker(lines) {
+							lines = append(lines, managedMarker)
+						}
 						lines = append(lines, key+"="+val)
 						replaced[key] = true
 						continue
@@ -62,10 +108,21 @@ func MergeDotEnv(envPath, backupPath string, newVars map[string]string) error {
 		}
 	}
 
-	for key, val := range newVars {
-		if !replaced[key] {
-			lines = append(lines, key+"="+val)
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(newVars))
+	for k := range newVars {
+		if !replaced[k] {
+			keys = append(keys, k)
 		}
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		val := newVars[key]
+		if managed {
+			lines = append(lines, managedMarker)
+		}
+		lines = append(lines, key+"="+val)
 	}
 
 	content := strings.Join(lines, "\n")
@@ -73,66 +130,39 @@ func MergeDotEnv(envPath, backupPath string, newVars map[string]string) error {
 		content += "\n"
 	}
 
-	return os.WriteFile(envPath, []byte(content), 0644)
-}
-
-// MergeManagedDotEnv reads an existing .env file, replaces matching keys
-// in-place, appends new keys, and labels every key it writes with a
-// preceding # pv-managed marker. Existing keys that are not present in newVars
-// are left untouched, including any old markers they already have.
-func MergeManagedDotEnv(envPath, backupPath string, newVars map[string]string) error {
-	existing, err := os.ReadFile(envPath)
-	if err != nil && !os.IsNotExist(err) {
+	// Atomic write: temp file in the same directory, then rename.
+	dir := filepath.Dir(envPath)
+	tmp, err := os.CreateTemp(dir, ".env.tmp-*")
+	if err != nil {
 		return err
 	}
+	tmpPath := tmp.Name()
 
-	if err == nil && backupPath != "" {
-		if err := os.WriteFile(backupPath, existing, 0644); err != nil {
-			return err
-		}
+	if _, err := tmp.WriteString(content); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
 	}
-
-	replaced := make(map[string]bool)
-	var lines []string
-
-	if len(existing) > 0 {
-		lines = strings.Split(string(existing), "\n")
-		if len(lines) > 0 && lines[len(lines)-1] == "" {
-			lines = lines[:len(lines)-1]
-		}
-
-		merged := make([]string, 0, len(lines)+len(newVars)*2)
-		for _, line := range lines {
-			trimmed := strings.TrimSpace(line)
-			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
-				parts := strings.SplitN(trimmed, "=", 2)
-				if len(parts) == 2 {
-					key := parts[0]
-					if val, ok := newVars[key]; ok {
-						if len(merged) == 0 || strings.TrimSpace(merged[len(merged)-1]) != managedMarker {
-							merged = append(merged, managedMarker)
-						}
-						merged = append(merged, key+"="+val)
-						replaced[key] = true
-						continue
-					}
-				}
-			}
-			merged = append(merged, line)
-		}
-		lines = merged
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
 	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, envPath)
+}
 
-	for key, val := range newVars {
-		if !replaced[key] {
-			lines = append(lines, managedMarker, key+"="+val)
+// hasManagedMarker reports whether the last non-empty line in lines is
+// the pv-managed marker. It skips blank lines when looking backward.
+func hasManagedMarker(lines []string) bool {
+	for i := len(lines) - 1; i >= 0; i-- {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "" {
+			continue
 		}
+		return trimmed == managedMarker
 	}
-
-	content := strings.Join(lines, "\n")
-	if !strings.HasSuffix(content, "\n") {
-		content += "\n"
-	}
-
-	return os.WriteFile(envPath, []byte(content), 0644)
+	return false
 }

--- a/internal/projectenv/dotenv.go
+++ b/internal/projectenv/dotenv.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+const managedMarker = "# pv-managed"
+
 // ReadDotEnv reads a .env file into a map of key=value pairs.
 func ReadDotEnv(path string) (map[string]string, error) {
 	data, err := os.ReadFile(path)
@@ -63,6 +65,67 @@ func MergeDotEnv(envPath, backupPath string, newVars map[string]string) error {
 	for key, val := range newVars {
 		if !replaced[key] {
 			lines = append(lines, key+"="+val)
+		}
+	}
+
+	content := strings.Join(lines, "\n")
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+
+	return os.WriteFile(envPath, []byte(content), 0644)
+}
+
+// MergeManagedDotEnv reads an existing .env file, replaces matching keys
+// in-place, appends new keys, and labels every key it writes with a
+// preceding # pv-managed marker. Existing keys that are not present in newVars
+// are left untouched, including any old markers they already have.
+func MergeManagedDotEnv(envPath, backupPath string, newVars map[string]string) error {
+	existing, err := os.ReadFile(envPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if err == nil && backupPath != "" {
+		if err := os.WriteFile(backupPath, existing, 0644); err != nil {
+			return err
+		}
+	}
+
+	replaced := make(map[string]bool)
+	var lines []string
+
+	if len(existing) > 0 {
+		lines = strings.Split(string(existing), "\n")
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+
+		merged := make([]string, 0, len(lines)+len(newVars)*2)
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				parts := strings.SplitN(trimmed, "=", 2)
+				if len(parts) == 2 {
+					key := parts[0]
+					if val, ok := newVars[key]; ok {
+						if len(merged) == 0 || strings.TrimSpace(merged[len(merged)-1]) != managedMarker {
+							merged = append(merged, managedMarker)
+						}
+						merged = append(merged, key+"="+val)
+						replaced[key] = true
+						continue
+					}
+				}
+			}
+			merged = append(merged, line)
+		}
+		lines = merged
+	}
+
+	for key, val := range newVars {
+		if !replaced[key] {
+			lines = append(lines, managedMarker, key+"="+val)
 		}
 	}
 

--- a/internal/projectenv/dotenv_test.go
+++ b/internal/projectenv/dotenv_test.go
@@ -127,3 +127,120 @@ func TestMergeDotEnv_NewFile(t *testing.T) {
 		t.Error("DB_HOST not written")
 	}
 }
+
+func TestMergeManagedDotEnv_AppendsNewKeyWithMarker(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	if err := os.WriteFile(envPath, []byte("CUSTOM_THING=keep-me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"APP_URL": "https://myapp.test"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	result, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "CUSTOM_THING=keep-me\n# pv-managed\nAPP_URL=https://myapp.test\n"
+	if string(result) != want {
+		t.Errorf(".env = %q, want %q", string(result), want)
+	}
+}
+
+func TestMergeManagedDotEnv_UpdatesExistingKeyWithMarker(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	if err := os.WriteFile(envPath, []byte("APP_URL=http://old.test\nCUSTOM_THING=keep-me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"APP_URL": "https://myapp.test"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	result, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# pv-managed\nAPP_URL=https://myapp.test\nCUSTOM_THING=keep-me\n"
+	if string(result) != want {
+		t.Errorf(".env = %q, want %q", string(result), want)
+	}
+}
+
+func TestMergeManagedDotEnv_DoesNotDuplicateMarker(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	if err := os.WriteFile(envPath, []byte("# pv-managed\nAPP_URL=http://old.test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"APP_URL": "https://myapp.test"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	result, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# pv-managed\nAPP_URL=https://myapp.test\n"
+	if string(result) != want {
+		t.Errorf(".env = %q, want %q", string(result), want)
+	}
+}
+
+func TestMergeManagedDotEnv_LeavesRemovedManagedKeyUntouched(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	original := "# pv-managed\nAPP_URL=https://myapp.test\nCUSTOM_THING=keep-me\n"
+	if err := os.WriteFile(envPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"DB_HOST": "127.0.0.1"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	result, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := original + "# pv-managed\nDB_HOST=127.0.0.1\n"
+	if string(result) != want {
+		t.Errorf(".env = %q, want %q", string(result), want)
+	}
+}
+
+func TestMergeManagedDotEnv_CreatesBackup(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	backupPath := filepath.Join(dir, ".pv-backup")
+
+	original := "APP_URL=http://old.test\n"
+	if err := os.WriteFile(envPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeManagedDotEnv(envPath, backupPath, map[string]string{"APP_URL": "https://myapp.test"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	backup, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+	if string(backup) != original {
+		t.Errorf("backup = %q, want %q", string(backup), original)
+	}
+}

--- a/internal/projectenv/dotenv_test.go
+++ b/internal/projectenv/dotenv_test.go
@@ -244,3 +244,178 @@ func TestMergeManagedDotEnv_CreatesBackup(t *testing.T) {
 		t.Errorf("backup = %q, want %q", string(backup), original)
 	}
 }
+
+func TestMergeManagedDotEnv_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"APP_URL": "https://myapp.test"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	result, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# pv-managed\nAPP_URL=https://myapp.test\n"
+	if string(result) != want {
+		t.Errorf(".env = %q, want %q", string(result), want)
+	}
+}
+
+func TestMergeManagedDotEnv_DedupWithWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	if err := os.WriteFile(envPath, []byte("# pv-managed\n\nAPP_URL=old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"APP_URL": "new"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	result, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# pv-managed\n\nAPP_URL=new\n"
+	if string(result) != want {
+		t.Errorf(".env = %q, want %q", string(result), want)
+	}
+}
+
+func TestMergeManagedDotEnv_DuplicateKey(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	if err := os.WriteFile(envPath, []byte("APP_URL=old\nAPP_URL=older\nCUSTOM_THING=keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"APP_URL": "new"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	result, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# pv-managed\nAPP_URL=new\nAPP_URL=older\nCUSTOM_THING=keep\n"
+	if string(result) != want {
+		t.Errorf(".env = %q, want %q", string(result), want)
+	}
+}
+
+func TestMergeManagedDotEnv_MultipleKeysDeterministic(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"B": "2", "A": "1"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	result, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "# pv-managed\nA=1\n# pv-managed\nB=2\n"
+	if string(result) != want {
+		t.Errorf(".env = %q, want %q", string(result), want)
+	}
+}
+
+func TestMergeManagedDotEnv_InvalidKey(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"FOO\nBAR": "value"})
+	if err == nil {
+		t.Fatal("expected error for invalid key, got nil")
+	}
+}
+
+func TestMergeManagedDotEnv_InvalidValue(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"FOO": "val\nue"})
+	if err == nil {
+		t.Fatal("expected error for invalid value, got nil")
+	}
+}
+
+func TestMergeManagedDotEnv_PreservesPermissions(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	if err := os.WriteFile(envPath, []byte("APP_URL=old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeManagedDotEnv(envPath, "", map[string]string{"APP_URL": "new"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	info, err := os.Stat(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %o, want 0o600", info.Mode().Perm())
+	}
+}
+
+func TestMergeManagedDotEnv_SkipsExistingBackup(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	backupPath := filepath.Join(dir, ".pv-backup")
+
+	original := "APP_URL=old\n"
+	if err := os.WriteFile(envPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(backupPath, []byte("existing-backup\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeManagedDotEnv(envPath, backupPath, map[string]string{"APP_URL": "new"})
+	if err != nil {
+		t.Fatalf("MergeManagedDotEnv() error = %v", err)
+	}
+
+	backup, err := os.ReadFile(backupPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(backup) != "existing-backup\n" {
+		t.Errorf("backup was overwritten = %q", string(backup))
+	}
+}
+
+func TestMergeDotEnv_PreservesPermissions(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+
+	if err := os.WriteFile(envPath, []byte("APP_URL=old\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := MergeDotEnv(envPath, "", map[string]string{"APP_URL": "new"})
+	if err != nil {
+		t.Fatalf("MergeDotEnv() error = %v", err)
+	}
+
+	info, err := os.Stat(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %o, want 0o600", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `projectenv.MergeManagedDotEnv` to label keys written from `pv.yml` with adjacent `# pv-managed` comments.
- Wires `ApplyPvYmlEnvStep` to use managed-label merges while keeping generic `MergeDotEnv` for fallback hooks.
- Documents that removing a key from `pv.yml` stops future pv updates but leaves the existing `.env` line for user cleanup.

## Test Plan

- [x] `go test ./...`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `git diff --check`