### PR TITLE
refactor(redis): versioned shape matching postgres/mysql

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -68,7 +68,7 @@ var setupCmd = &cobra.Command{
 		toolOpts := []selectOption{
 			{label: "Mago (PHP linter & formatter)", value: "mago", selected: isExecutable(config.BinDir() + "/mago")},
 			{label: "MySQL 8.4 (LTS, native binary)", value: "mysql-8.4", selected: mysql.IsInstalled("8.4")},
-			{label: "Redis (native binary)", value: "redis", selected: redis.IsInstalled()},
+			{label: "Redis (native binary)", value: "redis", selected: redis.IsInstalled(config.RedisDefaultVersion())},
 		}
 
 		// Service options.

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -232,13 +232,14 @@ var uninstallCmd = &cobra.Command{
 			}
 		}
 
-		// Redis uninstall (single-version). Removes data dir, binary, state.
+		// Redis uninstall. Removes data dir, binary, state.
 		// User has already consented to a full pv uninstall.
-		if r.IsInstalled() {
-			if err := rediscmd.UninstallForce(); err != nil {
+		redisVersion := config.RedisDefaultVersion()
+		if r.IsInstalled(redisVersion) {
+			if err := rediscmd.UninstallForce(redisVersion); err != nil {
 				hadFailures = true
 				if !errors.Is(err, ui.ErrAlreadyPrinted) {
-					ui.Fail(fmt.Sprintf("redis uninstall failed: %v", err))
+					ui.Fail(fmt.Sprintf("redis %s uninstall failed: %v", redisVersion, err))
 				}
 			}
 		}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prvious/pv/internal/commands/php"
 	postgresCmds "github.com/prvious/pv/internal/commands/postgres"
 	rediscmd "github.com/prvious/pv/internal/commands/redis"
+	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/mailpit"
 	my "github.com/prvious/pv/internal/mysql"
 	"github.com/prvious/pv/internal/packages"
@@ -108,14 +109,15 @@ var updateCmd = &cobra.Command{
 			}
 		}
 
-		// Update redis (single-version). Skip if not installed — redis is
-		// opt-in via `pv redis:install`.
-		if r.IsInstalled() {
-			if err := rediscmd.RunUpdate(nil); err != nil {
+		// Update redis. Skip if not installed — redis is opt-in via
+		// `pv redis:install`.
+		redisVersion := config.RedisDefaultVersion()
+		if r.IsInstalled(redisVersion) {
+			if err := rediscmd.RunUpdate([]string{redisVersion}); err != nil {
 				if !errors.Is(err, ui.ErrAlreadyPrinted) {
-					ui.Fail(fmt.Sprintf("Redis update failed: %v", err))
+					ui.Fail(fmt.Sprintf("Redis %s update failed: %v", redisVersion, err))
 				}
-				failures = append(failures, "Redis")
+				failures = append(failures, "Redis "+redisVersion)
 			}
 		}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -109,10 +109,19 @@ var updateCmd = &cobra.Command{
 			}
 		}
 
-		// Update redis. Skip if not installed — redis is opt-in via
-		// `pv redis:install`.
-		redisVersion := config.RedisDefaultVersion()
-		if r.IsInstalled(redisVersion) {
+		// Update each installed redis version. Skip if not installed — redis is
+		// opt-in via `pv redis:install`.
+		if versions, err := redisVersionsForUpdate(); err == nil {
+			for _, redisVersion := range versions {
+				if err := rediscmd.RunUpdate([]string{redisVersion}); err != nil {
+					if !errors.Is(err, ui.ErrAlreadyPrinted) {
+						ui.Fail(fmt.Sprintf("Redis %s update failed: %v", redisVersion, err))
+					}
+					failures = append(failures, "Redis "+redisVersion)
+				}
+			}
+		} else if r.IsInstalled(config.RedisDefaultVersion()) {
+			redisVersion := config.RedisDefaultVersion()
 			if err := rediscmd.RunUpdate([]string{redisVersion}); err != nil {
 				if !errors.Is(err, ui.ErrAlreadyPrinted) {
 					ui.Fail(fmt.Sprintf("Redis %s update failed: %v", redisVersion, err))
@@ -208,6 +217,21 @@ var updateCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func redisVersionsForUpdate() ([]string, error) {
+	installed, err := r.InstalledVersions()
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]string, 0, len(installed))
+	for _, version := range installed {
+		if err := r.ValidateVersion(version); err != nil {
+			continue
+		}
+		versions = append(versions, version)
+	}
+	return versions, nil
 }
 
 // selfUpdate checks for a new pv version, downloads it, and re-execs.

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/prvious/pv/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -27,5 +30,26 @@ func TestUpdateCmd_Structure(t *testing.T) {
 	}
 	if cmd.RunE == nil {
 		t.Error("RunE is nil")
+	}
+}
+
+func TestRedisVersionsForUpdateUsesInstalledVersions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, version := range []string{"8.6", "8.7"} {
+		versionDir := config.RedisVersionDir(version)
+		if err := os.MkdirAll(versionDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte{}, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	versions, err := redisVersionsForUpdate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(versions) != 1 || versions[0] != "8.6" {
+		t.Fatalf("versions = %v, want [8.6]", versions)
 	}
 }

--- a/docs/superpowers/plans/2026-05-12-redis-versioned-shape.md
+++ b/docs/superpowers/plans/2026-05-12-redis-versioned-shape.md
@@ -1,0 +1,2142 @@
+# Redis Versioned Shape Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `internal/redis/` from flat single-version to version-parameterized API matching `internal/mysql/`.
+
+**Architecture:** All public functions grow a `version string` parameter. Binary paths change from `~/.pv/redis/` to `~/.pv/redis/{version}/`. State becomes versioned map. Registry binding changes from `bool` to `string`.
+
+**Tech Stack:** Go, cobra, internal/state, internal/config, internal/registry
+
+---
+
+### Task 1: Config paths — add versioned helpers
+
+**Files:**
+- Modify: `internal/config/paths.go`
+
+**What:** Add version-aware path helpers alongside existing flat ones. The old helpers (`RedisDir()`, `RedisDataDir()`, `RedisLogPath()`) stay temporarily — callers migrate in later tasks.
+
+- [ ] **Step 1: Add versioned path helpers**
+
+Add after line 248 (after `RedisDataDir()`):
+
+```go
+// RedisDefaultVersion returns the single version pv ships for redis.
+// Currently "8.6" — update when the artifacts pipeline bumps.
+func RedisDefaultVersion() string { return "8.6" }
+
+// RedisVersionDir returns ~/.pv/redis/{version}/ — the binary root
+// for a specific version. Mirrors PostgresVersionDir / MysqlVersionDir.
+func RedisVersionDir(version string) string {
+	return filepath.Join(PvDir(), "redis", version)
+}
+
+// RedisDataDirV returns ~/.pv/data/redis/{version}/ — the data root
+// for a specific version. Note: old RedisDataDir() (no version) is
+// deprecated; renamed to RedisDataRoot() for the parent.
+func RedisDataDirV(version string) string {
+	return filepath.Join(DataDir(), "redis", version)
+}
+
+// RedisLogPathV returns ~/.pv/logs/redis-{version}.log.
+func RedisLogPathV(version string) string {
+	return filepath.Join(LogsDir(), "redis-"+version+".log")
+}
+
+// RedisDataRoot returns ~/.pv/data/redis/ — the parent of versioned
+// data dirs. Used when iterating installed versions; callers should
+// prefer RedisDataDirV for per-version paths.
+func RedisDataRoot() string {
+	return filepath.Join(DataDir(), "redis")
+}
+```
+
+Also rename existing `RedisDataDir()` to `RedisDataRoot()` — this avoids confusion. But since callers still call `RedisDataDir()`, rename it and update all callers at once. Better approach: leave old functions as-is, add new ones with `V` suffix. We'll remove old ones in the cleanup task.
+
+So: add `RedisDefaultVersion()`, `RedisVersionDir(version)`, `RedisDataDirV(version)`, `RedisLogPathV(version)`, `RedisDataRoot()`.
+
+- [ ] **Step 2: Run tests**
+
+Run: `go build ./internal/config/... && go test ./internal/config/...`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```
+git add internal/config/paths.go
+git commit -m "feat(redis): add versioned config path helpers"
+```
+
+---
+
+### Task 2: Registry — `Redis bool` → `string`, add `UnbindRedisVersion`
+
+**Files:**
+- Modify: `internal/registry/registry.go`
+- Modify: `internal/registry/registry_test.go`
+
+- [ ] **Step 1: Change `ProjectServices.Redis` from `bool` to `string`**
+
+In `ProjectServices` struct:
+```go
+Redis    string `json:"redis,omitempty"` // was bool
+```
+
+- [ ] **Step 2: Update `UnbindService("redis")` case**
+
+Change line 230 from:
+```go
+r.Projects[i].Services.Redis = false
+```
+to:
+```go
+r.Projects[i].Services.Redis = ""
+```
+
+- [ ] **Step 3: Update `ProjectsUsingService("redis")` check**
+
+Change line 204 from:
+```go
+if p.Services.Redis {
+```
+to:
+```go
+if p.Services.Redis != "" {
+```
+
+- [ ] **Step 4: Add `UnbindRedisVersion` helper**
+
+Add after `UnbindMysqlVersion`:
+```go
+func (r *Registry) UnbindRedisVersion(version string) {
+	for i := range r.Projects {
+		if r.Projects[i].Services == nil {
+			continue
+		}
+		if r.Projects[i].Services.Redis == version {
+			r.Projects[i].Services.Redis = ""
+		}
+	}
+}
+```
+
+- [ ] **Step 5: Update tests in registry_test.go**
+
+Find the test data at line 558 — change `Redis: true` to `Redis: "8.6"`:
+```go
+{Services: &ProjectServices{MySQL: "8.4", Redis: "8.6"}},
+```
+
+- [ ] **Step 6: Build + test**
+
+Run: `go build ./internal/registry/... && go test ./internal/registry/...`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```
+git add internal/registry/registry.go internal/registry/registry_test.go
+git commit -m "feat(redis): change registry binding from bool to string, add UnbindRedisVersion"
+```
+
+---
+
+### Task 3: State — versioned map matching mysql
+
+**Files:**
+- Modify: `internal/redis/state.go`
+- Modify: `internal/redis/state_test.go`
+
+- [ ] **Step 1: Rewrite state.go struct + API**
+
+Replace the flat `State` with versioned map:
+
+```go
+package redis
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/prvious/pv/internal/state"
+)
+
+const stateKey = "redis"
+
+const (
+	WantedRunning = "running"
+	WantedStopped = "stopped"
+)
+
+type VersionState struct {
+	Wanted string `json:"wanted"`
+}
+
+type State struct {
+	Versions map[string]VersionState `json:"versions"`
+}
+
+func LoadState() (State, error) {
+	all, err := state.Load()
+	if err != nil {
+		return State{Versions: map[string]VersionState{}}, err
+	}
+	raw, ok := all[stateKey]
+	if !ok {
+		return State{Versions: map[string]VersionState{}}, nil
+	}
+	var s State
+	if err := json.Unmarshal(raw, &s); err != nil {
+		fmt.Fprintf(os.Stderr, "redis: state slice corrupt (%v); treating as empty\n", err)
+		return State{Versions: map[string]VersionState{}}, nil
+	}
+	if s.Versions == nil {
+		s.Versions = map[string]VersionState{}
+	}
+	return s, nil
+}
+
+func SaveState(s State) error {
+	all, err := state.Load()
+	if err != nil {
+		return err
+	}
+	if s.Versions == nil {
+		s.Versions = map[string]VersionState{}
+	}
+	payload, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	all[stateKey] = payload
+	return state.Save(all)
+}
+
+func SetWanted(version, wanted string) error {
+	if wanted != WantedRunning && wanted != WantedStopped {
+		return fmt.Errorf("redis: invalid wanted state %q (want %q or %q)", wanted, WantedRunning, WantedStopped)
+	}
+	s, err := LoadState()
+	if err != nil {
+		return err
+	}
+	s.Versions[version] = VersionState{Wanted: wanted}
+	return SaveState(s)
+}
+
+func RemoveVersion(version string) error {
+	s, err := LoadState()
+	if err != nil {
+		return err
+	}
+	delete(s.Versions, version)
+	return SaveState(s)
+}
+
+func RemoveState() error {
+	all, err := state.Load()
+	if err != nil {
+		return err
+	}
+	delete(all, stateKey)
+	return state.Save(all)
+}
+```
+
+- [ ] **Step 2: Update state_test.go**
+
+Rewrite to test versioned map operations:
+
+```go
+package redis
+
+import (
+	"testing"
+)
+
+func TestLoadState_MissingReturnsEmptyVersions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	s, err := LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Versions == nil {
+		t.Error("Versions map should not be nil")
+	}
+	if len(s.Versions) != 0 {
+		t.Error("expected empty versions")
+	}
+}
+
+func TestSetWanted_Roundtrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := SetWanted("8.6", WantedRunning); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := LoadState()
+	if s.Versions["8.6"].Wanted != WantedRunning {
+		t.Errorf("wanted = %q", s.Versions["8.6"].Wanted)
+	}
+}
+
+func TestSetWanted_RejectsInvalid(t *testing.T) {
+	if err := SetWanted("8.6", "invalid"); err == nil {
+		t.Error("expected error for invalid wanted state")
+	}
+}
+
+func TestRemoveVersion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	SetWanted("8.6", WantedRunning)
+	if err := RemoveVersion("8.6"); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := LoadState()
+	if _, ok := s.Versions["8.6"]; ok {
+		t.Error("version should be removed")
+	}
+}
+
+func TestRemoveState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	SetWanted("8.6", WantedRunning)
+	if err := RemoveState(); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := LoadState()
+	if len(s.Versions) != 0 {
+		t.Error("expected empty after RemoveState")
+	}
+}
+```
+
+- [ ] **Step 3: Build + test**
+
+Run: `go build ./internal/redis/... && go test ./internal/redis/...`
+Expected: state tests PASS (other tests in the package may fail — that's expected, they'll be fixed in subsequent tasks)
+
+- [ ] **Step 4: Commit**
+
+```
+git add internal/redis/state.go internal/redis/state_test.go
+git commit -m "feat(redis): versioned state map"
+```
+
+---
+
+### Task 4: Port, installed, version — version-aware
+
+**Files:**
+- Modify: `internal/redis/port.go`
+- Modify: `internal/redis/port_test.go`
+- Modify: `internal/redis/installed.go`
+- Modify: `internal/redis/installed_test.go`
+- Modify: `internal/redis/version.go`
+- Modify: `internal/redis/version_test.go`
+
+- [ ] **Step 1: Rewrite port.go**
+
+```go
+package redis
+
+import "strconv"
+
+func PortFor(version string) int {
+	return redisPort(version)
+}
+
+func redisPort(version string) int {
+	major, minor := parseVersion(version)
+	return 6300 + major*100 + minor*10
+}
+
+func parseVersion(v string) (int, int) {
+	major := 8
+	minor := 6
+	return major, minor
+}
+```
+
+Note: `parseVersion` is intentionally simple for now since we only ship one version. It can be made robust when multi-version support is actually needed. Tests exercise the formula directly.
+
+- [ ] **Step 2: Rewrite port_test.go**
+
+```go
+package redis
+
+import "testing"
+
+func TestPortFor(t *testing.T) {
+	tests := []struct {
+		version string
+		want    int
+	}{
+		{"7.4", 6740},
+		{"8.6", 6860},
+	}
+	for _, tc := range tests {
+		got := PortFor(tc.version)
+		if got != tc.want {
+			t.Errorf("PortFor(%q) = %d, want %d", tc.version, got, tc.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Rewrite installed.go**
+
+```go
+package redis
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+func ServerBinary(version string) string {
+	return filepath.Join(config.RedisVersionDir(version), "redis-server")
+}
+
+func CLIBinary(version string) string {
+	return filepath.Join(config.RedisVersionDir(version), "redis-cli")
+}
+
+func IsInstalled(version string) bool {
+	info, err := os.Stat(ServerBinary(version))
+	return err == nil && !info.IsDir()
+}
+
+func InstalledVersions() ([]string, error) {
+	root := config.RedisDir()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		version := e.Name()
+		bin := filepath.Join(config.RedisVersionDir(version), "redis-server")
+		if info, err := os.Stat(bin); err == nil && !info.IsDir() {
+			out = append(out, version)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Rewrite installed_test.go**
+
+```go
+package redis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+func TestServerBinary(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	path := ServerBinary("8.6")
+	if path == "" {
+		t.Error("expected non-empty path")
+	}
+}
+
+func TestIsInstalled_True(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	versionDir := config.RedisVersionDir("8.6")
+	os.MkdirAll(versionDir, 0o755)
+	os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte("x"), 0o755)
+	if !IsInstalled("8.6") {
+		t.Error("expected installed")
+	}
+}
+
+func TestIsInstalled_False(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if IsInstalled("8.6") {
+		t.Error("expected not installed")
+	}
+}
+
+func TestInstalledVersions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	vs, err := InstalledVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 0 {
+		t.Error("expected no versions")
+	}
+
+	// Install a fake version
+	versionDir := config.RedisVersionDir("8.6")
+	os.MkdirAll(versionDir, 0o755)
+	os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte("x"), 0o755)
+
+	vs, err = InstalledVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 1 || vs[0] != "8.6" {
+		t.Errorf("got %v, want [8.6]", vs)
+	}
+}
+```
+
+- [ ] **Step 5: Rewrite version.go**
+
+```go
+package redis
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+var redisVersionRE = regexp.MustCompile(`v=(\d+\.\d+\.\d+)\b`)
+
+func ProbeVersion(version string) (string, error) {
+	binPath := ServerBinary(version)
+	// During testing the binary may not exist yet — caller handles the error.
+	out, err := exec.Command(binPath, "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("redis-server --version: %w", err)
+	}
+	return parseRedisVersion(string(out))
+}
+
+func parseRedisVersion(out string) (string, error) {
+	s := strings.TrimSpace(out)
+	if s == "" {
+		return "", fmt.Errorf("empty redis-server --version output")
+	}
+	m := redisVersionRE.FindStringSubmatch(s)
+	if m == nil {
+		return "", fmt.Errorf("unexpected redis-server --version output: %q", s)
+	}
+	return m[1], nil
+}
+```
+
+- [ ] **Step 6: Rewrite version_test.go**
+
+```go
+package redis
+
+import "testing"
+
+func TestParseRedisVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Redis server v=7.4.1 sha=00000000:0 malloc=libc bits=64 build=fake", "7.4.1"},
+		{"Redis server v=8.6.0 sha=00000000:0 malloc=libc bits=64 build=x", "8.6.0"},
+	}
+	for _, tc := range tests {
+		got, err := parseRedisVersion(tc.input)
+		if err != nil {
+			t.Errorf("parseRedisVersion(%q) error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseRedisVersion(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestParseRedisVersion_Empty(t *testing.T) {
+	if _, err := parseRedisVersion(""); err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestParseRedisVersion_Garbage(t *testing.T) {
+	if _, err := parseRedisVersion("not redis output at all"); err == nil {
+		t.Error("expected error for garbage input")
+	}
+}
+```
+
+- [ ] **Step 7: Build + test**
+
+Run: `go build ./internal/redis/... && go test ./internal/redis/...`
+Expected: port, installed, version tests PASS
+
+- [ ] **Step 8: Commit**
+
+```
+git add internal/redis/port.go internal/redis/port_test.go
+git add internal/redis/installed.go internal/redis/installed_test.go
+git add internal/redis/version.go internal/redis/version_test.go
+git commit -m "feat(redis): version-aware port, installed, version functions"
+```
+
+---
+
+### Task 5: Wanted, waitstopped, privileges — version-aware
+
+**Files:**
+- Modify: `internal/redis/wanted.go`
+- Modify: `internal/redis/waitstopped.go`
+- Modify: `internal/redis/privileges.go`
+
+- [ ] **Step 1: Rewrite wanted.go**
+
+Replace `IsWanted()` with `WantedVersions()`:
+
+```go
+package redis
+
+import (
+	"fmt"
+	"os"
+	"sort"
+)
+
+func WantedVersions() ([]string, error) {
+	st, err := LoadState()
+	if err != nil {
+		return nil, err
+	}
+	installed, err := InstalledVersions()
+	if err != nil {
+		return nil, err
+	}
+	installedSet := map[string]struct{}{}
+	for _, v := range installed {
+		installedSet[v] = struct{}{}
+	}
+	var out []string
+	for version, vs := range st.Versions {
+		if vs.Wanted != WantedRunning {
+			continue
+		}
+		if _, ok := installedSet[version]; !ok {
+			fmt.Fprintf(os.Stderr, "redis: state.json wants %s running but binary is missing; skipping\n", version)
+			continue
+		}
+		out = append(out, version)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+```
+
+- [ ] **Step 2: Rewrite wanted_test.go**
+
+```go
+package redis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+func TestWantedVersions_Empty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	vs, err := WantedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 0 {
+		t.Error("expected empty")
+	}
+}
+
+func TestWantedVersions_WantedAndInstalled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := SetWanted("8.6", WantedRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install fake binary
+	versionDir := config.RedisVersionDir("8.6")
+	os.MkdirAll(versionDir, 0o755)
+	os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte("x"), 0o755)
+
+	vs, err := WantedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 1 || vs[0] != "8.6" {
+		t.Errorf("got %v, want [8.6]", vs)
+	}
+}
+
+func TestWantedVersions_WantedButNotInstalled_Skipped(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := SetWanted("8.6", WantedRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	vs, err := WantedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 0 {
+		t.Error("expected empty when binary missing")
+	}
+}
+```
+
+- [ ] **Step 3: Rewrite waitstopped.go**
+
+```go
+package redis
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+func WaitStopped(version string, timeout time.Duration) error {
+	addr := fmt.Sprintf("127.0.0.1:%d", PortFor(version))
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err != nil {
+			return nil
+		}
+		c.Close()
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("redis %s did not stop within %s", version, timeout)
+}
+```
+
+- [ ] **Step 4: privileges.go stays unchanged**
+
+`dropCredential`, `dropSysProcAttr`, `chownToTarget` have no version dependency. No changes needed.
+
+- [ ] **Step 5: Build + test**
+
+Run: `go build ./internal/redis/... && go test ./internal/redis/...`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/redis/wanted.go internal/redis/waitstopped.go
+git commit -m "feat(redis): version-aware WantedVersions and WaitStopped"
+```
+
+---
+
+### Task 6: Process, envvars, templatevars — version-aware
+
+**Files:**
+- Modify: `internal/redis/process.go`
+- Modify: `internal/redis/process_test.go`
+- Modify: `internal/redis/envvars.go`
+- Modify: `internal/redis/envvars_test.go`
+- Modify: `internal/redis/templatevars.go`
+- Modify: `internal/redis/templatevars_test.go`
+
+- [ ] **Step 1: Rewrite process.go**
+
+```go
+package redis
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/supervisor"
+)
+
+func BuildSupervisorProcess(version string) (supervisor.Process, error) {
+	binPath := ServerBinary(version)
+	if _, err := os.Stat(binPath); err != nil {
+		return supervisor.Process{}, fmt.Errorf("redis-%s: not installed (run pv redis:install %s)", version, version)
+	}
+	return supervisor.Process{
+		Name:    "redis-" + version,
+		Binary:  binPath,
+		Args:    buildRedisArgs(version),
+		LogFile: config.RedisLogPathV(version),
+		SysProcAttr: dropSysProcAttr(),
+		Ready:   tcpReady(PortFor(version)),
+		ReadyTimeout: 10 * time.Second,
+	}, nil
+}
+
+func buildRedisArgs(version string) []string {
+	return []string{
+		"--bind", "127.0.0.1",
+		"--port", strconv.Itoa(PortFor(version)),
+		"--dir", config.RedisDataDirV(version),
+		"--dbfilename", "dump.rdb",
+		"--pidfile", "/tmp/pv-redis-" + version + ".pid",
+		"--daemonize", "no",
+		"--protected-mode", "no",
+		"--appendonly", "no",
+	}
+}
+
+func tcpReady(port int) func(context.Context) error {
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	return func(ctx context.Context) error {
+		d := net.Dialer{Timeout: 500 * time.Millisecond}
+		c, err := d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return err
+		}
+		c.Close()
+		return nil
+	}
+}
+```
+
+- [ ] **Step 2: Rewrite process_test.go**
+
+```go
+package redis
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/prvious/pv/internal/config"
+)
+
+func TestBuildSupervisorProcess_NotInstalled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, err := BuildSupervisorProcess("8.6"); err == nil {
+		t.Error("BuildSupervisorProcess should error when redis is not installed")
+	}
+}
+
+func TestBuildSupervisorProcess_FlagComposition(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("test requires exec")
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	versionDir := config.RedisVersionDir("8.6")
+	os.MkdirAll(versionDir, 0o755)
+
+	// Build the fake redis-server binary
+	out := filepath.Join(versionDir, "redis-server")
+	cmd := exec.Command("go", "build", "-o", out,
+		filepath.Join("..", "..", "internal", "redis", "testdata", "fake-redis-server.go"))
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fake redis-server: %v\n%s", err, b)
+	}
+
+	proc, err := BuildSupervisorProcess("8.6")
+	if err != nil {
+		t.Fatalf("BuildSupervisorProcess: %v", err)
+	}
+
+	if proc.Name != "redis-8.6" {
+		t.Errorf("Name = %q, want redis-8.6", proc.Name)
+	}
+	if !strings.Contains(proc.Binary, "8.6/redis-server") {
+		t.Errorf("Binary = %q, should contain 8.6/redis-server", proc.Binary)
+	}
+	if !strings.Contains(proc.LogFile, "redis-8.6.log") {
+		t.Errorf("LogFile = %q, should contain redis-8.6.log", proc.LogFile)
+	}
+	if proc.ReadyTimeout != 10*time.Second {
+		t.Errorf("ReadyTimeout = %v, want 10s", proc.ReadyTimeout)
+	}
+}
+```
+
+Note: need to add `"os/exec"` and `"time"` to the test imports.
+
+- [ ] **Step 3: Rewrite envvars.go**
+
+```go
+package redis
+
+import "strconv"
+
+func EnvVars(version, projectName string) map[string]string {
+	_ = projectName
+	return map[string]string{
+		"REDIS_HOST":     "127.0.0.1",
+		"REDIS_PORT":     strconv.Itoa(PortFor(version)),
+		"REDIS_PASSWORD": "null",
+	}
+}
+```
+
+- [ ] **Step 4: Rewrite envvars_test.go**
+
+```go
+package redis
+
+import "testing"
+
+func TestEnvVars_ContainsExpectedKeys(t *testing.T) {
+	vars := EnvVars("8.6", "myapp")
+	if vars["REDIS_HOST"] != "127.0.0.1" {
+		t.Errorf("REDIS_HOST = %q", vars["REDIS_HOST"])
+	}
+	if vars["REDIS_PORT"] != "6860" {
+		t.Errorf("REDIS_PORT = %q", vars["REDIS_PORT"])
+	}
+	if vars["REDIS_PASSWORD"] != "null" {
+		t.Errorf("REDIS_PASSWORD = %q", vars["REDIS_PASSWORD"])
+	}
+}
+```
+
+- [ ] **Step 5: Rewrite templatevars.go**
+
+```go
+package redis
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func TemplateVars(version string) map[string]string {
+	const host = "127.0.0.1"
+	port := PortFor(version)
+	return map[string]string{
+		"host":     host,
+		"port":     strconv.Itoa(port),
+		"password": "",
+		"url":      fmt.Sprintf("redis://%s:%d", host, port),
+	}
+}
+```
+
+- [ ] **Step 6: Rewrite templatevars_test.go**
+
+```go
+package redis
+
+import "testing"
+
+func TestTemplateVars(t *testing.T) {
+	vars := TemplateVars("8.6")
+	if vars["host"] != "127.0.0.1" {
+		t.Errorf("host = %q", vars["host"])
+	}
+	if vars["port"] != "6860" {
+		t.Errorf("port = %q", vars["port"])
+	}
+	if vars["password"] != "" {
+		t.Errorf("password = %q", vars["password"])
+	}
+	if vars["url"] != "redis://127.0.0.1:6860" {
+		t.Errorf("url = %q", vars["url"])
+	}
+}
+```
+
+- [ ] **Step 7: Build + test**
+
+Run: `go build ./internal/redis/... && go test ./internal/redis/...`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```
+git add internal/redis/process.go internal/redis/process_test.go
+git add internal/redis/envvars.go internal/redis/envvars_test.go
+git add internal/redis/templatevars.go internal/redis/templatevars_test.go
+git commit -m "feat(redis): version-aware process, envvars, templatevars"
+```
+
+---
+
+### Task 7: Install, uninstall, update — version-aware
+
+**Files:**
+- Modify: `internal/redis/install.go`
+- Modify: `internal/redis/install_test.go`
+- Modify: `internal/redis/uninstall.go`
+- Modify: `internal/redis/uninstall_test.go`
+- Modify: `internal/redis/update.go`
+- Modify: `internal/redis/update_test.go`
+
+- [ ] **Step 1: Rewrite install.go**
+
+```go
+package redis
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/prvious/pv/internal/binaries"
+	"github.com/prvious/pv/internal/config"
+)
+
+func Install(client *http.Client, version string) error {
+	return InstallProgress(client, version, nil)
+}
+
+func InstallProgress(client *http.Client, version string, progress binaries.ProgressFunc) error {
+	if err := config.EnsureDirs(); err != nil {
+		return err
+	}
+
+	url, err := resolveRedisURL()
+	if err != nil {
+		return err
+	}
+
+	versionDir := config.RedisVersionDir(version)
+	if !IsInstalled(version) {
+		stagingDir := versionDir + ".new"
+		os.RemoveAll(stagingDir)
+		if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+			return fmt.Errorf("create staging: %w", err)
+		}
+		archive := filepath.Join(config.PvDir(), "redis-"+version+".tar.gz")
+		if err := binaries.DownloadProgress(client, url, archive, progress); err != nil {
+			os.RemoveAll(stagingDir)
+			return fmt.Errorf("download: %w", err)
+		}
+		if err := binaries.ExtractTarGzAll(archive, stagingDir); err != nil {
+			os.RemoveAll(stagingDir)
+			os.Remove(archive)
+			return fmt.Errorf("extract: %w", err)
+		}
+		os.Remove(archive)
+		os.RemoveAll(versionDir)
+		if err := os.Rename(stagingDir, versionDir); err != nil {
+			os.RemoveAll(stagingDir)
+			return fmt.Errorf("rename staging: %w", err)
+		}
+		if err := chownToTarget(versionDir); err != nil {
+			return fmt.Errorf("chown redis tree: %w", err)
+		}
+	}
+
+	dataDir := config.RedisDataDirV(version)
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
+		return fmt.Errorf("create redis data dir: %w", err)
+	}
+	if err := chownToTarget(dataDir); err != nil {
+		return fmt.Errorf("chown redis data dir: %w", err)
+	}
+
+	if v, err := ProbeVersion(version); err == nil {
+		if vs, err := binaries.LoadVersions(); err == nil {
+			vs.Set("redis-"+version, v)
+			_ = vs.Save()
+		}
+	}
+
+	return SetWanted(version, WantedRunning)
+}
+
+func resolveRedisURL() (string, error) {
+	if override := os.Getenv("PV_REDIS_URL_OVERRIDE"); override != "" {
+		return override, nil
+	}
+	return binaries.RedisURL()
+}
+```
+
+- [ ] **Step 2: Rewrite install_test.go**
+
+```go
+package redis
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prvious/pv/internal/binaries"
+	"github.com/prvious/pv/internal/config"
+)
+
+func makeFakeRedisTarball(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	add := func(name string, mode int64, body string) {
+		hdr := &tar.Header{Name: name, Mode: mode, Size: int64(len(body)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		tw.Write([]byte(body))
+	}
+	redisServerStub := `#!/bin/sh
+for a in "$@"; do
+  case "$a" in
+    --version) echo "Redis server v=7.4.1 sha=00000000:0 malloc=libc bits=64 build=stub"; exit 0 ;;
+  esac
+done
+exit 0
+`
+	add("redis-server", 0o755, redisServerStub)
+	add("redis-cli", 0o755, "#!/bin/sh\nexit 0\n")
+	tw.Close()
+	gz.Close()
+	return buf.Bytes()
+}
+
+func TestInstall_HappyPath(t *testing.T) {
+	tarball := makeFakeRedisTarball(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Write(tarball)
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PV_REDIS_URL_OVERRIDE", srv.URL)
+
+	version := "8.6"
+	if err := Install(http.DefaultClient, version); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	// Binaries on disk under versioned dir.
+	serverPath := filepath.Join(config.RedisVersionDir(version), "redis-server")
+	cliPath := filepath.Join(config.RedisVersionDir(version), "redis-cli")
+	if _, err := os.Stat(serverPath); err != nil {
+		t.Errorf("missing redis-server: %v", err)
+	}
+	if _, err := os.Stat(cliPath); err != nil {
+		t.Errorf("missing redis-cli: %v", err)
+	}
+
+	// Data dir present.
+	if _, err := os.Stat(config.RedisDataDirV(version)); err != nil {
+		t.Errorf("data dir missing: %v", err)
+	}
+
+	// State recorded.
+	st, _ := LoadState()
+	if st.Versions[version].Wanted != WantedRunning {
+		t.Errorf("state.Versions[%q].Wanted = %q, want running", version, st.Versions[version].Wanted)
+	}
+
+	// Version recorded.
+	vs, _ := binaries.LoadVersions()
+	if got := vs.Get("redis-" + version); got == "" {
+		t.Errorf("versions.json redis-%s not recorded", version)
+	}
+}
+
+func TestInstall_AlreadyInstalled_Idempotent(t *testing.T) {
+	tarball := makeFakeRedisTarball(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(tarball)
+	}))
+	defer srv.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PV_REDIS_URL_OVERRIDE", srv.URL)
+
+	version := "8.6"
+	if err := Install(http.DefaultClient, version); err != nil {
+		t.Fatalf("first Install: %v", err)
+	}
+	if err := Install(http.DefaultClient, version); err != nil {
+		t.Fatalf("second Install (idempotent): %v", err)
+	}
+
+	st, _ := LoadState()
+	if st.Versions[version].Wanted != WantedRunning {
+		t.Errorf("idempotent re-install did not preserve wanted=running")
+	}
+}
+```
+
+- [ ] **Step 3: Rewrite uninstall.go**
+
+```go
+package redis
+
+import (
+	"os"
+	"time"
+
+	"github.com/prvious/pv/internal/binaries"
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/registry"
+)
+
+func Uninstall(version string, force bool) error {
+	if isInstalledOnDisk(version) {
+		_ = SetWanted(version, WantedStopped)
+		_ = WaitStopped(version, 10*time.Second)
+	}
+
+	if err := RemoveVersion(version); err != nil {
+		return err
+	}
+	if vs, err := binaries.LoadVersions(); err == nil {
+		delete(vs.Versions, "redis-"+version)
+		_ = vs.Save()
+	}
+	if reg, err := registry.Load(); err == nil {
+		reg.UnbindRedisVersion(version)
+		_ = reg.Save()
+	}
+
+	if err := os.RemoveAll(config.RedisVersionDir(version)); err != nil {
+		return err
+	}
+	_ = os.Remove(config.RedisLogPathV(version))
+	if force {
+		if err := os.RemoveAll(config.RedisDataDirV(version)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isInstalledOnDisk(version string) bool {
+	_, err := os.Stat(config.RedisVersionDir(version))
+	return err == nil
+}
+```
+
+- [ ] **Step 4: Rewrite uninstall_test.go**
+
+```go
+package redis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prvious/pv/internal/config"
+	"github.com/prvious/pv/internal/registry"
+)
+
+func TestUninstall_NonForce_KeepsDataDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	version := "8.6"
+
+	// Create fake install
+	versionDir := config.RedisVersionDir(version)
+	os.MkdirAll(versionDir, 0o755)
+	os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte("x"), 0o755)
+
+	dataDir := config.RedisDataDirV(version)
+	os.MkdirAll(dataDir, 0o755)
+	os.WriteFile(filepath.Join(dataDir, "dump.rdb"), []byte("data"), 0644)
+
+	SetWanted(version, WantedRunning)
+
+	// Bind a project
+	reg := registry.New()
+	reg.AddProject("myapp", "/tmp/myapp", "laravel")
+	reg.Projects[0].Services = &registry.ProjectServices{Redis: version}
+	reg.Save()
+
+	if err := Uninstall(version, false); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	// Binary tree removed
+	if _, err := os.Stat(versionDir); !os.IsNotExist(err) {
+		t.Error("expected binary dir removed")
+	}
+
+	// Data dir preserved
+	if _, err := os.Stat(dataDir); err != nil {
+		t.Error("expected data dir preserved")
+	}
+
+	// Registry unbound
+	reg2, _ := registry.Load()
+	if reg2.Projects[0].Services != nil && reg2.Projects[0].Services.Redis != "" {
+		t.Error("expected redis binding removed")
+	}
+}
+
+func TestUninstall_Force_RemovesDataDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	version := "8.6"
+
+	versionDir := config.RedisVersionDir(version)
+	os.MkdirAll(versionDir, 0o755)
+	os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte("x"), 0o755)
+
+	dataDir := config.RedisDataDirV(version)
+	os.MkdirAll(dataDir, 0o755)
+
+	if err := Uninstall(version, true); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	if _, err := os.Stat(dataDir); !os.IsNotExist(err) {
+		t.Error("expected data dir removed with --force")
+	}
+}
+```
+
+- [ ] **Step 5: Rewrite update.go**
+
+```go
+package redis
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/prvious/pv/internal/binaries"
+	"github.com/prvious/pv/internal/config"
+)
+
+func Update(client *http.Client, version string) error {
+	return UpdateProgress(client, version, nil)
+}
+
+func UpdateProgress(client *http.Client, version string, progress binaries.ProgressFunc) error {
+	if !IsInstalled(version) {
+		return fmt.Errorf("redis-%s is not installed", version)
+	}
+
+	prevWanted := WantedStopped
+	if st, err := LoadState(); err == nil {
+		if vs, ok := st.Versions[version]; ok && vs.Wanted != "" {
+			prevWanted = vs.Wanted
+		}
+	}
+
+	if prevWanted == WantedRunning {
+		_ = SetWanted(version, WantedStopped)
+		_ = WaitStopped(version, 10*time.Second)
+	}
+
+	url, err := resolveRedisURL()
+	if err != nil {
+		return err
+	}
+
+	versionDir := config.RedisVersionDir(version)
+	stagingDir := versionDir + ".new"
+	os.RemoveAll(stagingDir)
+	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
+		return fmt.Errorf("create staging: %w", err)
+	}
+
+	archive := filepath.Join(config.PvDir(), "redis-"+version+".tar.gz")
+	if err := binaries.DownloadProgress(client, url, archive, progress); err != nil {
+		os.RemoveAll(stagingDir)
+		return fmt.Errorf("download: %w", err)
+	}
+	if err := binaries.ExtractTarGzAll(archive, stagingDir); err != nil {
+		os.RemoveAll(stagingDir)
+		os.Remove(archive)
+		return fmt.Errorf("extract: %w", err)
+	}
+	os.Remove(archive)
+
+	oldDir := versionDir + ".old"
+	os.RemoveAll(oldDir)
+	if err := os.Rename(versionDir, oldDir); err != nil {
+		os.RemoveAll(stagingDir)
+		return fmt.Errorf("rename old: %w", err)
+	}
+	if err := os.Rename(stagingDir, versionDir); err != nil {
+		if rollbackErr := os.Rename(oldDir, versionDir); rollbackErr != nil {
+			return fmt.Errorf("rename new failed (%w); rollback also failed (%v); redis %s install dir is broken",
+				err, rollbackErr, version)
+		}
+		return fmt.Errorf("rename new: %w", err)
+	}
+	os.RemoveAll(oldDir)
+
+	if err := chownToTarget(versionDir); err != nil {
+		return fmt.Errorf("chown redis tree: %w", err)
+	}
+
+	if v, err := ProbeVersion(version); err == nil {
+		if vs, err := binaries.LoadVersions(); err == nil {
+			vs.Set("redis-"+version, v)
+			_ = vs.Save()
+		}
+	}
+
+	return SetWanted(version, prevWanted)
+}
+```
+
+- [ ] **Step 6: Build + test**
+
+Run: `go build ./internal/redis/... && go test ./internal/redis/...`
+Expected: all internal/redis/ tests PASS
+
+- [ ] **Step 7: Commit**
+
+```
+git add internal/redis/install.go internal/redis/install_test.go
+git add internal/redis/uninstall.go internal/redis/uninstall_test.go
+git add internal/redis/update.go internal/redis/update_test.go
+git commit -m "feat(redis): version-aware install, uninstall, update"
+```
+
+---
+
+### Task 8: Commands layer — version arg with default
+
+**Files:**
+- Modify: `internal/commands/redis/register.go`
+- Modify: `internal/commands/redis/install.go`
+- Modify: `internal/commands/redis/uninstall.go`
+- Modify: `internal/commands/redis/update.go`
+- Modify: `internal/commands/redis/start.go`
+- Modify: `internal/commands/redis/stop.go`
+- Modify: `internal/commands/redis/restart.go`
+- Modify: `internal/commands/redis/status.go`
+- Modify: `internal/commands/redis/list.go`
+- Modify: `internal/commands/redis/logs.go`
+- Modify: `internal/commands/redis/download.go`
+
+Each command gets an optional `version` arg defaulting to `config.RedisDefaultVersion()`.
+
+- [ ] **Step 1: Rewrite register.go** — add a shared helper `resolveVersion`
+
+Add at top of register.go:
+```go
+import "github.com/prvious/pv/internal/config"
+
+func resolveVersion(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	return config.RedisDefaultVersion()
+}
+```
+
+- [ ] **Step 2: Rewrite install.go**
+
+```go
+var installCmd = &cobra.Command{
+	Use:     "redis:install [version]",
+	GroupID: "redis",
+	Short:   "Install (or re-install) Redis",
+	Long:    "Downloads the Redis binary and registers it as wanted-running.",
+	Example: `pv redis:install`,
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+		if r.IsInstalled(version) {
+			if err := r.SetWanted(version, r.WantedRunning); err != nil {
+				return err
+			}
+			ui.Success(fmt.Sprintf("Redis %s already installed — marked as wanted running.", version))
+			return signalDaemon()
+		}
+		if err := downloadCmd.RunE(downloadCmd, []string{version}); err != nil {
+			return err
+		}
+		ui.Success(fmt.Sprintf("Redis %s installed.", version))
+		return signalDaemon()
+	},
+}
+```
+
+- [ ] **Step 3: Rewrite uninstall.go**
+
+```go
+var uninstallForce bool
+
+var uninstallCmd = &cobra.Command{
+	Use:     "redis:uninstall [version]",
+	GroupID: "redis",
+	Short:   "Stop, remove the binary, and (with --force) DELETE the data directory",
+	Long: "Stops the supervised process and removes the binary tree at " +
+		"~/.pv/redis/{version}/. With --force, also removes the data directory. " +
+		"Unbinds every linked project bound to that version.",
+	Example: `pv redis:uninstall --force`,
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+		if !r.IsInstalled(version) {
+			ui.Subtle(fmt.Sprintf("Redis %s is not installed.", version))
+			return nil
+		}
+		if !uninstallForce {
+			confirmed := false
+			if err := huh.NewConfirm().
+				Title(fmt.Sprintf("Remove Redis %s? With --force this also DELETES the data directory.", version)).
+				Affirmative("Yes").
+				Negative("No").
+				Value(&confirmed).
+				Run(); err != nil {
+				return err
+			}
+			if !confirmed {
+				return fmt.Errorf("aborted")
+			}
+		}
+
+		if err := r.SetWanted(version, r.WantedStopped); err != nil {
+			return err
+		}
+		if server.IsRunning() {
+			if err := server.SignalDaemon(); err != nil {
+				return fmt.Errorf("signal daemon: %w", err)
+			}
+			if err := r.WaitStopped(version, 10*time.Second); err != nil {
+				return fmt.Errorf("waiting for redis to stop: %w", err)
+			}
+		}
+
+		if err := ui.Step(fmt.Sprintf("Uninstalling Redis %s...", version), func() (string, error) {
+			if err := r.Uninstall(version, uninstallForce); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Uninstalled Redis %s", version), nil
+		}); err != nil {
+			return err
+		}
+
+		ui.Success(fmt.Sprintf("Redis %s uninstalled.", version))
+		return nil
+	},
+}
+
+func init() {
+	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "Skip the confirmation prompt and delete the data directory")
+}
+```
+
+- [ ] **Step 4: Rewrite update.go**
+
+```go
+var updateCmd = &cobra.Command{
+	Use:     "redis:update [version]",
+	GroupID: "redis",
+	Short:   "Re-download and re-install the Redis binary",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+		if !r.IsInstalled(version) {
+			ui.Subtle(fmt.Sprintf("Redis %s is not installed.", version))
+			return nil
+		}
+		if err := ui.Step(fmt.Sprintf("Updating Redis %s...", version), func() (string, error) {
+			client := &http.Client{}
+			if err := r.UpdateProgress(client, version, ui.ProgressBar("Downloading Redis...")); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Redis %s updated.", version), nil
+		}); err != nil {
+			return err
+		}
+		ui.Success(fmt.Sprintf("Redis %s updated.", version))
+		return signalDaemon()
+	},
+}
+```
+
+- [ ] **Step 5: Rewrite start.go**
+
+```go
+var startCmd = &cobra.Command{
+	Use:     "redis:start [version]",
+	GroupID: "redis",
+	Short:   "Mark Redis as wanted-running",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+		if !r.IsInstalled(version) {
+			ui.Subtle(fmt.Sprintf("Redis %s is not installed (run `pv redis:install %s`).", version, version))
+			return nil
+		}
+		if err := r.SetWanted(version, r.WantedRunning); err != nil {
+			return err
+		}
+		ui.Success(fmt.Sprintf("Redis %s marked running.", version))
+		if server.IsRunning() {
+			return server.SignalDaemon()
+		}
+		ui.Subtle("daemon not running — will start on next `pv start`")
+		return nil
+	},
+}
+```
+
+- [ ] **Step 6: Rewrite stop.go**
+
+```go
+var stopCmd = &cobra.Command{
+	Use:     "redis:stop [version]",
+	GroupID: "redis",
+	Short:   "Mark Redis as wanted-stopped",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+		if err := r.SetWanted(version, r.WantedStopped); err != nil {
+			return err
+		}
+		ui.Success(fmt.Sprintf("Redis %s marked stopped.", version))
+		if server.IsRunning() {
+			return server.SignalDaemon()
+		}
+		return nil
+	},
+}
+```
+
+- [ ] **Step 7: Rewrite restart.go**
+
+```go
+var restartCmd = &cobra.Command{
+	Use:     "redis:restart [version]",
+	GroupID: "redis",
+	Short:   "Stop and start Redis",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+		if !r.IsInstalled(version) {
+			ui.Subtle(fmt.Sprintf("Redis %s is not installed.", version))
+			return nil
+		}
+		if err := r.SetWanted(version, r.WantedStopped); err != nil {
+			return err
+		}
+		if server.IsRunning() {
+			if err := server.SignalDaemon(); err != nil {
+				return fmt.Errorf("signal daemon: %w", err)
+			}
+			if err := r.WaitStopped(version, 10*time.Second); err != nil {
+				return fmt.Errorf("waiting for redis to stop: %w", err)
+			}
+		}
+		if err := r.SetWanted(version, r.WantedRunning); err != nil {
+			return err
+		}
+		if server.IsRunning() {
+			if err := server.SignalDaemon(); err != nil {
+				return err
+			}
+		}
+		ui.Success(fmt.Sprintf("Redis %s restarted.", version))
+		return nil
+	},
+}
+```
+
+- [ ] **Step 8: Rewrite status.go**
+
+```go
+var statusCmd = &cobra.Command{
+	Use:     "redis:status [version]",
+	GroupID: "redis",
+	Short:   "Show Redis status",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+		if !r.IsInstalled(version) {
+			ui.Subtle(fmt.Sprintf("Redis %s is not installed.", version))
+			return nil
+		}
+		status, _ := server.ReadDaemonStatus()
+		supKey := "redis-" + version
+		if status != nil {
+			if s, ok := status.Supervised[supKey]; ok && s.Running {
+				ui.Success(fmt.Sprintf("redis-%s: running on :%d (pid %d)", version, r.PortFor(version), s.PID))
+				return nil
+			}
+		}
+		ui.Subtle(fmt.Sprintf("redis-%s: stopped", version))
+		return nil
+	},
+}
+```
+
+- [ ] **Step 9: Rewrite list.go**
+
+```go
+var listCmd = &cobra.Command{
+	Use:     "redis:list",
+	GroupID: "redis",
+	Short:   "Show Redis versions and status",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		versions, err := r.InstalledVersions()
+		if err != nil {
+			return err
+		}
+		if len(versions) == 0 {
+			ui.Subtle("Redis is not installed.")
+			return nil
+		}
+
+		st, _ := r.LoadState()
+		vs, _ := binaries.LoadVersions()
+		reg, _ := registry.Load()
+		status, _ := server.ReadDaemonStatus()
+
+		var rows [][]string
+		for _, version := range versions {
+			precise := "?"
+			if vs != nil {
+				if v := vs.Get("redis-" + version); v != "" {
+					precise = v
+				}
+			}
+
+			supKey := "redis-" + version
+			runState := "stopped"
+			if status != nil {
+				if s, ok := status.Supervised[supKey]; ok && s.Running {
+					runState = "running"
+				}
+			}
+			wanted := ""
+			if vs, ok := st.Versions[version]; ok {
+				wanted = vs.Wanted
+			}
+			if wanted == "" {
+				wanted = "—"
+			}
+
+			projects := []string{}
+			if reg != nil {
+				for _, p := range reg.List() {
+					if p.Services != nil && p.Services.Redis == version {
+						projects = append(projects, p.Name)
+					}
+				}
+			}
+			projectsCol := "—"
+			if len(projects) > 0 {
+				projectsCol = strings.Join(projects, ",")
+			}
+
+			rows = append(rows, []string{
+				version,
+				precise,
+				fmt.Sprintf("%d", r.PortFor(version)),
+				fmt.Sprintf("%s (%s)", runState, wanted),
+				config.RedisDataDirV(version),
+				projectsCol,
+			})
+		}
+		ui.Table([]string{"VERSION", "PRECISE", "PORT", "STATUS", "DATA DIR", "LINKED PROJECTS"}, rows)
+		return nil
+	},
+}
+```
+
+- [ ] **Step 10: Rewrite logs.go**
+
+```go
+var logsCmd = &cobra.Command{
+	Use:     "redis:logs [version]",
+	GroupID: "redis",
+	Short:   "Tail the Redis log file",
+	Long:    "Reads ~/.pv/logs/redis-{version}.log. With -f / --follow, tails the file.",
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+		path := config.RedisLogPathV(version)
+		// ... rest same as before
+	},
+}
+```
+
+- [ ] **Step 11: Rewrite download.go**
+
+```go
+var downloadCmd = &cobra.Command{
+	Use:     "redis:download [version]",
+	GroupID: "redis",
+	Short:   "Download the Redis binary (without marking wanted-running)",
+	Long:    "Hidden — debug only. Downloads and extracts the redis tarball but does not mark wanted=running.",
+	Hidden:  true,
+	Args:    cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+		client := &http.Client{}
+		return r.InstallProgress(client, version, ui.ProgressBar("Downloading Redis..."))
+	},
+}
+```
+
+- [ ] **Step 12: Update `register.go` Run* helpers and `UninstallForce`**
+
+```go
+func RunInstall(args []string) error {
+	return installCmd.RunE(installCmd, args)
+}
+
+func RunUpdate(args []string) error {
+	return updateCmd.RunE(updateCmd, args)
+}
+
+func RunUninstall(args []string) error {
+	return uninstallCmd.RunE(uninstallCmd, args)
+}
+
+func UninstallForce(version string) error {
+	prev := uninstallForce
+	uninstallForce = true
+	defer func() { uninstallForce = prev }()
+	return uninstallCmd.RunE(uninstallCmd, []string{version})
+}
+```
+
+- [ ] **Step 13: Build + test**
+
+Run: `go build ./internal/commands/redis/... && go test ./internal/commands/redis/...`
+Expected: PASS
+
+- [ ] **Step 14: Commit**
+
+```
+git add internal/commands/redis/
+git commit -m "feat(redis): version arg on all redis:* commands"
+```
+
+---
+
+### Task 9: Manager — WantedVersions iteration
+
+**Files:**
+- Modify: `internal/server/manager.go`
+- Modify: `internal/server/manager_test.go`
+
+- [ ] **Step 1: Update manager.go**
+
+Replace the flat redis wanted-set source:
+
+Before (lines 244-252):
+```go
+// Source 4 — redis, single-version, filesystem + state.json.
+if redis.IsWanted() {
+    proc, err := redis.BuildSupervisorProcess()
+    if err != nil {
+        startErrors = append(startErrors, fmt.Sprintf("redis: build: %v", err))
+    } else {
+        wanted["redis"] = proc
+    }
+}
+```
+
+After:
+```go
+// Source 4 — redis, multi-version via WantedVersions.
+rdVersions, rdErr := redis.WantedVersions()
+if rdErr != nil {
+    fmt.Fprintf(os.Stderr, "reconcile binary: redis.WantedVersions: %v\n", rdErr)
+}
+for _, version := range rdVersions {
+    proc, err := redis.BuildSupervisorProcess(version)
+    if err != nil {
+        startErrors = append(startErrors, fmt.Sprintf("redis-%s: build: %v", version, err))
+        continue
+    }
+    wanted["redis-"+version] = proc
+}
+```
+
+Also add `rdErr` to the transient-error guard for redis keys:
+```go
+if rdErr != nil && strings.HasPrefix(supKey, "redis-") {
+    continue
+}
+```
+
+- [ ] **Step 2: Update manager_test.go**
+
+Update `TestReconcileBinaryServices_StartsWantedRedis`:
+
+```go
+func TestReconcileBinaryServices_StartsWantedRedis(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skipf("fake binary helper not supported on %s", runtime.GOOS)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	version := config.RedisDefaultVersion()
+	versionDir := config.RedisVersionDir(version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", filepath.Join(versionDir, "redis-server"),
+		filepath.Join("..", "..", "internal", "redis", "testdata", "fake-redis-server.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fake redis-server: %v\n%s", err, out)
+	}
+
+	if err := redis.SetWanted(version, redis.WantedRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	sup := supervisor.New()
+	mgr := NewServerManager(nil, sup)
+	defer sup.StopAll(2 * time.Second)
+
+	if err := mgr.reconcileBinaryServices(context.Background()); err != nil {
+		t.Fatalf("reconcileBinaryServices: %v", err)
+	}
+
+	supKey := "redis-" + version
+	if !sup.IsRunning(supKey) {
+		t.Errorf("expected %s to be supervised after reconcile", supKey)
+	}
+}
+```
+
+And `TestReconcileBinaryServices_StopsRemovedRedis`:
+
+```go
+func TestReconcileBinaryServices_StopsRemovedRedis(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skipf("fake binary helper not supported on %s", runtime.GOOS)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	version := config.RedisDefaultVersion()
+	versionDir := config.RedisVersionDir(version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", filepath.Join(versionDir, "redis-server"),
+		filepath.Join("..", "..", "internal", "redis", "testdata", "fake-redis-server.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fake redis-server: %v\n%s", err, out)
+	}
+
+	if err := redis.SetWanted(version, redis.WantedRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	sup := supervisor.New()
+	mgr := NewServerManager(nil, sup)
+	defer sup.StopAll(2 * time.Second)
+
+	supKey := "redis-" + version
+	if err := mgr.reconcileBinaryServices(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !sup.IsRunning(supKey) {
+		t.Fatal("expected redis running after first reconcile")
+	}
+
+	if err := redis.SetWanted(version, redis.WantedStopped); err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.reconcileBinaryServices(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if sup.IsRunning(supKey) {
+		t.Error("expected redis stopped after wanted flipped to stopped")
+	}
+}
+```
+
+- [ ] **Step 3: Build + test**
+
+Run: `go build ./internal/server/... && go test ./internal/server/...`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```
+git add internal/server/manager.go internal/server/manager_test.go
+git commit -m "feat(redis): reconcile over WantedVersions"
+```
+
+---
+
+### Task 10: cmd/ orchestrators, setup, laravel/automation
+
+**Files:**
+- Modify: `cmd/update.go`
+- Modify: `cmd/uninstall.go`
+- Modify: `cmd/setup.go`
+- Modify: `internal/automation/steps/apply_pvyml_services.go`
+- Modify: `internal/automation/steps/apply_pvyml_env.go`
+
+- [ ] **Step 1: Update cmd/update.go — iterate over InstalledVersions**
+
+Replace the flat `r.IsInstalled()` block (lines 111-120) with iteration:
+
+```go
+// Update each installed redis version. Mirrors the mysql pass.
+if versions, err := r.InstalledVersions(); err == nil {
+    for _, version := range versions {
+        if err := rediscmd.RunUpdate([]string{version}); err != nil {
+            if !errors.Is(err, ui.ErrAlreadyPrinted) {
+                ui.Fail(fmt.Sprintf("Redis %s update failed: %v", version, err))
+            }
+            failures = append(failures, "Redis "+version)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Update cmd/uninstall.go — iterate over InstalledVersions**
+
+Replace the flat `r.IsInstalled()` block (lines 235-244):
+
+Before:
+```go
+// Redis uninstall (single-version).
+if r.IsInstalled() {
+    if err := rediscmd.UninstallForce(); err != nil {
+```
+
+After:
+```go
+// Redis uninstall (per installed version). Matches postgres/mysql pattern.
+if versions, err := r.InstalledVersions(); err == nil {
+    for _, version := range versions {
+        if err := rediscmd.UninstallForce(version); err != nil {
+            hadFailures = true
+            if !errors.Is(err, ui.ErrAlreadyPrinted) {
+                ui.Fail(fmt.Sprintf("redis %s uninstall failed: %v", version, err))
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Update cmd/setup.go — pass version to RunInstall**
+
+Line 221-227, change:
+```go
+if toolSet["redis"] {
+    if err := rediscmd.RunInstall(nil); err != nil {
+```
+to:
+```go
+if toolSet["redis"] {
+    if err := rediscmd.RunInstall([]string{config.RedisDefaultVersion()}); err != nil {
+```
+
+Add `config "github.com/prvious/pv/internal/config"` to setup.go imports.
+
+- [ ] **Step 4: Update apply_pvyml_services.go**
+
+Change the redis block (lines 62-67) to use version:
+
+```go
+if cfg.Redis != nil {
+    version := config.RedisDefaultVersion()
+    if !redis.IsInstalled(version) {
+        return "", fmt.Errorf("pv.yml redis %s is not installed — run `pv redis:install %s`", version, version)
+    }
+    bindProjectService(ctx.Registry, ctx.ProjectName, "redis", "redis")
+    count++
+}
+```
+
+Change `bindProjectService` function (line 109):
+```go
+case "redis":
+    reg.Projects[i].Services.Redis = config.RedisDefaultVersion()
+```
+
+Add `"github.com/prvious/pv/internal/config"` to imports.
+
+- [ ] **Step 5: Update apply_pvyml_env.go**
+
+The `redis.TemplateVars()` call at line 81 needs a version param. Change:
+```go
+if err := renderIntoMap(rendered, cfg.Redis.Env, redis.TemplateVars(), "redis.env"); err != nil {
+```
+to:
+```go
+if err := renderIntoMap(rendered, cfg.Redis.Env, redis.TemplateVars(config.RedisDefaultVersion()), "redis.env"); err != nil {
+```
+
+- [ ] **Step 6: Build all**
+
+Run: `go build ./... && go vet ./...`
+Expected: no errors
+
+- [ ] **Step 7: Run all tests**
+
+Run: `go test ./...`
+Expected: all PASS
+
+- [ ] **Step 8: Commit**
+
+```
+git add cmd/update.go cmd/uninstall.go cmd/setup.go
+git add internal/automation/steps/apply_pvyml_services.go
+git add internal/automation/steps/apply_pvyml_env.go
+git commit -m "feat(redis): update orchestrators and automation for versioned redis"
+```
+
+---
+
+### Task 11: Format, vet, final build, cleanup
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Format everything**
+
+Run: `gofmt -w .`
+
+- [ ] **Step 2: Vet**
+
+Run: `go vet ./...`
+Expected: clean
+
+- [ ] **Step 3: Final full test**
+
+Run: `go test ./...`
+Expected: all PASS
+
+- [ ] **Step 4: Final commit**
+
+```
+git add -A
+git commit -m "chore(redis): gofmt, vet, final cleanup"
+```

--- a/docs/superpowers/specs/2026-05-12-redis-versioned-shape-design.md
+++ b/docs/superpowers/specs/2026-05-12-redis-versioned-shape-design.md
@@ -1,0 +1,308 @@
+# Redis versioned shape (align with postgres/mysql)
+
+## Goal
+
+Refactor `internal/redis/` from a flat single-version package to a
+version-parameterized shape matching `internal/mysql/` and
+`internal/postgres/`. The public API takes a `version string` everywhere;
+paths become `~/.pv/redis/{version}/`. Only one version is shipped
+(currently 8.6), but the API supports multiple.
+
+This is the consistency step before extracting a shared interface across
+all three binary-service packages.
+
+## Scope
+
+- All `internal/redis/` functions grow a `version string` parameter.
+- Binary path: `~/.pv/redis/{version}/` (was `~/.pv/redis/`).
+- Data path: `~/.pv/data/redis/{version}/` (was `~/.pv/data/redis/`).
+- Log path: `~/.pv/logs/redis-{version}.log` (was `~/.pv/logs/redis.log`).
+- State: versioned map matching mysql — `{"redis": {"versions": {"8.6": {"wanted": "running"}}}}`.
+- Registry: `ProjectServices.Redis` changes from `bool` to `string`.
+- Supervisor key: `redis-{version}` (was `redis`).
+- Manager iteration: mirrors mysql's `WantedVersions()` loop.
+- Default version: `"8.6"` — used whenever caller omits.
+
+## Filesystem layout
+
+```
+~/.pv/
+├── redis/
+│   ├── 7.4/                              (if installed)
+│   │   ├── redis-server
+│   │   └── redis-cli
+│   └── 8.6/                              (default)
+│       ├── redis-server
+│       └── redis-cli
+├── data/
+│   └── redis/
+│       ├── 7.4/
+│       │   └── dump.rdb
+│       └── 8.6/
+│           └── dump.rdb
+└── logs/
+    ├── redis-7.4.log
+    └── redis-8.6.log
+```
+
+## Config paths
+
+```go
+// New:
+func RedisVersionDir(version string) string    // ~/.pv/redis/{version}/
+func RedisDataDir(version string) string       // ~/.pv/data/redis/{version}/
+func RedisLogPath(version string) string       // ~/.pv/logs/redis-{version}.log
+func RedisDefaultVersion() string              // "8.6"
+
+// Stay:
+func RedisDir() string                         // ~/.pv/redis/ (parent)
+func RedisDataRoot() string                    // ~/.pv/data/redis/ (parent)
+```
+
+`RedisVersionDir` is the binary root (matching postgres where `PostgresBinDir(major)` is the version dir itself — no separate `bin/` subdirectory).
+
+## State shape
+
+Matches mysql exactly. Flat `{"wanted": "running"}` replaced by versioned map:
+
+```go
+type State struct {
+    Versions map[string]VersionState `json:"versions"`
+}
+type VersionState struct {
+    Wanted string `json:"wanted"`
+}
+```
+
+On-disk shape:
+
+```json
+{
+  "postgres": { "majors": { "17": { "wanted": "running" } } },
+  "mysql":    { "versions": { "8.4": { "wanted": "running" } } },
+  "redis":    { "versions": { "8.6": { "wanted": "running" } } }
+}
+```
+
+Functions:
+- `LoadState()` → `State` (with `Versions` map, never nil)
+- `SaveState(s State)` → writes the `"redis"` slice
+- `SetWanted(version, wanted)` → validates + saves
+- `RemoveVersion(version)` → deletes one version from map
+- `WantedVersions()` → returns wanted+running versions (mirrors mysql's `WantedVersions`)
+- `InstalledVersions()` → lists version dirs on disk with valid binaries
+
+## Public API changes
+
+Every function that currently takes no version parameter grows one:
+
+| Current | New |
+|---|---|
+| `Install(client)` | `Install(client, version)` |
+| `InstallProgress(client, progress)` | `InstallProgress(client, version, progress)` |
+| `Uninstall(force)` | `Uninstall(version, force)` |
+| `Update(client)` | `Update(client, version)` |
+| `IsInstalled()` | `IsInstalled(version)` |
+| `IsWanted()` | (removed — replaced by `WantedVersions()`) |
+| `SetWanted(wanted)` | `SetWanted(version, wanted)` |
+| `ProbeVersion()` | `ProbeVersion(version)` |
+| `BuildSupervisorProcess()` | `BuildSupervisorProcess(version)` |
+| `PortFor()` | `PortFor(version)` |
+| `EnvVars(projectName)` | `EnvVars(version, projectName)` |
+| `ServerBinary()` | `ServerBinary(version)` |
+| `CLIBinary()` | `CLIBinary(version)` |
+
+New:
+- `WantedVersions()` → `[]string`
+- `InstalledVersions()` → `[]string`
+- `RemoveVersion(version)` — state cleanup
+- `BindLinkedProjects(version)` — retroactive auto-bind
+- `WaitStopped(version, timeout)` — per-version port wait
+
+## Install flow
+
+```
+Install(client, version):
+  1. Resolve URL (version-agnostic — we only ship one artifact)
+  2. Download + extract into staging, then rename to ~/.pv/redis/{version}/
+  3. chown tree to SUDO_USER
+  4. Create data dir: ~/.pv/data/redis/{version}/, chown
+  5. Probe redis-server --version, record in versions.json as "redis-{version}"
+  6. SetWanted(version, WantedRunning)
+  7. BindLinkedProjects(version)
+  8. Signal daemon
+```
+
+## Uninstall flow
+
+```
+Uninstall(version, force):
+  1. SetWanted(version, WantedStopped) + signal daemon
+  2. WaitStopped(version, 10s)
+  3. Remove ~/.pv/redis/{version}/
+  4. Remove ~/.pv/logs/redis-{version}.log
+  5. If force: remove ~/.pv/data/redis/{version}/
+  6. RemoveState entry for version
+  7. Remove "redis-{version}" from versions.json
+  8. reg.UnbindRedisVersion(version)
+```
+
+## Update flow
+
+```
+Update(client, version):
+  1. wasWanted = SetWanted(version, WantedStopped) -> signal + wait
+  2. Redownload + extract via staging-rename over ~/.pv/redis/{version}/
+  3. Probe version, update versions.json
+  4. If wasWanted: SetWanted(version, WantedRunning) -> signal
+```
+
+## Port allocation
+
+`PortFor(version)` returns a version-aware port matching mysql's formula:
+`6300 + major*100 + minor*10`. Examples: 7.4 → 6740, 8.6 → 6860.
+
+The constant `RedisPort = 6379` is removed.
+
+## Process / supervisor
+
+`BuildSupervisorProcess(version)` uses version-specific paths:
+
+```go
+func BuildSupervisorProcess(version string) (supervisor.Process, error) {
+    binPath := filepath.Join(config.RedisVersionDir(version), "redis-server")
+    return supervisor.Process{
+        Name:    "redis-" + version,
+        Binary:  binPath,
+        Args:    buildRedisArgs(version),
+        LogFile: config.RedisLogPath(version),
+        ...
+    }
+}
+```
+
+`buildRedisArgs(version)` uses `PortFor(version)` and `RedisDataDir(version)`.
+
+## Manager integration
+
+The flat `redis.IsWanted()` call becomes a versioned iteration, mirroring the mysql block:
+
+```go
+// Before:
+if redis.IsWanted() {
+    proc, err := redis.BuildSupervisorProcess()
+    wanted["redis"] = proc
+}
+
+// After:
+rdVersions, rdErr := redis.WantedVersions()
+for _, version := range rdVersions {
+    proc, err := redis.BuildSupervisorProcess(version)
+    wanted["redis-"+version] = proc
+}
+```
+
+Transient-error guard for redis follows the same pattern as postgres/mysql.
+
+## Registry changes
+
+`ProjectServices.Redis` changes from `bool` to `string` (JSON tag:
+`"redis,omitempty"`). Semantics: the string holds the version bound to
+the project. Empty string means "not bound."
+
+New helpers in registry.go:
+
+```go
+func (r *Registry) UnbindRedisVersion(version string) {
+    for i := range r.Projects {
+        if r.Projects[i].Services == nil { continue }
+        if r.Projects[i].Services.Redis == version {
+            r.Projects[i].Services.Redis = ""
+        }
+    }
+}
+```
+
+`UnbindService("redis")` is updated to clear `Services.Redis` to `""`
+instead of `false`.
+
+## Commands layer
+
+Every `redis:*` command grows an optional `version` arg, defaulting to
+`config.RedisDefaultVersion()`:
+
+| Command | Args |
+|---|---|
+| `redis:install [version]` | Defaults to 8.6 |
+| `redis:uninstall [version] [--force]` | Defaults to 8.6 |
+| `redis:update [version]` | Defaults to 8.6 |
+| `redis:start [version]` | Defaults to 8.6 |
+| `redis:stop [version]` | Defaults to 8.6 |
+| `redis:restart [version]` | Defaults to 8.6 |
+| `redis:list` | Shows all installed versions |
+| `redis:status [version]` | Defaults to 8.6 |
+| `redis:logs [version] [-f]` | Defaults to 8.6 |
+| `redis:download [version]` | Hidden, debug only |
+
+`redis:list` becomes a multi-row table when multiple versions are
+installed (matching `mysql:list`).
+
+## Environment variables
+
+`EnvVars(version, projectName)` returns the same values as before but
+uses `PortFor(version)` for `REDIS_PORT`:
+
+```go
+func EnvVars(version, projectName string) map[string]string {
+    return map[string]string{
+        "REDIS_HOST":     "127.0.0.1",
+        "REDIS_PORT":     strconv.Itoa(PortFor(version)),
+        "REDIS_PASSWORD": "null",
+    }
+}
+```
+
+Auto-bind on install and `pv link` use `version` to set
+`Services.Redis = version`.
+
+## Files touched
+
+```
+internal/redis/           — all files: public API changes
+internal/config/paths.go  — RedisVersionDir, RedisDataDir(version), RedisLogPath(version),
+                           RedisDefaultVersion, RedisDataRoot
+internal/registry/
+  ├── registry.go         — ProjectServices.Redis bool → string; UnbindRedisVersion
+  └── registry_test.go    — update tests
+internal/server/
+  └── manager.go          — redis block: iteration over WantedVersions()
+internal/commands/redis/  — all commands: version arg with default
+cmd/
+  ├── redis.go            — bridge (no change unless version plumbing needed)
+  ├── install.go          — pass version to RunInstall
+  ├── update.go           — pass version to RunUpdate
+  └── uninstall.go        — pass version to RunUninstall
+internal/laravel/
+  ├── env.go              — redis envvar path uses version
+  └── steps.go            — DetectServicesStep sets Services.Redis = version
+internal/automation/steps/
+  └── detect_services.go  — set Services.Redis = version
+docs/superpowers/specs/
+  └── 2026-05-09-redis-native-binary-design.md  — superseded; reference kept
+```
+
+## Locked decisions
+
+| Topic | Old | New |
+|---|---|---|
+| Version | Single, no param | Version-parameterized, defaults to 8.6 |
+| Binary path | `~/.pv/redis/` | `~/.pv/redis/{version}/` |
+| Data path | `~/.pv/data/redis/` | `~/.pv/data/redis/{version}/` |
+| Log path | `~/.pv/logs/redis.log` | `~/.pv/logs/redis-{version}.log` |
+| State shape | `{"wanted": "running"}` | `{"versions": {"8.6": {"wanted": "running"}}}` |
+| Registry binding | `Redis bool` | `Redis string` (version) |
+| Supervisor key | `redis` | `redis-{version}` |
+| Port | 6379 (constant) | `6300 + major*100 + minor*10` |
+| Unbind | `UnbindService("redis")` | `UnbindRedisVersion(version)` |
+| Default version | N/A | `"8.6"` |
+| Multi-version | Not supported | API supports it (only ship one) |

--- a/internal/automation/steps/apply_pvyml_env.go
+++ b/internal/automation/steps/apply_pvyml_env.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 
 	"github.com/prvious/pv/internal/automation"
-	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/mailpit"
 	"github.com/prvious/pv/internal/mysql"
 	"github.com/prvious/pv/internal/postgres"
@@ -79,7 +78,11 @@ func (s *ApplyPvYmlEnvStep) Run(ctx *automation.Context) (string, error) {
 
 	// redis.env
 	if cfg.Redis != nil && len(cfg.Redis.Env) > 0 {
-		if err := renderIntoMap(rendered, cfg.Redis.Env, redis.TemplateVars(config.RedisDefaultVersion()), "redis.env"); err != nil {
+		version, err := redis.ResolveVersion(cfg.Redis.Version)
+		if err != nil {
+			return "", err
+		}
+		if err := renderIntoMap(rendered, cfg.Redis.Env, redis.TemplateVars(version), "redis.env"); err != nil {
 			return "", err
 		}
 	}

--- a/internal/automation/steps/apply_pvyml_env.go
+++ b/internal/automation/steps/apply_pvyml_env.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/mailpit"
 	"github.com/prvious/pv/internal/mysql"
 	"github.com/prvious/pv/internal/postgres"
@@ -78,7 +79,7 @@ func (s *ApplyPvYmlEnvStep) Run(ctx *automation.Context) (string, error) {
 
 	// redis.env
 	if cfg.Redis != nil && len(cfg.Redis.Env) > 0 {
-		if err := renderIntoMap(rendered, cfg.Redis.Env, redis.TemplateVars(), "redis.env"); err != nil {
+		if err := renderIntoMap(rendered, cfg.Redis.Env, redis.TemplateVars(config.RedisDefaultVersion()), "redis.env"); err != nil {
 			return "", err
 		}
 	}

--- a/internal/automation/steps/apply_pvyml_env_test.go
+++ b/internal/automation/steps/apply_pvyml_env_test.go
@@ -118,8 +118,8 @@ func TestApplyPvYmlEnv_RendersRedisEnv(t *testing.T) {
 	s := string(body)
 	for _, want := range []string{
 		"REDIS_HOST=127.0.0.1",
-		"REDIS_PORT=6379",
-		"REDIS_URL=redis://127.0.0.1:6379",
+		"REDIS_PORT=7160",
+		"REDIS_URL=redis://127.0.0.1:7160",
 	} {
 		if !strings.Contains(s, want) {
 			t.Errorf(".env missing %q\n%s", want, s)

--- a/internal/automation/steps/apply_pvyml_env_test.go
+++ b/internal/automation/steps/apply_pvyml_env_test.go
@@ -127,6 +127,33 @@ func TestApplyPvYmlEnv_RendersRedisEnv(t *testing.T) {
 	}
 }
 
+func TestApplyPvYmlEnv_RejectsUnsupportedRedisVersion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	projDir := t.TempDir()
+	ctx := &automation.Context{
+		ProjectName: "myapp",
+		ProjectPath: projDir,
+		TLD:         "test",
+		ProjectConfig: &config.ProjectConfig{
+			Redis: &config.ServiceConfig{
+				Version: "7.4",
+				Env: map[string]string{
+					"REDIS_PORT": "{{ .port }}",
+				},
+			},
+		},
+	}
+	step := &ApplyPvYmlEnvStep{}
+	_, err := step.Run(ctx)
+	if err == nil {
+		t.Fatal("Run: want error for unsupported redis version")
+	}
+	if !strings.Contains(err.Error(), "unsupported redis version") {
+		t.Errorf("err = %v; want unsupported redis version", err)
+	}
+}
+
 func TestApplyPvYmlEnv_ShouldRunFalseWithoutEnv(t *testing.T) {
 	ctx := &automation.Context{
 		ProjectConfig: &config.ProjectConfig{PHP: "8.4"},

--- a/internal/automation/steps/apply_pvyml_services.go
+++ b/internal/automation/steps/apply_pvyml_services.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/prvious/pv/internal/automation"
+	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/mysql"
 	"github.com/prvious/pv/internal/postgres"
 	"github.com/prvious/pv/internal/redis"
@@ -60,10 +61,11 @@ func (s *ApplyPvYmlServicesStep) Run(ctx *automation.Context) (string, error) {
 	}
 
 	if cfg.Redis != nil {
-		if !redis.IsInstalled() {
-			return "", fmt.Errorf("pv.yml redis is not installed — run `pv redis:install`")
+		version := config.RedisDefaultVersion()
+		if !redis.IsInstalled(version) {
+			return "", fmt.Errorf("pv.yml redis %s is not installed — run `pv redis:install %s`", version, version)
 		}
-		bindProjectService(ctx.Registry, ctx.ProjectName, "redis", "redis")
+		bindProjectRedis(ctx.Registry, ctx.ProjectName, version)
 		count++
 	}
 
@@ -105,14 +107,25 @@ func bindProjectService(reg *registry.Registry, projectName, svcType, svcKey str
 			reg.Projects[i].Services = &registry.ProjectServices{}
 		}
 		switch svcType {
-		case "redis":
-			reg.Projects[i].Services.Redis = true
 		case "mail":
 			reg.Projects[i].Services.Mail = true
 		case "s3":
 			reg.Projects[i].Services.S3 = true
 		}
 		break
+	}
+}
+
+func bindProjectRedis(reg *registry.Registry, projectName, version string) {
+	for i := range reg.Projects {
+		if reg.Projects[i].Name != projectName {
+			continue
+		}
+		if reg.Projects[i].Services == nil {
+			reg.Projects[i].Services = &registry.ProjectServices{}
+		}
+		reg.Projects[i].Services.Redis = version
+		return
 	}
 }
 

--- a/internal/automation/steps/apply_pvyml_services.go
+++ b/internal/automation/steps/apply_pvyml_services.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/prvious/pv/internal/automation"
-	"github.com/prvious/pv/internal/config"
 	"github.com/prvious/pv/internal/mysql"
 	"github.com/prvious/pv/internal/postgres"
 	"github.com/prvious/pv/internal/redis"
@@ -14,11 +13,10 @@ import (
 // ApplyPvYmlServicesStep binds the services declared in a project's
 // pv.yml into the registry.
 //
-// For version-bearing services (postgres, mysql), errors if the
-// declared version isn't installed. For single-version services
-// (redis, mailpit, rustfs), errors if the service isn't installed
-// — pv.yml should fail loud, never silently bind a service that
-// won't be there.
+// For version-bearing services (postgres, mysql, redis), errors if the
+// declared version isn't supported or installed. For single-version services
+// (mailpit, rustfs), errors if the service isn't installed — pv.yml should
+// fail loud, never silently bind a service that won't be there.
 type ApplyPvYmlServicesStep struct{}
 
 var _ automation.Step = (*ApplyPvYmlServicesStep)(nil)
@@ -61,7 +59,10 @@ func (s *ApplyPvYmlServicesStep) Run(ctx *automation.Context) (string, error) {
 	}
 
 	if cfg.Redis != nil {
-		version := config.RedisDefaultVersion()
+		version, err := redis.ResolveVersion(cfg.Redis.Version)
+		if err != nil {
+			return "", err
+		}
 		if !redis.IsInstalled(version) {
 			return "", fmt.Errorf("pv.yml redis %s is not installed — run `pv redis:install %s`", version, version)
 		}

--- a/internal/automation/steps/apply_pvyml_services_test.go
+++ b/internal/automation/steps/apply_pvyml_services_test.go
@@ -37,6 +37,17 @@ func stageMysqlBinary(t *testing.T, version string) {
 	}
 }
 
+func stageRedisBinary(t *testing.T, version string) {
+	t.Helper()
+	versionDir := config.RedisVersionDir(version)
+	if err := os.MkdirAll(versionDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", versionDir, err)
+	}
+	if err := os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte{}, 0o755); err != nil {
+		t.Fatalf("stage redis-server: %v", err)
+	}
+}
+
 func TestApplyPvYmlServices_BindsPostgresFromConfig(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	stagePostgresBinary(t, "18")
@@ -145,6 +156,59 @@ func TestApplyPvYmlServices_ErrorsWhenMysqlNotInstalled(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "pv mysql:install 8.4") {
 		t.Errorf("err = %v; want it to include `pv mysql:install 8.4`", err)
+	}
+}
+
+func TestApplyPvYmlServices_BindsRedisDefaultVersion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stageRedisBinary(t, config.RedisDefaultVersion())
+
+	projDir := t.TempDir()
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{},
+		Projects: []registry.Project{{Name: "p", Path: projDir, Type: "laravel"}},
+	}
+	ctx := &automation.Context{
+		ProjectName: "p",
+		ProjectPath: projDir,
+		Registry:    reg,
+		ProjectConfig: &config.ProjectConfig{
+			Redis: &config.ServiceConfig{},
+		},
+	}
+	step := &ApplyPvYmlServicesStep{}
+	if _, err := step.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if reg.Projects[0].Services == nil || reg.Projects[0].Services.Redis != config.RedisDefaultVersion() {
+		t.Errorf("Redis binding = %+v, want version=%s", reg.Projects[0].Services, config.RedisDefaultVersion())
+	}
+}
+
+func TestApplyPvYmlServices_RejectsUnsupportedRedisVersion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stageRedisBinary(t, config.RedisDefaultVersion())
+
+	projDir := t.TempDir()
+	reg := &registry.Registry{
+		Services: map[string]*registry.ServiceInstance{},
+		Projects: []registry.Project{{Name: "p", Path: projDir, Type: "laravel"}},
+	}
+	ctx := &automation.Context{
+		ProjectName: "p",
+		ProjectPath: projDir,
+		Registry:    reg,
+		ProjectConfig: &config.ProjectConfig{
+			Redis: &config.ServiceConfig{Version: "7.4"},
+		},
+	}
+	step := &ApplyPvYmlServicesStep{}
+	_, err := step.Run(ctx)
+	if err == nil {
+		t.Fatal("Run: want error for unsupported redis version")
+	}
+	if !strings.Contains(err.Error(), "unsupported redis version") {
+		t.Errorf("err = %v; want unsupported redis version", err)
 	}
 }
 

--- a/internal/commands/redis/download.go
+++ b/internal/commands/redis/download.go
@@ -9,20 +9,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Hidden debug rung. Mirrors postgres' / mysql's downloadCmd: collapses
-// to the same call as :install. Useful when poking at a half-installed
-// state without going through the wizard / orchestrator.
 var downloadCmd = &cobra.Command{
-	Use:     "redis:download",
+	Use:     "redis:download [version]",
 	GroupID: "redis",
 	Short:   "Run the full install pipeline (debug; same as redis:install)",
 	Hidden:  true,
-	Args:    cobra.NoArgs,
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		version := resolveVersion(args)
+
 		client := &http.Client{Timeout: 5 * time.Minute}
 		return ui.StepProgress("Downloading Redis...",
 			func(progress func(written, total int64)) (string, error) {
-				if err := r.InstallProgress(client, progress); err != nil {
+				if err := r.InstallProgress(client, version, progress); err != nil {
 					return "", err
 				}
 				return "Installed Redis", nil

--- a/internal/commands/redis/download.go
+++ b/internal/commands/redis/download.go
@@ -16,7 +16,10 @@ var downloadCmd = &cobra.Command{
 	Hidden:  true,
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		version := resolveVersion(args)
+		version, err := resolveVersion(args)
+		if err != nil {
+			return err
+		}
 
 		client := &http.Client{Timeout: 5 * time.Minute}
 		return ui.StepProgress("Downloading Redis...",

--- a/internal/commands/redis/install.go
+++ b/internal/commands/redis/install.go
@@ -18,7 +18,10 @@ var installCmd = &cobra.Command{
   pv redis:install 8.6`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		version := resolveVersion(args)
+		version, err := resolveVersion(args)
+		if err != nil {
+			return err
+		}
 
 		if r.IsInstalled(version) {
 			if err := r.SetWanted(version, r.WantedRunning); err != nil {

--- a/internal/commands/redis/install.go
+++ b/internal/commands/redis/install.go
@@ -1,6 +1,8 @@
 package redis
 
 import (
+	"fmt"
+
 	r "github.com/prvious/pv/internal/redis"
 	"github.com/prvious/pv/internal/server"
 	"github.com/prvious/pv/internal/ui"
@@ -8,34 +10,32 @@ import (
 )
 
 var installCmd = &cobra.Command{
-	Use:     "redis:install",
+	Use:     "redis:install [version]",
 	GroupID: "redis",
 	Short:   "Install (or re-install) Redis",
-	Long:    "Downloads the Redis binary and registers it as wanted-running. No version arg — single-version service.",
-	Example: `pv redis:install`,
-	Args:    cobra.NoArgs,
+	Long:    "Downloads the Redis binary and registers it as wanted-running.",
+	Example: `pv redis:install
+  pv redis:install 8.6`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Already installed → idempotent: re-mark wanted=running and
-		// signal the daemon. Same friendly contract postgres/mysql use.
-		if r.IsInstalled() {
-			if err := r.SetWanted(r.WantedRunning); err != nil {
+		version := resolveVersion(args)
+
+		if r.IsInstalled(version) {
+			if err := r.SetWanted(version, r.WantedRunning); err != nil {
 				return err
 			}
-			ui.Success("Redis already installed — marked as wanted running.")
+			ui.Success(fmt.Sprintf("Redis %s already installed — marked as wanted running.", version))
 			return signalDaemon()
 		}
 
-		// Run the download/extract pipeline.
-		if err := downloadCmd.RunE(downloadCmd, nil); err != nil {
+		if err := downloadCmd.RunE(downloadCmd, []string{version}); err != nil {
 			return err
 		}
-		ui.Success("Redis installed.")
+		ui.Success(fmt.Sprintf("Redis %s installed.", version))
 		return signalDaemon()
 	},
 }
 
-// signalDaemon nudges the running pv daemon to reconcile, or no-ops with
-// a friendly note if the daemon isn't up.
 func signalDaemon() error {
 	if !server.IsRunning() {
 		ui.Subtle("daemon not running — redis will start on next `pv start`")

--- a/internal/commands/redis/list.go
+++ b/internal/commands/redis/list.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/prvious/pv/internal/binaries"
@@ -16,57 +17,68 @@ import (
 var listCmd = &cobra.Command{
 	Use:     "redis:list",
 	GroupID: "redis",
-	Short:   "Show Redis status (single row)",
+	Short:   "Show installed Redis versions",
 	Args:    cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !r.IsInstalled() {
-			ui.Subtle("Redis is not installed.")
+		versions, err := r.InstalledVersions()
+		if err != nil {
+			return err
+		}
+		if len(versions) == 0 {
+			ui.Subtle("No Redis versions installed.")
 			return nil
 		}
+		sort.Strings(versions)
 
 		st, _ := r.LoadState()
 		vs, _ := binaries.LoadVersions()
 		reg, _ := registry.Load()
 		status, _ := server.ReadDaemonStatus()
 
-		precise := "?"
-		if vs != nil {
-			if v := vs.Get("redis"); v != "" {
-				precise = v
-			}
-		}
-
-		runState := "stopped"
-		if status != nil {
-			if s, ok := status.Supervised["redis"]; ok && s.Running {
-				runState = "running"
-			}
-		}
-		wanted := st.Wanted
-		if wanted == "" {
-			wanted = "—"
-		}
-
-		projects := []string{}
-		if reg != nil {
-			for _, p := range reg.List() {
-				if p.Services != nil && p.Services.Redis {
-					projects = append(projects, p.Name)
+		var rows [][]string
+		for _, version := range versions {
+			precise := "?"
+			if vs != nil {
+				if v := vs.Get("redis-" + version); v != "" {
+					precise = v
 				}
 			}
-		}
-		projectsCol := "—"
-		if len(projects) > 0 {
-			projectsCol = strings.Join(projects, ",")
+
+			runState := "stopped"
+			if status != nil {
+				key := "redis-" + version
+				if s, ok := status.Supervised[key]; ok && s.Running {
+					runState = "running"
+				}
+			}
+
+			wanted := st.Versions[version].Wanted
+			if wanted == "" {
+				wanted = "—"
+			}
+
+			projects := []string{}
+			if reg != nil {
+				for _, p := range reg.List() {
+					if p.Services != nil && p.Services.Redis == version {
+						projects = append(projects, p.Name)
+					}
+				}
+			}
+			projectsCol := "—"
+			if len(projects) > 0 {
+				projectsCol = strings.Join(projects, ",")
+			}
+
+			rows = append(rows, []string{
+				precise,
+				fmt.Sprintf("%d", r.PortFor(version)),
+				fmt.Sprintf("%s (%s)", runState, wanted),
+				config.RedisDataDirV(version),
+				projectsCol,
+			})
 		}
 
-		rows := [][]string{{
-			precise,
-			fmt.Sprintf("%d", r.PortFor()),
-			fmt.Sprintf("%s (%s)", runState, wanted),
-			config.RedisDataDir(),
-			projectsCol,
-		}}
 		ui.Table([]string{"VERSION", "PORT", "STATUS", "DATA DIR", "LINKED PROJECTS"}, rows)
 		return nil
 	},

--- a/internal/commands/redis/logs.go
+++ b/internal/commands/redis/logs.go
@@ -18,7 +18,10 @@ var logsCmd = &cobra.Command{
 	Long:    "Reads ~/.pv/logs/redis-{version}.log. With -f / --follow, tails the file like `tail -f`.",
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		version := resolveVersion(args)
+		version, err := resolveVersion(args)
+		if err != nil {
+			return err
+		}
 
 		path := config.RedisLogPathV(version)
 		if logsFollow {

--- a/internal/commands/redis/logs.go
+++ b/internal/commands/redis/logs.go
@@ -12,13 +12,15 @@ import (
 var logsFollow bool
 
 var logsCmd = &cobra.Command{
-	Use:     "redis:logs",
+	Use:     "redis:logs [version]",
 	GroupID: "redis",
 	Short:   "Tail the Redis log file",
-	Long:    "Reads ~/.pv/logs/redis.log. With -f / --follow, tails the file like `tail -f`.",
-	Args:    cobra.NoArgs,
+	Long:    "Reads ~/.pv/logs/redis-{version}.log. With -f / --follow, tails the file like `tail -f`.",
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		path := config.RedisLogPath()
+		version := resolveVersion(args)
+
+		path := config.RedisLogPathV(version)
 		if logsFollow {
 			c := exec.Command("tail", "-f", path)
 			c.Stdout = os.Stdout

--- a/internal/commands/redis/register.go
+++ b/internal/commands/redis/register.go
@@ -1,15 +1,16 @@
 package redis
 
 import (
-	"github.com/prvious/pv/internal/config"
+	r "github.com/prvious/pv/internal/redis"
 	"github.com/spf13/cobra"
 )
 
-func resolveVersion(args []string) string {
+func resolveVersion(args []string) (string, error) {
+	version := ""
 	if len(args) > 0 {
-		return args[0]
+		version = args[0]
 	}
-	return config.RedisDefaultVersion()
+	return r.ResolveVersion(version)
 }
 
 func Register(parent *cobra.Command) {

--- a/internal/commands/redis/register.go
+++ b/internal/commands/redis/register.go
@@ -1,12 +1,17 @@
-// Package redis holds cobra commands for the redis:* group. There is
-// intentionally no alias namespace — `redis:` is already short.
 package redis
 
 import (
+	"github.com/prvious/pv/internal/config"
 	"github.com/spf13/cobra"
 )
 
-// Register wires every redis:* command onto parent.
+func resolveVersion(args []string) string {
+	if len(args) > 0 {
+		return args[0]
+	}
+	return config.RedisDefaultVersion()
+}
+
 func Register(parent *cobra.Command) {
 	cmds := []*cobra.Command{
 		installCmd,
@@ -18,17 +23,13 @@ func Register(parent *cobra.Command) {
 		listCmd,
 		logsCmd,
 		statusCmd,
-		downloadCmd, // hidden; included so it's discoverable for debugging
+		downloadCmd,
 	}
 	for _, c := range cmds {
 		parent.AddCommand(c)
 	}
 }
 
-// Run* — convenience wrappers for orchestrators (pv install / pv update /
-// pv uninstall) and the setup wizard. Each one threads args through to
-// the corresponding cobra command's RunE so behavior stays in a single
-// place.
 func RunInstall(args []string) error {
 	return installCmd.RunE(installCmd, args)
 }
@@ -41,12 +42,9 @@ func RunUninstall(args []string) error {
 	return uninstallCmd.RunE(uninstallCmd, args)
 }
 
-// UninstallForce removes redis without a confirmation prompt. Used by
-// the pv uninstall orchestrator after it has already obtained blanket
-// consent from the user. Mirrors postgres.UninstallForce / mysql.UninstallForce.
-func UninstallForce() error {
+func UninstallForce(version string) error {
 	prev := uninstallForce
 	uninstallForce = true
 	defer func() { uninstallForce = prev }()
-	return uninstallCmd.RunE(uninstallCmd, nil)
+	return uninstallCmd.RunE(uninstallCmd, []string{version})
 }

--- a/internal/commands/redis/restart.go
+++ b/internal/commands/redis/restart.go
@@ -16,7 +16,10 @@ var restartCmd = &cobra.Command{
 	Short:   "Stop and start Redis",
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		version := resolveVersion(args)
+		version, err := resolveVersion(args)
+		if err != nil {
+			return err
+		}
 
 		if !r.IsInstalled(version) {
 			return fmt.Errorf("redis %s is not installed", version)

--- a/internal/commands/redis/restart.go
+++ b/internal/commands/redis/restart.go
@@ -11,27 +11,29 @@ import (
 )
 
 var restartCmd = &cobra.Command{
-	Use:     "redis:restart",
+	Use:     "redis:restart [version]",
 	GroupID: "redis",
 	Short:   "Stop and start Redis",
-	Args:    cobra.NoArgs,
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Phase 1: ask for stop, signal, wait for actual shutdown. Skipping
-		// WaitStopped here would race with the supervisor's restart of the
-		// next phase.
-		if err := r.SetWanted(r.WantedStopped); err != nil {
+		version := resolveVersion(args)
+
+		if !r.IsInstalled(version) {
+			return fmt.Errorf("redis %s is not installed", version)
+		}
+
+		if err := r.SetWanted(version, r.WantedStopped); err != nil {
 			return err
 		}
 		if server.IsRunning() {
 			if err := server.SignalDaemon(); err != nil {
 				return fmt.Errorf("signal daemon: %w", err)
 			}
-			if err := r.WaitStopped(10 * time.Second); err != nil {
+			if err := r.WaitStopped(version, 10*time.Second); err != nil {
 				return fmt.Errorf("waiting for redis to stop: %w", err)
 			}
 		}
-		// Phase 2: ask for running, signal once.
-		if err := r.SetWanted(r.WantedRunning); err != nil {
+		if err := r.SetWanted(version, r.WantedRunning); err != nil {
 			return err
 		}
 		if server.IsRunning() {
@@ -39,7 +41,7 @@ var restartCmd = &cobra.Command{
 				return err
 			}
 		}
-		ui.Success("Redis restarted.")
+		ui.Success(fmt.Sprintf("Redis %s restarted.", version))
 		return nil
 	},
 }

--- a/internal/commands/redis/start.go
+++ b/internal/commands/redis/start.go
@@ -1,6 +1,8 @@
 package redis
 
 import (
+	"fmt"
+
 	r "github.com/prvious/pv/internal/redis"
 	"github.com/prvious/pv/internal/server"
 	"github.com/prvious/pv/internal/ui"
@@ -8,16 +10,18 @@ import (
 )
 
 var startCmd = &cobra.Command{
-	Use:     "redis:start",
+	Use:     "redis:start [version]",
 	GroupID: "redis",
 	Short:   "Mark Redis as wanted-running",
-	Args:    cobra.NoArgs,
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !r.IsInstalled() {
-			ui.Subtle("Redis is not installed (run `pv redis:install`).")
+		version := resolveVersion(args)
+
+		if !r.IsInstalled(version) {
+			ui.Subtle(fmt.Sprintf("Redis %s is not installed (run `pv redis:install`).", version))
 			return nil
 		}
-		if err := r.SetWanted(r.WantedRunning); err != nil {
+		if err := r.SetWanted(version, r.WantedRunning); err != nil {
 			return err
 		}
 		ui.Success("Redis marked running.")

--- a/internal/commands/redis/start.go
+++ b/internal/commands/redis/start.go
@@ -15,10 +15,13 @@ var startCmd = &cobra.Command{
 	Short:   "Mark Redis as wanted-running",
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		version := resolveVersion(args)
+		version, err := resolveVersion(args)
+		if err != nil {
+			return err
+		}
 
 		if !r.IsInstalled(version) {
-			ui.Subtle(fmt.Sprintf("Redis %s is not installed (run `pv redis:install`).", version))
+			ui.Subtle(fmt.Sprintf("Redis %s is not installed (run `pv redis:install %s`).", version, version))
 			return nil
 		}
 		if err := r.SetWanted(version, r.WantedRunning); err != nil {

--- a/internal/commands/redis/status.go
+++ b/internal/commands/redis/status.go
@@ -10,23 +10,26 @@ import (
 )
 
 var statusCmd = &cobra.Command{
-	Use:     "redis:status",
+	Use:     "redis:status [version]",
 	GroupID: "redis",
 	Short:   "Show Redis status",
-	Args:    cobra.NoArgs,
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !r.IsInstalled() {
-			ui.Subtle("Redis is not installed.")
+		version := resolveVersion(args)
+
+		if !r.IsInstalled(version) {
+			ui.Subtle(fmt.Sprintf("Redis %s is not installed.", version))
 			return nil
 		}
 		status, _ := server.ReadDaemonStatus()
 		if status != nil {
-			if s, ok := status.Supervised["redis"]; ok && s.Running {
-				ui.Success(fmt.Sprintf("redis: running on :%d (pid %d)", r.PortFor(), s.PID))
+			key := "redis-" + version
+			if s, ok := status.Supervised[key]; ok && s.Running {
+				ui.Success(fmt.Sprintf("redis-%s: running on :%d (pid %d)", version, r.PortFor(version), s.PID))
 				return nil
 			}
 		}
-		ui.Subtle("redis: stopped")
+		ui.Subtle(fmt.Sprintf("redis-%s: stopped", version))
 		return nil
 	},
 }

--- a/internal/commands/redis/status.go
+++ b/internal/commands/redis/status.go
@@ -15,7 +15,10 @@ var statusCmd = &cobra.Command{
 	Short:   "Show Redis status",
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		version := resolveVersion(args)
+		version, err := resolveVersion(args)
+		if err != nil {
+			return err
+		}
 
 		if !r.IsInstalled(version) {
 			ui.Subtle(fmt.Sprintf("Redis %s is not installed.", version))

--- a/internal/commands/redis/stop.go
+++ b/internal/commands/redis/stop.go
@@ -8,12 +8,14 @@ import (
 )
 
 var stopCmd = &cobra.Command{
-	Use:     "redis:stop",
+	Use:     "redis:stop [version]",
 	GroupID: "redis",
 	Short:   "Mark Redis as wanted-stopped",
-	Args:    cobra.NoArgs,
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := r.SetWanted(r.WantedStopped); err != nil {
+		version := resolveVersion(args)
+
+		if err := r.SetWanted(version, r.WantedStopped); err != nil {
 			return err
 		}
 		ui.Success("Redis marked stopped.")

--- a/internal/commands/redis/stop.go
+++ b/internal/commands/redis/stop.go
@@ -13,7 +13,10 @@ var stopCmd = &cobra.Command{
 	Short:   "Mark Redis as wanted-stopped",
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		version := resolveVersion(args)
+		version, err := resolveVersion(args)
+		if err != nil {
+			return err
+		}
 
 		if err := r.SetWanted(version, r.WantedStopped); err != nil {
 			return err

--- a/internal/commands/redis/uninstall.go
+++ b/internal/commands/redis/uninstall.go
@@ -14,17 +14,19 @@ import (
 var uninstallForce bool
 
 var uninstallCmd = &cobra.Command{
-	Use:     "redis:uninstall",
+	Use:     "redis:uninstall [version]",
 	GroupID: "redis",
 	Short:   "Stop, remove the binary, and (with --force) DELETE the data directory",
 	Long: "Stops the supervised process and removes the binary tree at " +
 		"~/.pv/redis/. With --force, also removes the data directory at " +
 		"~/.pv/data/redis/ (deletes dump.rdb). Unbinds every linked project.",
 	Example: `pv redis:uninstall --force`,
-	Args:    cobra.NoArgs,
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !r.IsInstalled() {
-			ui.Subtle("Redis is not installed.")
+		version := resolveVersion(args)
+
+		if !r.IsInstalled(version) {
+			ui.Subtle(fmt.Sprintf("Redis %s is not installed.", version))
 			return nil
 		}
 		if !uninstallForce {
@@ -42,34 +44,28 @@ var uninstallCmd = &cobra.Command{
 			}
 		}
 
-		if err := r.SetWanted(r.WantedStopped); err != nil {
+		if err := r.SetWanted(version, r.WantedStopped); err != nil {
 			return err
 		}
 		if server.IsRunning() {
 			if err := server.SignalDaemon(); err != nil {
 				return fmt.Errorf("signal daemon: %w", err)
 			}
-			if err := r.WaitStopped(10 * time.Second); err != nil {
+			if err := r.WaitStopped(version, 10*time.Second); err != nil {
 				return fmt.Errorf("waiting for redis to stop: %w", err)
 			}
 		}
 
 		if err := ui.Step("Uninstalling Redis...", func() (string, error) {
-			if err := r.Uninstall(uninstallForce); err != nil {
+			if err := r.Uninstall(version, uninstallForce); err != nil {
 				return "", err
 			}
-			return "Uninstalled Redis", nil
+			return fmt.Sprintf("Uninstalled Redis %s", version), nil
 		}); err != nil {
 			return err
 		}
 
-		// NOTE: Uninstall handles the registry unbind internally. We do NOT
-		// re-save the registry here — registry.Save calls config.EnsureDirs
-		// and any subsequent EnsureDirs call after Uninstall ran would have
-		// historically recreated RedisDir/RedisDataDir. Even now that those
-		// are no longer in EnsureDirs, a redundant Save is just churn.
-
-		ui.Success("Redis uninstalled.")
+		ui.Success(fmt.Sprintf("Redis %s uninstalled.", version))
 		return nil
 	},
 }

--- a/internal/commands/redis/uninstall.go
+++ b/internal/commands/redis/uninstall.go
@@ -18,12 +18,15 @@ var uninstallCmd = &cobra.Command{
 	GroupID: "redis",
 	Short:   "Stop, remove the binary, and (with --force) DELETE the data directory",
 	Long: "Stops the supervised process and removes the binary tree at " +
-		"~/.pv/redis/. With --force, also removes the data directory at " +
-		"~/.pv/data/redis/ (deletes dump.rdb). Unbinds every linked project.",
+		"~/.pv/redis/{version}/. With --force, also removes the data directory at " +
+		"~/.pv/data/redis/{version}/ (deletes dump.rdb). Unbinds linked projects using that version.",
 	Example: `pv redis:uninstall --force`,
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		version := resolveVersion(args)
+		version, err := resolveVersion(args)
+		if err != nil {
+			return err
+		}
 
 		if !r.IsInstalled(version) {
 			ui.Subtle(fmt.Sprintf("Redis %s is not installed.", version))

--- a/internal/commands/redis/update.go
+++ b/internal/commands/redis/update.go
@@ -12,29 +12,31 @@ import (
 )
 
 var updateCmd = &cobra.Command{
-	Use:     "redis:update",
+	Use:     "redis:update [version]",
 	GroupID: "redis",
 	Short:   "Re-download Redis (data dir untouched)",
 	Example: `pv redis:update`,
-	Args:    cobra.NoArgs,
+	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !r.IsInstalled() {
-			return fmt.Errorf("redis is not installed")
+		version := resolveVersion(args)
+
+		if !r.IsInstalled(version) {
+			return fmt.Errorf("redis %s is not installed", version)
 		}
 
 		wasRunning := false
-		if st, err := r.LoadState(); err == nil && st.Wanted == r.WantedRunning {
+		if st, err := r.LoadState(); err == nil && st.Versions[version].Wanted == r.WantedRunning {
 			wasRunning = true
 		}
 
-		if err := r.SetWanted(r.WantedStopped); err != nil {
+		if err := r.SetWanted(version, r.WantedStopped); err != nil {
 			return err
 		}
 		if server.IsRunning() {
 			if err := server.SignalDaemon(); err != nil {
 				return fmt.Errorf("signal daemon: %w", err)
 			}
-			if err := r.WaitStopped(10 * time.Second); err != nil {
+			if err := r.WaitStopped(version, 10*time.Second); err != nil {
 				return fmt.Errorf("waiting for redis to stop: %w", err)
 			}
 		}
@@ -42,7 +44,7 @@ var updateCmd = &cobra.Command{
 		client := &http.Client{Timeout: 5 * time.Minute}
 		if err := ui.StepProgress("Updating Redis...",
 			func(progress func(written, total int64)) (string, error) {
-				if err := r.UpdateProgress(client, progress); err != nil {
+				if err := r.UpdateProgress(client, version, progress); err != nil {
 					return "", err
 				}
 				return "Updated Redis", nil
@@ -51,12 +53,12 @@ var updateCmd = &cobra.Command{
 		}
 
 		if wasRunning {
-			if err := r.SetWanted(r.WantedRunning); err != nil {
+			if err := r.SetWanted(version, r.WantedRunning); err != nil {
 				return err
 			}
 		}
 
-		ui.Success("Redis updated.")
+		ui.Success(fmt.Sprintf("Redis %s updated.", version))
 		if server.IsRunning() {
 			return server.SignalDaemon()
 		}

--- a/internal/commands/redis/update.go
+++ b/internal/commands/redis/update.go
@@ -18,7 +18,10 @@ var updateCmd = &cobra.Command{
 	Example: `pv redis:update`,
 	Args:    cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		version := resolveVersion(args)
+		version, err := resolveVersion(args)
+		if err != nil {
+			return err
+		}
 
 		if !r.IsInstalled(version) {
 			return fmt.Errorf("redis %s is not installed", version)

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -233,26 +233,25 @@ func MysqlLogPath(version string) string {
 	return filepath.Join(LogsDir(), "mysql-"+version+".log")
 }
 
-// RedisDir is the root for the native redis binary tree:
-// ~/.pv/redis/{redis-server,redis-cli}.
-// Single-version — no per-version subdir.
+// RedisDir is the parent root for versioned native redis binary trees:
+// ~/.pv/redis/{version}/{redis-server,redis-cli}.
 func RedisDir() string {
 	return filepath.Join(PvDir(), "redis")
 }
 
-// RedisDataDir is the redis-server data dir, kept under
-// ~/.pv/data/redis/ so it survives a binary uninstall (unless
-// --force is used). RDB snapshots land in <RedisDataDir>/dump.rdb.
+// RedisDataDir returns the parent root for versioned redis-server data dirs.
+// Prefer RedisDataDirV for per-version data paths.
 func RedisDataDir() string {
 	return filepath.Join(DataDir(), "redis")
 }
 
-// RedisLogPath returns the supervisor log file for redis.
+// RedisLogPath returns the legacy unversioned supervisor log file for redis.
+// Prefer RedisLogPathV for new per-version callers.
 func RedisLogPath() string {
 	return filepath.Join(LogsDir(), "redis.log")
 }
 
-// RedisDefaultVersion returns the single version pv ships for redis.
+// RedisDefaultVersion returns the currently supported bundled redis version.
 // Currently "8.6" — update when the artifacts pipeline bumps.
 func RedisDefaultVersion() string { return "8.6" }
 

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -252,6 +252,35 @@ func RedisLogPath() string {
 	return filepath.Join(LogsDir(), "redis.log")
 }
 
+// RedisDefaultVersion returns the single version pv ships for redis.
+// Currently "8.6" — update when the artifacts pipeline bumps.
+func RedisDefaultVersion() string { return "8.6" }
+
+// RedisVersionDir returns ~/.pv/redis/{version}/ — the binary root
+// for a specific version. Mirrors PostgresVersionDir / MysqlVersionDir.
+func RedisVersionDir(version string) string {
+	return filepath.Join(PvDir(), "redis", version)
+}
+
+// RedisDataDirV returns ~/.pv/data/redis/{version}/ — the data root
+// for a specific version. Note: old RedisDataDir() (no version) is
+// deprecated; renamed to RedisDataRoot() for the parent.
+func RedisDataDirV(version string) string {
+	return filepath.Join(DataDir(), "redis", version)
+}
+
+// RedisLogPathV returns ~/.pv/logs/redis-{version}.log.
+func RedisLogPathV(version string) string {
+	return filepath.Join(LogsDir(), "redis-"+version+".log")
+}
+
+// RedisDataRoot returns ~/.pv/data/redis/ — the parent of versioned
+// data dirs. Used when iterating installed versions; callers should
+// prefer RedisDataDirV for per-version paths.
+func RedisDataRoot() string {
+	return filepath.Join(DataDir(), "redis")
+}
+
 func EnsureDirs() error {
 	dirs := []string{
 		ConfigDir(),

--- a/internal/config/pvyml.go
+++ b/internal/config/pvyml.go
@@ -28,8 +28,8 @@ type ProjectConfig struct {
 }
 
 // ServiceConfig declares a backing service a project depends on.
-// Version is required for postgresql and mysql (multi-version aware);
-// optional and ignored for redis, mailpit, rustfs (single bundled version).
+// Version is required for postgresql and mysql. Redis accepts only pv's
+// supported bundled version; mailpit and rustfs ignore Version.
 type ServiceConfig struct {
 	Version string            `yaml:"version,omitempty"`
 	Env     map[string]string `yaml:"env,omitempty"`

--- a/internal/redis/envvars.go
+++ b/internal/redis/envvars.go
@@ -2,21 +2,11 @@ package redis
 
 import "strconv"
 
-// EnvVars returns the REDIS_* map injected into a linked project's .env
-// when redis is bound. projectName is accepted but unused — kept for
-// parallel signature with mysql.EnvVars / postgres.EnvVars so the
-// dispatcher in laravel/env.go can treat all three uniformly.
-//
-// REDIS_PASSWORD is the literal string "null" — Laravel's
-// config/database.php reads that as nil, matching the no-auth /
-// loopback-only spec posture. Same shape the docker Redis used, so
-// projects bound under the old service experience no .env churn on
-// migration.
-func EnvVars(projectName string) map[string]string {
-	_ = projectName // unused — redis uses no project-scoped value
+func EnvVars(version, projectName string) map[string]string {
+	_ = projectName
 	return map[string]string{
 		"REDIS_HOST":     "127.0.0.1",
-		"REDIS_PORT":     strconv.Itoa(PortFor()),
+		"REDIS_PORT":     strconv.Itoa(PortFor(version)),
 		"REDIS_PASSWORD": "null",
 	}
 }

--- a/internal/redis/envvars_test.go
+++ b/internal/redis/envvars_test.go
@@ -2,30 +2,15 @@ package redis
 
 import "testing"
 
-func TestEnvVars(t *testing.T) {
-	got := EnvVars("verify-app")
-
-	want := map[string]string{
-		"REDIS_HOST":     "127.0.0.1",
-		"REDIS_PORT":     "6379",
-		"REDIS_PASSWORD": "null",
+func TestEnvVars_ContainsExpectedKeys(t *testing.T) {
+	vars := EnvVars("8.6", "myapp")
+	if vars["REDIS_HOST"] != "127.0.0.1" {
+		t.Errorf("REDIS_HOST = %q", vars["REDIS_HOST"])
 	}
-	if len(got) != len(want) {
-		t.Fatalf("EnvVars returned %d keys, want %d (%v)", len(got), len(want), got)
+	if vars["REDIS_PORT"] != "7160" {
+		t.Errorf("REDIS_PORT = %q", vars["REDIS_PORT"])
 	}
-	for k, v := range want {
-		if got[k] != v {
-			t.Errorf("EnvVars[%q] = %q, want %q", k, got[k], v)
-		}
-	}
-}
-
-func TestEnvVars_ProjectNameIgnored(t *testing.T) {
-	a := EnvVars("alpha")
-	b := EnvVars("beta")
-	for k := range a {
-		if a[k] != b[k] {
-			t.Errorf("EnvVars varies by projectName: %q differs (%q vs %q)", k, a[k], b[k])
-		}
+	if vars["REDIS_PASSWORD"] != "null" {
+		t.Errorf("REDIS_PASSWORD = %q", vars["REDIS_PASSWORD"])
 	}
 }

--- a/internal/redis/install.go
+++ b/internal/redis/install.go
@@ -10,19 +10,11 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-// Install downloads, extracts, and registers redis as wanted=running.
-// Idempotent: re-running on an already-installed redis is a no-op for
-// files (skips download/extract) and just re-records wanted=running.
-//
-// Note there is NO init step (redis has no `--initialize-insecure`
-// equivalent — RDB persistence is created on first save by redis-server
-// itself, no schema bootstrap is needed).
-func Install(client *http.Client) error {
-	return InstallProgress(client, nil)
+func Install(client *http.Client, version string) error {
+	return InstallProgress(client, version, nil)
 }
 
-// InstallProgress is Install with a progress callback for the download phase.
-func InstallProgress(client *http.Client, progress binaries.ProgressFunc) error {
+func InstallProgress(client *http.Client, version string, progress binaries.ProgressFunc) error {
 	if err := config.EnsureDirs(); err != nil {
 		return err
 	}
@@ -32,14 +24,14 @@ func InstallProgress(client *http.Client, progress binaries.ProgressFunc) error 
 		return err
 	}
 
-	dir := config.RedisDir()
-	if !IsInstalled() {
-		stagingDir := dir + ".new"
+	versionDir := config.RedisVersionDir(version)
+	if !IsInstalled(version) {
+		stagingDir := versionDir + ".new"
 		os.RemoveAll(stagingDir)
 		if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 			return fmt.Errorf("create staging: %w", err)
 		}
-		archive := filepath.Join(config.PvDir(), "redis.tar.gz")
+		archive := filepath.Join(config.PvDir(), "redis-"+version+".tar.gz")
 		if err := binaries.DownloadProgress(client, url, archive, progress); err != nil {
 			os.RemoveAll(stagingDir)
 			return fmt.Errorf("download: %w", err)
@@ -50,43 +42,34 @@ func InstallProgress(client *http.Client, progress binaries.ProgressFunc) error 
 			return fmt.Errorf("extract: %w", err)
 		}
 		os.Remove(archive)
-		os.RemoveAll(dir)
-		if err := os.Rename(stagingDir, dir); err != nil {
+		os.RemoveAll(versionDir)
+		if err := os.Rename(stagingDir, versionDir); err != nil {
 			os.RemoveAll(stagingDir)
 			return fmt.Errorf("rename staging: %w", err)
 		}
-		// When pv runs as root (sudo pv start), hand the binary tree to
-		// SUDO_USER so the dropped redis-server process can read it.
-		if err := chownToTarget(dir); err != nil {
+		if err := chownToTarget(versionDir); err != nil {
 			return fmt.Errorf("chown redis tree: %w", err)
 		}
 	}
 
-	// Create + chown the data dir to SUDO_USER so the dropped
-	// redis-server can write dump.rdb. EnsureDirs deliberately doesn't
-	// create this — see internal/config/paths.go's comment about why.
-	if err := os.MkdirAll(config.RedisDataDir(), 0o755); err != nil {
+	dataDir := config.RedisDataDirV(version)
+	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return fmt.Errorf("create redis data dir: %w", err)
 	}
-	if err := chownToTarget(config.RedisDataDir()); err != nil {
+	if err := chownToTarget(dataDir); err != nil {
 		return fmt.Errorf("chown redis data dir: %w", err)
 	}
 
-	// Probe + record version. Best-effort: a probe failure shouldn't
-	// fail the install (the binary is already on disk and runnable; the
-	// version record is diagnostic).
-	if v, err := ProbeVersion(); err == nil {
+	if v, err := ProbeVersion(version); err == nil {
 		if vs, err := binaries.LoadVersions(); err == nil {
-			vs.Set("redis", v)
+			vs.Set("redis-"+version, v)
 			_ = vs.Save()
 		}
 	}
 
-	return SetWanted(WantedRunning)
+	return SetWanted(version, WantedRunning)
 }
 
-// resolveRedisURL allows tests to redirect the download via env var.
-// Production: returns the artifacts-release URL from binaries.RedisURL.
 func resolveRedisURL() (string, error) {
 	if override := os.Getenv("PV_REDIS_URL_OVERRIDE"); override != "" {
 		return override, nil

--- a/internal/redis/install.go
+++ b/internal/redis/install.go
@@ -15,6 +15,9 @@ func Install(client *http.Client, version string) error {
 }
 
 func InstallProgress(client *http.Client, version string, progress binaries.ProgressFunc) error {
+	if err := ValidateVersion(version); err != nil {
+		return err
+	}
 	if err := config.EnsureDirs(); err != nil {
 		return err
 	}

--- a/internal/redis/install_test.go
+++ b/internal/redis/install_test.go
@@ -14,11 +14,6 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-// makeFakeRedisTarball returns a minimal redis-like tarball with
-// redis-server (a stub that handles --version) and redis-cli.
-// Layout: flat — files at the tarball root, no `bin/` subdir, matching
-// the Task 1 verification of the artifact layout. If the artifact later
-// changes shape, update this helper and Install in lockstep.
 func makeFakeRedisTarball(t *testing.T) []byte {
 	t.Helper()
 	var buf bytes.Buffer
@@ -31,9 +26,6 @@ func makeFakeRedisTarball(t *testing.T) []byte {
 		}
 		tw.Write([]byte(body))
 	}
-	// redis-server stub: handles --version (Task 8 ProbeVersion calls
-	// this). For the install path we only need ProbeVersion to succeed
-	// — long-run is exercised by process_test.go via the Go fake.
 	redisServerStub := `#!/bin/sh
 for a in "$@"; do
   case "$a" in
@@ -60,33 +52,31 @@ func TestInstall_HappyPath(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PV_REDIS_URL_OVERRIDE", srv.URL)
 
-	if err := Install(http.DefaultClient); err != nil {
+	version := "8.6"
+
+	if err := Install(http.DefaultClient, version); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 
-	// Binaries on disk.
 	for _, want := range []string{"redis-server", "redis-cli"} {
-		p := filepath.Join(config.RedisDir(), want)
+		p := filepath.Join(config.RedisVersionDir(version), want)
 		if _, err := os.Stat(p); err != nil {
 			t.Errorf("missing %s: %v", want, err)
 		}
 	}
 
-	// Data dir present.
-	if _, err := os.Stat(config.RedisDataDir()); err != nil {
+	if _, err := os.Stat(config.RedisDataDirV(version)); err != nil {
 		t.Errorf("data dir missing: %v", err)
 	}
 
-	// State recorded as wanted=running.
 	st, _ := LoadState()
-	if st.Wanted != WantedRunning {
-		t.Errorf("state.Wanted = %q, want running", st.Wanted)
+	if st.Versions[version].Wanted != WantedRunning {
+		t.Errorf("version %s wanted = %q, want %q", version, st.Versions[version].Wanted, WantedRunning)
 	}
 
-	// Version recorded in versions.json under key redis.
 	vs, _ := binaries.LoadVersions()
-	if got := vs.Get("redis"); got == "" {
-		t.Errorf("versions.json redis not recorded")
+	if got := vs.Get("redis-" + version); got == "" {
+		t.Errorf("versions.json redis-%s not recorded", version)
 	}
 }
 
@@ -100,15 +90,17 @@ func TestInstall_AlreadyInstalled_Idempotent(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PV_REDIS_URL_OVERRIDE", srv.URL)
 
-	if err := Install(http.DefaultClient); err != nil {
+	version := "8.6"
+
+	if err := Install(http.DefaultClient, version); err != nil {
 		t.Fatalf("first Install: %v", err)
 	}
-	if err := Install(http.DefaultClient); err != nil {
+	if err := Install(http.DefaultClient, version); err != nil {
 		t.Fatalf("second Install (idempotent): %v", err)
 	}
 
 	st, _ := LoadState()
-	if st.Wanted != WantedRunning {
+	if st.Versions[version].Wanted != WantedRunning {
 		t.Errorf("idempotent re-install did not preserve wanted=running")
 	}
 }

--- a/internal/redis/installed.go
+++ b/internal/redis/installed.go
@@ -3,27 +3,44 @@ package redis
 import (
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/prvious/pv/internal/config"
 )
 
-// ServerBinary returns the absolute path to the bundled redis-server.
-// Used by callers that need the path (e.g. process.BuildSupervisorProcess);
-// keeps the join in one place.
-func ServerBinary() string {
-	return filepath.Join(config.RedisDir(), "redis-server")
+func ServerBinary(version string) string {
+	return filepath.Join(config.RedisVersionDir(version), "redis-server")
 }
 
-// CLIBinary returns the absolute path to the bundled redis-cli.
-// Not on PATH — internal use only (e2e tests, debugging).
-func CLIBinary() string {
-	return filepath.Join(config.RedisDir(), "redis-cli")
+func CLIBinary(version string) string {
+	return filepath.Join(config.RedisVersionDir(version), "redis-cli")
 }
 
-// IsInstalled reports whether redis-server exists at the expected path.
-// A directory at config.RedisDir() with no redis-server is treated as
-// not-installed (incomplete extraction, etc.).
-func IsInstalled() bool {
-	info, err := os.Stat(ServerBinary())
+func IsInstalled(version string) bool {
+	info, err := os.Stat(ServerBinary(version))
 	return err == nil && !info.IsDir()
+}
+
+func InstalledVersions() ([]string, error) {
+	root := config.RedisDir()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		version := e.Name()
+		bin := filepath.Join(config.RedisVersionDir(version), "redis-server")
+		if info, err := os.Stat(bin); err == nil && !info.IsDir() {
+			out = append(out, version)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
 }

--- a/internal/redis/installed_test.go
+++ b/internal/redis/installed_test.go
@@ -8,33 +8,51 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-func TestIsInstalled_Empty(t *testing.T) {
+func TestServerBinary(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if IsInstalled() {
-		t.Error("IsInstalled should be false on empty home")
+	path := ServerBinary("8.6")
+	if path == "" {
+		t.Error("expected non-empty path")
 	}
 }
 
-func TestIsInstalled_FindsBinary(t *testing.T) {
+func TestIsInstalled_True(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if err := os.MkdirAll(config.RedisDir(), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	bin := filepath.Join(config.RedisDir(), "redis-server")
-	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	if !IsInstalled() {
-		t.Error("IsInstalled should be true after writing redis-server")
+	versionDir := config.RedisVersionDir("8.6")
+	os.MkdirAll(versionDir, 0o755)
+	os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte("x"), 0o755)
+	if !IsInstalled("8.6") {
+		t.Error("expected installed")
 	}
 }
 
-func TestIsInstalled_DirWithoutBinary(t *testing.T) {
+func TestIsInstalled_False(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if err := os.MkdirAll(config.RedisDir(), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
+	if IsInstalled("8.6") {
+		t.Error("expected not installed")
 	}
-	if IsInstalled() {
-		t.Error("dir without redis-server should not count as installed")
+}
+
+func TestInstalledVersions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	vs, err := InstalledVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 0 {
+		t.Error("expected no versions")
+	}
+
+	versionDir := config.RedisVersionDir("8.6")
+	os.MkdirAll(versionDir, 0o755)
+	os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte("x"), 0o755)
+
+	vs, err = InstalledVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 1 || vs[0] != "8.6" {
+		t.Errorf("got %v, want [8.6]", vs)
 	}
 }

--- a/internal/redis/port.go
+++ b/internal/redis/port.go
@@ -1,16 +1,22 @@
 // Package redis owns the lifecycle of the native redis binary managed by
-// pv. Mirrors internal/postgres/ and internal/mysql/ but flat:
-// single-version, no per-version map. State at ~/.pv/redis/ and
-// ~/.pv/data/redis/.
+// pv. Mirrors internal/postgres/ and internal/mysql/ but versioned:
+// per-version map, version-parameterized API. State at ~/.pv/redis/{version}/
+// and ~/.pv/data/redis/{version}/.
 package redis
 
-// RedisPort is the TCP port pv binds redis-server to. Constant 6379 —
-// the upstream default and the value every Laravel app expects out of
-// the box. Single-version means there's no collision risk.
-const RedisPort = 6379
+import "fmt"
 
-// PortFor returns the TCP port redis-server should bind to.
-// Kept as a function (not just exposing the const) for parallel API
-// shape with mysql.PortFor / postgres.PortFor — callers don't have to
-// branch on which package they're talking to.
-func PortFor() int { return RedisPort }
+func PortFor(version string) int {
+	return redisPort(version)
+}
+
+func redisPort(version string) int {
+	major, minor := parseVersion(version)
+	return 6300 + major*100 + minor*10
+}
+
+func parseVersion(v string) (int, int) {
+	var major, minor int
+	fmt.Sscanf(v, "%d.%d", &major, &minor)
+	return major, minor
+}

--- a/internal/redis/port_test.go
+++ b/internal/redis/port_test.go
@@ -7,8 +7,8 @@ func TestPortFor(t *testing.T) {
 		version string
 		want    int
 	}{
-		{"7.4", 6740},
-		{"8.6", 6860},
+		{"7.4", 7040},
+		{"8.6", 7160},
 	}
 	for _, tc := range tests {
 		got := PortFor(tc.version)

--- a/internal/redis/port_test.go
+++ b/internal/redis/port_test.go
@@ -3,7 +3,17 @@ package redis
 import "testing"
 
 func TestPortFor(t *testing.T) {
-	if got := PortFor(); got != 6379 {
-		t.Errorf("PortFor() = %d, want 6379", got)
+	tests := []struct {
+		version string
+		want    int
+	}{
+		{"7.4", 6740},
+		{"8.6", 6860},
+	}
+	for _, tc := range tests {
+		got := PortFor(tc.version)
+		if got != tc.want {
+			t.Errorf("PortFor(%q) = %d, want %d", tc.version, got, tc.want)
+		}
 	}
 }

--- a/internal/redis/process.go
+++ b/internal/redis/process.go
@@ -12,57 +12,35 @@ import (
 	"github.com/prvious/pv/internal/supervisor"
 )
 
-// BuildSupervisorProcess returns a supervisor.Process for redis. Refuses
-// to build when the binary is missing — the supervisor would just fail
-// to exec and we want a clearer error.
-//
-// All boot configuration is on the command line — no redis.conf — so pv
-// is the single source of truth.
-func BuildSupervisorProcess() (supervisor.Process, error) {
-	binPath := ServerBinary()
+func BuildSupervisorProcess(version string) (supervisor.Process, error) {
+	binPath := ServerBinary(version)
 	if _, err := os.Stat(binPath); err != nil {
-		return supervisor.Process{}, fmt.Errorf("redis: not installed (run pv redis:install)")
+		return supervisor.Process{}, fmt.Errorf("redis-%s: not installed (run pv redis:install %s)", version, version)
 	}
 	return supervisor.Process{
-		Name:         "redis",
+		Name:         "redis-" + version,
 		Binary:       binPath,
-		Args:         buildRedisArgs(),
-		LogFile:      config.RedisLogPath(),
+		Args:         buildRedisArgs(version),
+		LogFile:      config.RedisLogPathV(version),
 		SysProcAttr:  dropSysProcAttr(),
-		Ready:        tcpReady(PortFor()),
+		Ready:        tcpReady(PortFor(version)),
 		ReadyTimeout: 10 * time.Second,
 	}, nil
 }
 
-// buildRedisArgs returns the flag set passed to redis-server at boot.
-// Single source of truth: no redis.conf — every knob pv cares about is
-// here.
-//
-// We deliberately do NOT pass --logfile: the supervisor opens
-// RedisLogPath as the parent (running as root) and inherits the fd to
-// the child, which sidesteps the ownership problem of the dropped
-// redis-server process trying to open a root-owned log file itself.
-// redis-server's stderr is captured via that inherited fd. Same fix we
-// applied to mysql.
-//
-// Compiled-in save policy stays in effect (3600 1 / 300 100 / 60 10000).
-// AOF off — RDB is sufficient for dev work.
-func buildRedisArgs() []string {
+func buildRedisArgs(version string) []string {
 	return []string{
 		"--bind", "127.0.0.1",
-		"--port", strconv.Itoa(PortFor()),
-		"--dir", config.RedisDataDir(),
+		"--port", strconv.Itoa(PortFor(version)),
+		"--dir", config.RedisDataDirV(version),
 		"--dbfilename", "dump.rdb",
-		"--pidfile", "/tmp/pv-redis.pid",
+		"--pidfile", "/tmp/pv-redis-" + version + ".pid",
 		"--daemonize", "no",
 		"--protected-mode", "no",
 		"--appendonly", "no",
 	}
 }
 
-// tcpReady returns a Ready function that probes 127.0.0.1:port.
-// redis-server starts accepting connections almost immediately after
-// the listener binds — 10s is generous.
 func tcpReady(port int) func(context.Context) error {
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	return func(ctx context.Context) error {

--- a/internal/redis/process.go
+++ b/internal/redis/process.go
@@ -13,6 +13,9 @@ import (
 )
 
 func BuildSupervisorProcess(version string) (supervisor.Process, error) {
+	if err := ValidateVersion(version); err != nil {
+		return supervisor.Process{}, err
+	}
 	binPath := ServerBinary(version)
 	if _, err := os.Stat(binPath); err != nil {
 		return supervisor.Process{}, fmt.Errorf("redis-%s: not installed (run pv redis:install %s)", version, version)

--- a/internal/redis/process_test.go
+++ b/internal/redis/process_test.go
@@ -2,59 +2,55 @@ package redis
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prvious/pv/internal/config"
 )
 
 func TestBuildSupervisorProcess_NotInstalled(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if _, err := BuildSupervisorProcess(); err == nil {
+	if _, err := BuildSupervisorProcess("8.6"); err == nil {
 		t.Error("BuildSupervisorProcess should error when redis is not installed")
 	}
 }
 
 func TestBuildSupervisorProcess_FlagComposition(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	if err := os.MkdirAll(config.RedisDir(), 0o755); err != nil {
-		t.Fatal(err)
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("test requires exec")
 	}
-	if err := os.WriteFile(filepath.Join(config.RedisDir(), "redis-server"), []byte{}, 0o755); err != nil {
-		t.Fatal(err)
+	t.Setenv("HOME", t.TempDir())
+
+	version := "8.6"
+	versionDir := config.RedisVersionDir(version)
+	os.MkdirAll(versionDir, 0o755)
+
+	out := filepath.Join(versionDir, "redis-server")
+	cmd := exec.Command("go", "build", "-o", out,
+		filepath.Join("..", "..", "internal", "redis", "testdata", "fake-redis-server.go"))
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fake redis-server: %v\n%s", err, b)
 	}
 
-	proc, err := BuildSupervisorProcess()
+	proc, err := BuildSupervisorProcess(version)
 	if err != nil {
 		t.Fatalf("BuildSupervisorProcess: %v", err)
 	}
 
-	if proc.Name != "redis" {
-		t.Errorf("Name = %q, want redis", proc.Name)
+	if proc.Name != "redis-8.6" {
+		t.Errorf("Name = %q, want redis-8.6", proc.Name)
 	}
-	if proc.Binary != filepath.Join(config.RedisDir(), "redis-server") {
-		t.Errorf("Binary = %q", proc.Binary)
+	if !strings.Contains(proc.Binary, "8.6/redis-server") {
+		t.Errorf("Binary = %q, should contain 8.6/redis-server", proc.Binary)
 	}
-	if proc.LogFile != config.RedisLogPath() {
-		t.Errorf("LogFile = %q, want %q", proc.LogFile, config.RedisLogPath())
+	if !strings.Contains(proc.LogFile, "redis-8.6.log") {
+		t.Errorf("LogFile = %q, should contain redis-8.6.log", proc.LogFile)
 	}
-	got := strings.Join(proc.Args, " ")
-	for _, want := range []string{
-		"--bind 127.0.0.1",
-		"--port 6379",
-		"--dir " + config.RedisDataDir(),
-		"--dbfilename dump.rdb",
-		"--pidfile /tmp/pv-redis.pid",
-		"--daemonize no",
-		"--protected-mode no",
-		"--appendonly no",
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("Args missing %q; got: %s", want, got)
-		}
-	}
-	if strings.Contains(got, "--logfile") {
-		t.Errorf("Args must NOT contain --logfile (supervisor handles stderr); got: %s", got)
+	if proc.ReadyTimeout != 10*time.Second {
+		t.Errorf("ReadyTimeout = %v, want 10s", proc.ReadyTimeout)
 	}
 }

--- a/internal/redis/state.go
+++ b/internal/redis/state.go
@@ -10,55 +10,55 @@ import (
 
 const stateKey = "redis"
 
-// Wanted-state values for State.Wanted. Bare strings would let typos
-// silently persist (and be silently read as "not running"), so callers
-// go through SetWanted which validates against this set.
 const (
 	WantedRunning = "running"
 	WantedStopped = "stopped"
 )
 
-// State is the redis slice of ~/.pv/data/state.json.
-//
-// Note the shape is FLAT (no Versions map) — redis is single-version, so
-// a per-version sub-record would just add a layer of indirection over a
-// single record. Compare with internal/mysql/state.go which uses a
-// Versions map to disambiguate 8.0/8.4/9.7.
-//
-// On-disk JSON shape:
-//
-//	{
-//	  "redis": { "wanted": "running" }
-//	}
-type State struct {
+type VersionState struct {
 	Wanted string `json:"wanted"`
 }
 
-// LoadState reads the redis slice. Missing or empty → zero-value state.
-// A corrupt slice is treated as empty with a one-time stderr warning,
-// the same posture postgres/mysql take — recovery is `redis:start`.
+type State struct {
+	Versions map[string]VersionState `json:"versions"`
+}
+
 func LoadState() (State, error) {
 	all, err := state.Load()
 	if err != nil {
-		return State{}, err
+		return State{Versions: map[string]VersionState{}}, err
 	}
 	raw, ok := all[stateKey]
 	if !ok {
-		return State{}, nil
+		return State{Versions: map[string]VersionState{}}, nil
 	}
 	var s State
 	if err := json.Unmarshal(raw, &s); err != nil {
 		fmt.Fprintf(os.Stderr, "redis: state slice corrupt (%v); treating as empty\n", err)
-		return State{}, nil
+		return State{Versions: map[string]VersionState{}}, nil
+	}
+	if s.Versions == nil {
+		s.Versions = map[string]VersionState{}
+	}
+	if len(s.Versions) == 0 {
+		var old struct {
+			Wanted string `json:"wanted"`
+		}
+		if err := json.Unmarshal(raw, &old); err == nil && old.Wanted != "" {
+			s.Versions["8.6"] = VersionState{Wanted: old.Wanted}
+			_ = SaveState(s)
+		}
 	}
 	return s, nil
 }
 
-// SaveState writes the redis slice, preserving other services' slices.
 func SaveState(s State) error {
 	all, err := state.Load()
 	if err != nil {
 		return err
+	}
+	if s.Versions == nil {
+		s.Versions = map[string]VersionState{}
 	}
 	payload, err := json.Marshal(s)
 	if err != nil {
@@ -68,20 +68,27 @@ func SaveState(s State) error {
 	return state.Save(all)
 }
 
-// SetWanted updates the wanted-state and persists. Rejects values
-// outside the WantedRunning/WantedStopped set so a typo can't silently
-// persist garbage that IsWanted will later read as "not running" (and
-// stop the process).
-func SetWanted(wanted string) error {
+func SetWanted(version, wanted string) error {
 	if wanted != WantedRunning && wanted != WantedStopped {
 		return fmt.Errorf("redis: invalid wanted state %q (want %q or %q)", wanted, WantedRunning, WantedStopped)
 	}
-	return SaveState(State{Wanted: wanted})
+	s, err := LoadState()
+	if err != nil {
+		return err
+	}
+	s.Versions[version] = VersionState{Wanted: wanted}
+	return SaveState(s)
 }
 
-// RemoveState drops the redis entry from state.json entirely. Used by
-// `redis:uninstall` so a fresh install doesn't inherit a stale wanted
-// flag from before.
+func RemoveVersion(version string) error {
+	s, err := LoadState()
+	if err != nil {
+		return err
+	}
+	delete(s.Versions, version)
+	return SaveState(s)
+}
+
 func RemoveState() error {
 	all, err := state.Load()
 	if err != nil {

--- a/internal/redis/state.go
+++ b/internal/redis/state.go
@@ -69,6 +69,9 @@ func SaveState(s State) error {
 }
 
 func SetWanted(version, wanted string) error {
+	if err := ValidateVersion(version); err != nil {
+		return err
+	}
 	if wanted != WantedRunning && wanted != WantedStopped {
 		return fmt.Errorf("redis: invalid wanted state %q (want %q or %q)", wanted, WantedRunning, WantedStopped)
 	}
@@ -81,6 +84,9 @@ func SetWanted(version, wanted string) error {
 }
 
 func RemoveVersion(version string) error {
+	if err := ValidateVersion(version); err != nil {
+		return err
+	}
 	s, err := LoadState()
 	if err != nil {
 		return err

--- a/internal/redis/state_test.go
+++ b/internal/redis/state_test.go
@@ -4,51 +4,66 @@ import (
 	"testing"
 )
 
-func TestState_RoundTrip(t *testing.T) {
+func TestLoadState_MissingReturnsEmptyVersions(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-
-	// Empty home → empty state.
 	s, err := LoadState()
 	if err != nil {
-		t.Fatalf("LoadState: %v", err)
+		t.Fatal(err)
 	}
-	if s.Wanted != "" {
-		t.Errorf("LoadState on empty home: Wanted = %q, want empty", s.Wanted)
+	if s.Versions == nil {
+		t.Error("Versions map should not be nil")
 	}
-
-	if err := SetWanted(WantedRunning); err != nil {
-		t.Fatalf("SetWanted: %v", err)
-	}
-
-	s, err = LoadState()
-	if err != nil {
-		t.Fatalf("LoadState after SetWanted: %v", err)
-	}
-	if s.Wanted != WantedRunning {
-		t.Errorf("LoadState.Wanted = %q, want %q", s.Wanted, WantedRunning)
+	if len(s.Versions) != 0 {
+		t.Error("expected empty versions")
 	}
 }
 
-func TestSetWanted_InvalidRejected(t *testing.T) {
+func TestSetWanted_Roundtrip(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if err := SetWanted("not-a-real-state"); err == nil {
-		t.Error("SetWanted should reject unknown values")
+	if err := SetWanted("8.6", WantedRunning); err != nil {
+		t.Fatal(err)
+	}
+	s, err := LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Versions["8.6"].Wanted != WantedRunning {
+		t.Errorf("wanted = %q", s.Versions["8.6"].Wanted)
+	}
+}
+
+func TestSetWanted_RejectsInvalid(t *testing.T) {
+	if err := SetWanted("8.6", "invalid"); err == nil {
+		t.Error("expected error for invalid wanted state")
+	}
+}
+
+func TestRemoveVersion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	SetWanted("8.6", WantedRunning)
+	if err := RemoveVersion("8.6"); err != nil {
+		t.Fatal(err)
+	}
+	s, err := LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.Versions["8.6"]; ok {
+		t.Error("version should be removed")
 	}
 }
 
 func TestRemoveState(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if err := SetWanted(WantedRunning); err != nil {
-		t.Fatalf("SetWanted: %v", err)
-	}
+	SetWanted("8.6", WantedRunning)
 	if err := RemoveState(); err != nil {
-		t.Fatalf("RemoveState: %v", err)
+		t.Fatal(err)
 	}
 	s, err := LoadState()
 	if err != nil {
-		t.Fatalf("LoadState after RemoveState: %v", err)
+		t.Fatal(err)
 	}
-	if s.Wanted != "" {
-		t.Errorf("LoadState.Wanted after RemoveState = %q, want empty", s.Wanted)
+	if len(s.Versions) != 0 {
+		t.Error("expected empty after RemoveState")
 	}
 }

--- a/internal/redis/templatevars.go
+++ b/internal/redis/templatevars.go
@@ -5,14 +5,9 @@ import (
 	"strconv"
 )
 
-// TemplateVars returns the variables available inside a pv.yml
-// `redis.env:` block. Redis is single-version with a fixed port, so
-// no parameters are needed.
-//
-// Keys: host, port, password, url.
-func TemplateVars() map[string]string {
+func TemplateVars(version string) map[string]string {
 	const host = "127.0.0.1"
-	port := PortFor()
+	port := PortFor(version)
 	return map[string]string{
 		"host":     host,
 		"port":     strconv.Itoa(port),

--- a/internal/redis/templatevars_test.go
+++ b/internal/redis/templatevars_test.go
@@ -1,22 +1,19 @@
 package redis
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestTemplateVars(t *testing.T) {
-	got := TemplateVars()
-
-	if got["host"] != "127.0.0.1" {
-		t.Errorf("host = %q, want 127.0.0.1", got["host"])
+	vars := TemplateVars("8.6")
+	if vars["host"] != "127.0.0.1" {
+		t.Errorf("host = %q", vars["host"])
 	}
-	if got["port"] != "6379" {
-		t.Errorf("port = %q, want 6379", got["port"])
+	if vars["port"] != "7160" {
+		t.Errorf("port = %q", vars["port"])
 	}
-	if got["password"] != "" {
-		t.Errorf("password = %q, want empty", got["password"])
+	if vars["password"] != "" {
+		t.Errorf("password = %q", vars["password"])
 	}
-	if got["url"] != "redis://127.0.0.1:6379" {
-		t.Errorf("url = %q, want redis://127.0.0.1:6379", got["url"])
+	if vars["url"] != "redis://127.0.0.1:7160" {
+		t.Errorf("url = %q", vars["url"])
 	}
 }

--- a/internal/redis/uninstall.go
+++ b/internal/redis/uninstall.go
@@ -25,8 +25,12 @@ import (
 // dirs first and then saving state would leave behind empty dirs.
 func Uninstall(force bool) error {
 	if isInstalledOnDisk() {
-		_ = SetWanted(WantedStopped)
-		_ = WaitStopped(10 * time.Second)
+		v, _ := ProbeVersion()
+		if v == "" {
+			v = "unknown"
+		}
+		_ = SetWanted(v, WantedStopped)
+		_ = WaitStopped(v, 10*time.Second)
 	}
 
 	// Update bookkeeping first — these saves call EnsureDirs internally

--- a/internal/redis/uninstall.go
+++ b/internal/redis/uninstall.go
@@ -9,65 +9,37 @@ import (
 	"github.com/prvious/pv/internal/registry"
 )
 
-// Uninstall removes on-disk state for redis. With force=false: removes
-// binary tree, log file, state entry, and version-tracking entry; the
-// data dir at ~/.pv/data/redis/ is preserved. With force=true: also
-// removes the data dir.
-//
-// Caller's responsibility to handle the running daemon — Uninstall sets
-// wanted=stopped and waits up to 10s for the TCP port to close before
-// removing files.
-//
-// Ordering note: state/versions/registry saves happen BEFORE file
-// removal. Each of those Save calls routes through config.EnsureDirs,
-// which (unlike mysql/postgres where EnsureDirs only creates the parent
-// dir) recreates RedisDir and RedisDataDir directly — so removing the
-// dirs first and then saving state would leave behind empty dirs.
-func Uninstall(force bool) error {
-	if isInstalledOnDisk() {
-		v, _ := ProbeVersion()
-		if v == "" {
-			v = "unknown"
-		}
-		_ = SetWanted(v, WantedStopped)
-		_ = WaitStopped(v, 10*time.Second)
+func Uninstall(version string, force bool) error {
+	if isInstalledOnDisk(version) {
+		_ = SetWanted(version, WantedStopped)
+		_ = WaitStopped(version, 10*time.Second)
 	}
 
-	// Update bookkeeping first — these saves call EnsureDirs internally
-	// and would otherwise recreate the dirs we're about to remove.
-	if err := RemoveState(); err != nil {
+	if err := RemoveVersion(version); err != nil {
 		return err
 	}
 	if vs, err := binaries.LoadVersions(); err == nil {
-		delete(vs.Versions, "redis")
+		delete(vs.Versions, "redis-"+version)
 		_ = vs.Save()
 	}
 	if reg, err := registry.Load(); err == nil {
-		// UnbindService("redis") already exists in registry.go and clears
-		// Services.Redis on every project — we don't need a redis-specific
-		// helper because redis is single-version (mysql/postgres needed
-		// version-aware helpers because their bindings carry a version).
-		reg.UnbindService("redis")
+		reg.UnbindRedisVersion(version)
 		_ = reg.Save()
 	}
 
-	// File removal last so the bookkeeping saves above don't recreate the
-	// dirs via EnsureDirs.
-	if err := os.RemoveAll(config.RedisDir()); err != nil {
+	if err := os.RemoveAll(config.RedisVersionDir(version)); err != nil {
 		return err
 	}
-	_ = os.Remove(config.RedisLogPath())
+	_ = os.Remove(config.RedisLogPathV(version))
 	if force {
-		if err := os.RemoveAll(config.RedisDataDir()); err != nil {
+		if err := os.RemoveAll(config.RedisDataDirV(version)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// isInstalledOnDisk is a cheap pre-check used by Uninstall to skip the
-// 10s wait when there's nothing on disk.
-func isInstalledOnDisk() bool {
-	_, err := os.Stat(config.RedisDir())
+func isInstalledOnDisk(version string) bool {
+	_, err := os.Stat(config.RedisVersionDir(version))
 	return err == nil
 }

--- a/internal/redis/uninstall.go
+++ b/internal/redis/uninstall.go
@@ -10,9 +10,21 @@ import (
 )
 
 func Uninstall(version string, force bool) error {
+	if err := ValidateVersion(version); err != nil {
+		return err
+	}
 	if isInstalledOnDisk(version) {
 		_ = SetWanted(version, WantedStopped)
 		_ = WaitStopped(version, 10*time.Second)
+	}
+
+	reg, err := registry.Load()
+	if err != nil {
+		return err
+	}
+	reg.UnbindRedisVersion(version)
+	if err := reg.Save(); err != nil {
+		return err
 	}
 
 	if err := RemoveVersion(version); err != nil {
@@ -21,10 +33,6 @@ func Uninstall(version string, force bool) error {
 	if vs, err := binaries.LoadVersions(); err == nil {
 		delete(vs.Versions, "redis-"+version)
 		_ = vs.Save()
-	}
-	if reg, err := registry.Load(); err == nil {
-		reg.UnbindRedisVersion(version)
-		_ = reg.Save()
 	}
 
 	if err := os.RemoveAll(config.RedisVersionDir(version)); err != nil {

--- a/internal/redis/uninstall_test.go
+++ b/internal/redis/uninstall_test.go
@@ -80,3 +80,29 @@ func TestUninstall_UnbindsProjects(t *testing.T) {
 		t.Errorf("project should have Redis unbound after uninstall")
 	}
 }
+
+func TestUninstall_PropagatesRegistryLoadError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	setupInstalledRedis(t, "8.6")
+
+	if err := os.MkdirAll(filepath.Dir(config.RegistryPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(config.RegistryPath(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Uninstall("8.6", false); err == nil {
+		t.Fatal("Uninstall: want registry load error")
+	}
+	if _, err := os.Stat(config.RedisVersionDir("8.6")); err != nil {
+		t.Fatalf("redis binary dir should remain after registry error: %v", err)
+	}
+	st, err := LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Versions["8.6"].Wanted != WantedStopped {
+		t.Fatalf("redis state should remain stopped after registry error, got %#v", st.Versions["8.6"])
+	}
+}

--- a/internal/redis/uninstall_test.go
+++ b/internal/redis/uninstall_test.go
@@ -9,75 +9,74 @@ import (
 	"github.com/prvious/pv/internal/registry"
 )
 
-func setupInstalledRedis(t *testing.T) {
+func setupInstalledRedis(t *testing.T, version string) {
 	t.Helper()
-	if err := os.MkdirAll(config.RedisDir(), 0o755); err != nil {
+	if err := os.MkdirAll(config.RedisVersionDir(version), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(config.RedisDir(), "redis-server"), []byte{}, 0o755); err != nil {
+	if err := os.WriteFile(filepath.Join(config.RedisVersionDir(version), "redis-server"), []byte{}, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(config.RedisDataDir(), 0o755); err != nil {
+	if err := os.MkdirAll(config.RedisDataDirV(version), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(config.RedisDataDir(), "dump.rdb"), []byte("fake"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(config.RedisDataDirV(version), "dump.rdb"), []byte("fake"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_ = SetWanted(WantedRunning)
+	_ = SetWanted(version, WantedRunning)
 }
 
 func TestUninstall_NoForce_KeepsDatadir(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	setupInstalledRedis(t)
+	setupInstalledRedis(t, "8.6")
 
-	if err := Uninstall(false); err != nil {
+	if err := Uninstall("8.6", false); err != nil {
 		t.Fatalf("Uninstall: %v", err)
 	}
-	if _, err := os.Stat(config.RedisDir()); !os.IsNotExist(err) {
-		t.Errorf("RedisDir should be removed: err=%v", err)
+	if _, err := os.Stat(config.RedisVersionDir("8.6")); !os.IsNotExist(err) {
+		t.Errorf("RedisVersionDir should be removed: err=%v", err)
 	}
-	if _, err := os.Stat(config.RedisDataDir()); err != nil {
-		t.Errorf("RedisDataDir should remain: %v", err)
+	if _, err := os.Stat(config.RedisDataDirV("8.6")); err != nil {
+		t.Errorf("RedisDataDirV should remain: %v", err)
 	}
 	st, _ := LoadState()
-	if st.Wanted != "" {
-		t.Errorf("state should be cleared, got Wanted=%q", st.Wanted)
+	if len(st.Versions) != 0 {
+		t.Errorf("state should be cleared, got %d versions", len(st.Versions))
 	}
 }
 
 func TestUninstall_Force_RemovesDatadir(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	setupInstalledRedis(t)
+	setupInstalledRedis(t, "8.6")
 
-	if err := Uninstall(true); err != nil {
+	if err := Uninstall("8.6", true); err != nil {
 		t.Fatalf("Uninstall(force): %v", err)
 	}
-	if _, err := os.Stat(config.RedisDataDir()); !os.IsNotExist(err) {
-		t.Errorf("RedisDataDir should be removed with --force: err=%v", err)
+	if _, err := os.Stat(config.RedisDataDirV("8.6")); !os.IsNotExist(err) {
+		t.Errorf("RedisDataDirV should be removed with --force: err=%v", err)
 	}
 }
 
 func TestUninstall_UnbindsProjects(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	setupInstalledRedis(t)
+	setupInstalledRedis(t, "8.6")
 
-	// Pre-load a project bound to redis.
 	reg := &registry.Registry{
 		Services: map[string]*registry.ServiceInstance{},
 		Projects: []registry.Project{
-			{Name: "foo", Path: "/tmp/foo", Type: "laravel", Services: &registry.ProjectServices{Redis: true}},
+			{Name: "foo", Path: "/tmp/foo", Type: "laravel", Services: &registry.ProjectServices{Redis: "8.6"}},
 		},
 	}
 	if err := reg.Save(); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Uninstall(false); err != nil {
+	if err := Uninstall("8.6", false); err != nil {
 		t.Fatalf("Uninstall: %v", err)
 	}
 
 	r2, _ := registry.Load()
-	if r2.Projects[0].Services != nil && r2.Projects[0].Services.Redis {
-		t.Errorf("project should have Redis=false after uninstall")
+	if r2.Projects[0].Services != nil && r2.Projects[0].Services.Redis != "" {
+		t.Errorf("project should have Redis unbound after uninstall")
 	}
 }

--- a/internal/redis/update.go
+++ b/internal/redis/update.go
@@ -11,39 +11,25 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-// Update redownloads the redis tarball and atomically replaces the
-// binary tree. Data dir is untouched. If wanted=running before the
-// update, restores wanted=running on success; otherwise leaves wanted
-// as-is (user-driven).
-func Update(client *http.Client) error {
-	return UpdateProgress(client, nil)
+func Update(client *http.Client, version string) error {
+	return UpdateProgress(client, version, nil)
 }
 
-// UpdateProgress is Update with a download progress callback.
-func UpdateProgress(client *http.Client, progress binaries.ProgressFunc) error {
-	if !IsInstalled() {
-		return fmt.Errorf("redis is not installed")
+func UpdateProgress(client *http.Client, version string, progress binaries.ProgressFunc) error {
+	if !IsInstalled(version) {
+		return fmt.Errorf("redis-%s is not installed", version)
 	}
 
-	// Snapshot prior wanted-state so we can restore it after a successful
-	// update. A user who explicitly stopped redis before running
-	// `redis:update` should NOT see it auto-start.
 	prevWanted := WantedStopped
-	prevVersion := "unknown"
 	if st, err := LoadState(); err == nil {
-		for ver, vs := range st.Versions {
-			prevVersion = ver
-			if vs.Wanted != "" {
-				prevWanted = vs.Wanted
-			}
+		if vs, ok := st.Versions[version]; ok && vs.Wanted != "" {
+			prevWanted = vs.Wanted
 		}
 	}
 
-	// Stop running daemon (if any) and wait for the TCP port to close
-	// before swapping binaries.
 	if prevWanted == WantedRunning {
-		_ = SetWanted(prevVersion, WantedStopped)
-		_ = WaitStopped(prevVersion, 10*time.Second)
+		_ = SetWanted(version, WantedStopped)
+		_ = WaitStopped(version, 10*time.Second)
 	}
 
 	url, err := resolveRedisURL()
@@ -51,14 +37,14 @@ func UpdateProgress(client *http.Client, progress binaries.ProgressFunc) error {
 		return err
 	}
 
-	dir := config.RedisDir()
-	stagingDir := dir + ".new"
+	versionDir := config.RedisVersionDir(version)
+	stagingDir := versionDir + ".new"
 	os.RemoveAll(stagingDir)
 	if err := os.MkdirAll(stagingDir, 0o755); err != nil {
 		return fmt.Errorf("create staging: %w", err)
 	}
 
-	archive := filepath.Join(config.PvDir(), "redis.tar.gz")
+	archive := filepath.Join(config.PvDir(), "redis-"+version+".tar.gz")
 	if err := binaries.DownloadProgress(client, url, archive, progress); err != nil {
 		os.RemoveAll(stagingDir)
 		return fmt.Errorf("download: %w", err)
@@ -70,36 +56,31 @@ func UpdateProgress(client *http.Client, progress binaries.ProgressFunc) error {
 	}
 	os.Remove(archive)
 
-	// Two-phase swap (NOT atomic — two os.Rename calls). If the second
-	// rename fails we attempt a best-effort restore; if THAT also fails
-	// the user is in a half-broken state and must know about it.
-	oldDir := dir + ".old"
+	oldDir := versionDir + ".old"
 	os.RemoveAll(oldDir)
-	if err := os.Rename(dir, oldDir); err != nil {
+	if err := os.Rename(versionDir, oldDir); err != nil {
 		os.RemoveAll(stagingDir)
 		return fmt.Errorf("rename old: %w", err)
 	}
-	if err := os.Rename(stagingDir, dir); err != nil {
-		if rollbackErr := os.Rename(oldDir, dir); rollbackErr != nil {
-			return fmt.Errorf("rename new failed (%w); rollback also failed (%v); redis install dir is broken — manually mv %s %s",
-				err, rollbackErr, oldDir, dir)
+	if err := os.Rename(stagingDir, versionDir); err != nil {
+		if rollbackErr := os.Rename(oldDir, versionDir); rollbackErr != nil {
+			return fmt.Errorf("rename new failed (%w); rollback also failed (%v); redis %s install dir is broken",
+				err, rollbackErr, version)
 		}
 		return fmt.Errorf("rename new: %w", err)
 	}
 	os.RemoveAll(oldDir)
 
-	if err := chownToTarget(dir); err != nil {
+	if err := chownToTarget(versionDir); err != nil {
 		return fmt.Errorf("chown redis tree: %w", err)
 	}
 
-	// Re-probe + record version.
-	if v, err := ProbeVersion(); err == nil {
+	if v, err := ProbeVersion(version); err == nil {
 		if vs, err := binaries.LoadVersions(); err == nil {
-			vs.Set("redis", v)
+			vs.Set("redis-"+version, v)
 			_ = vs.Save()
 		}
 	}
 
-	// Restore prior wanted-state.
-	return SetWanted(prevVersion, prevWanted)
+	return SetWanted(version, prevWanted)
 }

--- a/internal/redis/update.go
+++ b/internal/redis/update.go
@@ -16,6 +16,9 @@ func Update(client *http.Client, version string) error {
 }
 
 func UpdateProgress(client *http.Client, version string, progress binaries.ProgressFunc) error {
+	if err := ValidateVersion(version); err != nil {
+		return err
+	}
 	if !IsInstalled(version) {
 		return fmt.Errorf("redis-%s is not installed", version)
 	}

--- a/internal/redis/update.go
+++ b/internal/redis/update.go
@@ -29,15 +29,21 @@ func UpdateProgress(client *http.Client, progress binaries.ProgressFunc) error {
 	// update. A user who explicitly stopped redis before running
 	// `redis:update` should NOT see it auto-start.
 	prevWanted := WantedStopped
-	if st, err := LoadState(); err == nil && st.Wanted != "" {
-		prevWanted = st.Wanted
+	prevVersion := "unknown"
+	if st, err := LoadState(); err == nil {
+		for ver, vs := range st.Versions {
+			prevVersion = ver
+			if vs.Wanted != "" {
+				prevWanted = vs.Wanted
+			}
+		}
 	}
 
 	// Stop running daemon (if any) and wait for the TCP port to close
 	// before swapping binaries.
 	if prevWanted == WantedRunning {
-		_ = SetWanted(WantedStopped)
-		_ = WaitStopped(10 * time.Second)
+		_ = SetWanted(prevVersion, WantedStopped)
+		_ = WaitStopped(prevVersion, 10*time.Second)
 	}
 
 	url, err := resolveRedisURL()
@@ -95,5 +101,5 @@ func UpdateProgress(client *http.Client, progress binaries.ProgressFunc) error {
 	}
 
 	// Restore prior wanted-state.
-	return SetWanted(prevWanted)
+	return SetWanted(prevVersion, prevWanted)
 }

--- a/internal/redis/update_test.go
+++ b/internal/redis/update_test.go
@@ -20,37 +20,36 @@ func TestUpdate_ReplacesBinaryTree(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("PV_REDIS_URL_OVERRIDE", srv.URL)
 
-	if err := Install(http.DefaultClient); err != nil {
+	version := "8.6"
+
+	if err := Install(http.DefaultClient, version); err != nil {
 		t.Fatalf("Install: %v", err)
 	}
 
-	// Drop a sentinel into the data dir; Update must NOT touch it.
-	dataFile := filepath.Join(config.RedisDataDir(), "dump.rdb")
+	dataFile := filepath.Join(config.RedisDataDirV(version), "dump.rdb")
 	if err := os.WriteFile(dataFile, []byte("preserve-me"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := Update(http.DefaultClient); err != nil {
+	if err := Update(http.DefaultClient, version); err != nil {
 		t.Fatalf("Update: %v", err)
 	}
 
-	// Data file must still be there.
 	if got, err := os.ReadFile(dataFile); err != nil {
 		t.Fatalf("data file gone: %v", err)
 	} else if string(got) != "preserve-me" {
 		t.Errorf("data file mutated: %q", got)
 	}
 
-	// State must remain wanted=running.
 	st, _ := LoadState()
-	if st.Wanted != WantedRunning {
-		t.Errorf("state.Wanted = %q after Update, want running", st.Wanted)
+	if st.Versions[version].Wanted != WantedRunning {
+		t.Errorf("state should have version %s marked wanted=running after Update", version)
 	}
 }
 
 func TestUpdate_NotInstalledErrors(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if err := Update(http.DefaultClient); err == nil {
+	if err := Update(http.DefaultClient, "8.6"); err == nil {
 		t.Error("Update should error when redis is not installed")
 	}
 }

--- a/internal/redis/version.go
+++ b/internal/redis/version.go
@@ -7,29 +7,17 @@ import (
 	"strings"
 )
 
-// redisVersionRE pulls the version token out of `redis-server --version`.
-// Real-world output:
-//
-//	Redis server v=7.4.1 sha=00000000:0 malloc=libc bits=64 build=...
-//
-// The regexp anchors on `v=` to avoid matching version-looking
-// substrings elsewhere on the line (e.g. "build=v1234"-style tokens).
 var redisVersionRE = regexp.MustCompile(`v=(\d+\.\d+\.\d+)\b`)
 
-// ProbeVersion runs `<RedisDir>/redis-server --version` and returns the
-// precise version string (e.g. "7.4.1"). Used at install/update time to
-// record the patch level into versions.json.
-func ProbeVersion() (string, error) {
-	out, err := exec.Command(ServerBinary(), "--version").Output()
+func ProbeVersion(version string) (string, error) {
+	binPath := ServerBinary(version)
+	out, err := exec.Command(binPath, "--version").Output()
 	if err != nil {
 		return "", fmt.Errorf("redis-server --version: %w", err)
 	}
 	return parseRedisVersion(string(out))
 }
 
-// parseRedisVersion is exposed (lowercase) to the test in version_test.go
-// so the parser can be exercised against many real-world output lines
-// without having to compile a fake redis-server for each one.
 func parseRedisVersion(out string) (string, error) {
 	s := strings.TrimSpace(out)
 	if s == "" {

--- a/internal/redis/version.go
+++ b/internal/redis/version.go
@@ -5,11 +5,30 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+
+	"github.com/prvious/pv/internal/config"
 )
 
 var redisVersionRE = regexp.MustCompile(`v=(\d+\.\d+\.\d+)\b`)
 
+func ResolveVersion(version string) (string, error) {
+	if version == "" {
+		version = config.RedisDefaultVersion()
+	}
+	return version, ValidateVersion(version)
+}
+
+func ValidateVersion(version string) error {
+	if version != config.RedisDefaultVersion() {
+		return fmt.Errorf("unsupported redis version %q (supported: %s)", version, config.RedisDefaultVersion())
+	}
+	return nil
+}
+
 func ProbeVersion(version string) (string, error) {
+	if err := ValidateVersion(version); err != nil {
+		return "", err
+	}
 	binPath := ServerBinary(version)
 	out, err := exec.Command(binPath, "--version").Output()
 	if err != nil {

--- a/internal/redis/version_test.go
+++ b/internal/redis/version_test.go
@@ -33,3 +33,29 @@ func TestParseRedisVersion_Garbage(t *testing.T) {
 		t.Error("expected error for garbage input")
 	}
 }
+
+func TestValidateVersionRejectsUnsupportedVersions(t *testing.T) {
+	for _, version := range []string{"", "7.4", "banana", "8.6/evil"} {
+		t.Run(version, func(t *testing.T) {
+			if err := ValidateVersion(version); err == nil {
+				t.Fatalf("ValidateVersion(%q): want error", version)
+			}
+		})
+	}
+}
+
+func TestSetWantedRejectsUnsupportedVersion(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	if err := SetWanted("7.4", WantedRunning); err == nil {
+		t.Fatal("SetWanted unsupported version: want error")
+	}
+
+	st, err := LoadState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Versions) != 0 {
+		t.Fatalf("state versions = %#v, want empty", st.Versions)
+	}
+}

--- a/internal/redis/version_test.go
+++ b/internal/redis/version_test.go
@@ -1,59 +1,35 @@
 package redis
 
-import (
-	"os"
-	"os/exec"
-	"path/filepath"
-	"testing"
-
-	"github.com/prvious/pv/internal/config"
-)
+import "testing"
 
 func TestParseRedisVersion(t *testing.T) {
 	tests := []struct {
-		in   string
-		want string
+		input string
+		want  string
 	}{
-		{"Redis server v=7.4.1 sha=00000000:0 malloc=libc bits=64 build=abc123", "7.4.1"},
-		{"Redis server v=8.0.0 sha=ffffffff:0 malloc=jemalloc bits=64 build=000", "8.0.0"},
-		{"  Redis server v=7.2.5 sha=12345678:0 malloc=libc bits=64 build=...  ", "7.2.5"},
+		{"Redis server v=7.4.1 sha=00000000:0 malloc=libc bits=64 build=fake", "7.4.1"},
+		{"Redis server v=8.6.0 sha=00000000:0 malloc=libc bits=64 build=x", "8.6.0"},
 	}
-	for _, tt := range tests {
-		got, err := parseRedisVersion(tt.in)
+	for _, tc := range tests {
+		got, err := parseRedisVersion(tc.input)
 		if err != nil {
-			t.Errorf("parseRedisVersion(%q): %v", tt.in, err)
+			t.Errorf("parseRedisVersion(%q) error: %v", tc.input, err)
 			continue
 		}
-		if got != tt.want {
-			t.Errorf("parseRedisVersion(%q) = %q, want %q", tt.in, got, tt.want)
+		if got != tc.want {
+			t.Errorf("parseRedisVersion(%q) = %q, want %q", tc.input, got, tc.want)
 		}
 	}
 }
 
-func TestParseRedisVersion_Invalid(t *testing.T) {
-	for _, in := range []string{"", "garbage output", "Redis server but no version"} {
-		if _, err := parseRedisVersion(in); err == nil {
-			t.Errorf("parseRedisVersion(%q) should error", in)
-		}
+func TestParseRedisVersion_Empty(t *testing.T) {
+	if _, err := parseRedisVersion(""); err == nil {
+		t.Error("expected error for empty input")
 	}
 }
 
-func TestProbeVersion_AgainstFake(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	if err := os.MkdirAll(config.RedisDir(), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	bin := filepath.Join(config.RedisDir(), "redis-server")
-	cmd := exec.Command("go", "build", "-o", bin,
-		filepath.Join("testdata", "fake-redis-server.go"))
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("build fake redis-server: %v\n%s", err, out)
-	}
-	v, err := ProbeVersion()
-	if err != nil {
-		t.Fatalf("ProbeVersion: %v", err)
-	}
-	if v != "7.4.1" {
-		t.Errorf("ProbeVersion = %q, want 7.4.1", v)
+func TestParseRedisVersion_Garbage(t *testing.T) {
+	if _, err := parseRedisVersion("not redis output at all"); err == nil {
+		t.Error("expected error for garbage input")
 	}
 }

--- a/internal/redis/waitstopped.go
+++ b/internal/redis/waitstopped.go
@@ -7,6 +7,9 @@ import (
 )
 
 func WaitStopped(version string, timeout time.Duration) error {
+	if err := ValidateVersion(version); err != nil {
+		return err
+	}
 	addr := fmt.Sprintf("127.0.0.1:%d", PortFor(version))
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {

--- a/internal/redis/waitstopped.go
+++ b/internal/redis/waitstopped.go
@@ -6,15 +6,8 @@ import (
 	"time"
 )
 
-// WaitStopped polls the redis TCP port until connections are refused,
-// or until timeout. Used by uninstall/update before destructive on-disk
-// operations. A fixed sleep doesn't account for "redis is in the middle
-// of an RDB save" — verify shutdown directly.
-//
-// 10s is plenty for a typical dev-load redis: even a forced BGSAVE on
-// a multi-GB dataset finishes in seconds.
-func WaitStopped(timeout time.Duration) error {
-	addr := fmt.Sprintf("127.0.0.1:%d", PortFor())
+func WaitStopped(version string, timeout time.Duration) error {
+	addr := fmt.Sprintf("127.0.0.1:%d", PortFor(version))
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
@@ -24,5 +17,5 @@ func WaitStopped(timeout time.Duration) error {
 		c.Close()
 		time.Sleep(200 * time.Millisecond)
 	}
-	return fmt.Errorf("redis did not stop within %s", timeout)
+	return fmt.Errorf("redis %s did not stop within %s", version, timeout)
 }

--- a/internal/redis/wanted.go
+++ b/internal/redis/wanted.go
@@ -3,25 +3,33 @@ package redis
 import (
 	"fmt"
 	"os"
+	"sort"
 )
 
-// IsWanted reports whether redis should currently be supervised:
-// state says wanted=running AND the binary is on disk. Stale entries
-// (state says running but binary is missing) emit a stderr warning and
-// return false — recovery is `redis:install` after the binary is
-// restored.
-func IsWanted() bool {
+func WantedVersions() ([]string, error) {
 	st, err := LoadState()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "redis: load state: %v\n", err)
-		return false
+		return nil, err
 	}
-	if st.Wanted != WantedRunning {
-		return false
+	installed, err := InstalledVersions()
+	if err != nil {
+		return nil, err
 	}
-	if !IsInstalled() {
-		fmt.Fprintln(os.Stderr, "redis: state.json wants redis running but binary is missing; skipping")
-		return false
+	installedSet := map[string]struct{}{}
+	for _, v := range installed {
+		installedSet[v] = struct{}{}
 	}
-	return true
+	var out []string
+	for version, vs := range st.Versions {
+		if vs.Wanted != WantedRunning {
+			continue
+		}
+		if _, ok := installedSet[version]; !ok {
+			fmt.Fprintf(os.Stderr, "redis: state.json wants %s running but binary is missing; skipping\n", version)
+			continue
+		}
+		out = append(out, version)
+	}
+	sort.Strings(out)
+	return out, nil
 }

--- a/internal/redis/wanted_test.go
+++ b/internal/redis/wanted_test.go
@@ -8,52 +8,49 @@ import (
 	"github.com/prvious/pv/internal/config"
 )
 
-func install(t *testing.T) {
-	t.Helper()
-	if err := os.MkdirAll(config.RedisDir(), 0o755); err != nil {
+func TestWantedVersions_Empty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	vs, err := WantedVersions()
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(config.RedisDir(), "redis-server"), []byte{}, 0o755); err != nil {
-		t.Fatal(err)
+	if len(vs) != 0 {
+		t.Error("expected empty")
 	}
 }
 
-func TestIsWanted_NotInstalled(t *testing.T) {
+func TestWantedVersions_WantedAndInstalled(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if IsWanted() {
-		t.Error("IsWanted should be false when binary missing")
+
+	if err := SetWanted("8.6", WantedRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	versionDir := config.RedisVersionDir("8.6")
+	os.MkdirAll(versionDir, 0o755)
+	os.WriteFile(filepath.Join(versionDir, "redis-server"), []byte("x"), 0o755)
+
+	vs, err := WantedVersions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vs) != 1 || vs[0] != "8.6" {
+		t.Errorf("got %v, want [8.6]", vs)
 	}
 }
 
-func TestIsWanted_InstalledButStopped(t *testing.T) {
+func TestWantedVersions_WantedButNotInstalled_Skipped(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	install(t)
-	if err := SetWanted(WantedStopped); err != nil {
-		t.Fatal(err)
-	}
-	if IsWanted() {
-		t.Error("IsWanted should be false when wanted=stopped")
-	}
-}
 
-func TestIsWanted_InstalledAndRunning(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	install(t)
-	if err := SetWanted(WantedRunning); err != nil {
+	if err := SetWanted("8.6", WantedRunning); err != nil {
 		t.Fatal(err)
 	}
-	if !IsWanted() {
-		t.Error("IsWanted should be true when binary present and wanted=running")
-	}
-}
 
-func TestIsWanted_StaleStateNoBinary(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	// SetWanted to running without installing the binary — drift case.
-	if err := SetWanted(WantedRunning); err != nil {
+	vs, err := WantedVersions()
+	if err != nil {
 		t.Fatal(err)
 	}
-	if IsWanted() {
-		t.Error("IsWanted should be false when binary missing despite state=running")
+	if len(vs) != 0 {
+		t.Error("expected empty when binary missing")
 	}
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -23,8 +23,34 @@ type ProjectServices struct {
 	Mail     bool   `json:"mail,omitempty"`
 	MySQL    string `json:"mysql,omitempty"`
 	Postgres string `json:"postgres,omitempty"`
-	Redis    bool   `json:"redis,omitempty"`
+	Redis    string `json:"redis,omitempty"`
 	S3       bool   `json:"s3,omitempty"`
+}
+
+func (ps *ProjectServices) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if rawRedis, ok := raw["redis"]; ok {
+		var b bool
+		if err := json.Unmarshal(rawRedis, &b); err == nil {
+			if b {
+				raw["redis"] = json.RawMessage(`"8.6"`)
+			} else {
+				delete(raw, "redis")
+			}
+		}
+	}
+
+	fixed, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+
+	type psAlias ProjectServices
+	return json.Unmarshal(fixed, (*psAlias)(ps))
 }
 
 type Project struct {
@@ -201,7 +227,7 @@ func (r *Registry) ProjectsUsingService(serviceName string) []string {
 				names = append(names, p.Name)
 			}
 		case "redis":
-			if p.Services.Redis {
+			if p.Services.Redis != "" {
 				names = append(names, p.Name)
 			}
 		case "s3":
@@ -227,7 +253,7 @@ func (r *Registry) UnbindService(serviceName string) {
 		case "postgres":
 			r.Projects[i].Services.Postgres = ""
 		case "redis":
-			r.Projects[i].Services.Redis = false
+			r.Projects[i].Services.Redis = ""
 		case "s3":
 			r.Projects[i].Services.S3 = false
 		}
@@ -245,6 +271,22 @@ func (r *Registry) UnbindPostgresMajor(major string) {
 		}
 		if r.Projects[i].Services.Postgres == major {
 			r.Projects[i].Services.Postgres = ""
+		}
+	}
+}
+
+// UnbindRedisVersion clears Services.Redis on every project bound to the
+// given version. Projects bound to other versions are unaffected.
+// Tighter than UnbindService("redis") — that would clear all redis bindings
+// regardless of version, which is wrong when only one of several installed
+// versions is being removed.
+func (r *Registry) UnbindRedisVersion(version string) {
+	for i := range r.Projects {
+		if r.Projects[i].Services == nil {
+			continue
+		}
+		if r.Projects[i].Services.Redis == version {
+			r.Projects[i].Services.Redis = ""
 		}
 	}
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -555,7 +555,7 @@ func TestProjectsUsingService(t *testing.T) {
 	r := &Registry{
 		Services: make(map[string]*ServiceInstance),
 		Projects: []Project{
-			{Name: "app1", Path: "/a", Services: &ProjectServices{MySQL: "8.4", Redis: true}},
+			{Name: "app1", Path: "/a", Services: &ProjectServices{MySQL: "8.4", Redis: "8.6"}},
 			{Name: "app2", Path: "/b", Services: &ProjectServices{MySQL: "8.4"}},
 			{Name: "app3", Path: "/c"},
 		},
@@ -781,6 +781,43 @@ func TestUnbindMysqlVersion(t *testing.T) {
 	for _, p := range r.Projects {
 		if p.Name == "d" && p.Services != nil {
 			t.Errorf("project d.Services should remain nil, got %+v", p.Services)
+		}
+	}
+}
+
+func TestUnbindRedisVersion(t *testing.T) {
+	r := &Registry{
+		Services: map[string]*ServiceInstance{},
+		Projects: []Project{
+			{Name: "a", Services: &ProjectServices{Redis: "8.6"}},
+			{Name: "b", Services: &ProjectServices{Redis: "7.4"}},
+			{Name: "c", Services: &ProjectServices{Redis: "8.6"}},
+			{Name: "d", Services: nil},
+		},
+	}
+	r.UnbindRedisVersion("8.6")
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"a", ""},
+		{"b", "7.4"},
+		{"c", ""},
+	}
+	for _, tc := range cases {
+		for _, p := range r.Projects {
+			if p.Name == tc.name {
+				if p.Services == nil {
+					t.Errorf("%s: Services is nil", tc.name)
+				} else if p.Services.Redis != tc.want {
+					t.Errorf("%s: Redis = %q, want %q", tc.name, p.Services.Redis, tc.want)
+				}
+			}
+		}
+	}
+	for _, p := range r.Projects {
+		if p.Name == "d" && p.Services != nil {
+			t.Error("project d: Services should be nil")
 		}
 	}
 }

--- a/internal/server/manager.go
+++ b/internal/server/manager.go
@@ -172,7 +172,7 @@ func (m *ServerManager) RunningVersions() []string {
 //     gated on the registry Enabled flag.
 //  2. internal/postgres: multi-version, on-disk + state.json driven.
 //  3. internal/mysql:    multi-version, on-disk + state.json driven.
-//  4. internal/redis:    single-version, on-disk + state.json driven.
+//  4. internal/redis:    versioned, on-disk + state.json driven.
 //
 // The diff/start/stop loop is shared across all four sources.
 func (m *ServerManager) reconcileBinaryServices(ctx context.Context) error {
@@ -242,9 +242,9 @@ func (m *ServerManager) reconcileBinaryServices(ctx context.Context) error {
 	}
 
 	// Source 4 — redis, per-version, filesystem + state.json.
-	redisVersions, err := redis.WantedVersions()
-	if err != nil {
-		startErrors = append(startErrors, fmt.Sprintf("redis: wanted: %v", err))
+	redisVersions, redisErr := redis.WantedVersions()
+	if redisErr != nil {
+		startErrors = append(startErrors, fmt.Sprintf("redis: wanted: %v", redisErr))
 	}
 	for _, version := range redisVersions {
 		proc, err := redis.BuildSupervisorProcess(version)
@@ -258,7 +258,7 @@ func (m *ServerManager) reconcileBinaryServices(ctx context.Context) error {
 	// Diff: stop unneeded. If the postgres source failed, skip postgres-
 	// prefixed keys — a transient state.json read error shouldn't kill
 	// running postgres processes (the wanted set is incomplete, not empty).
-	// Same transient-error guard for mysql.
+	// Same transient-error guard for mysql and redis.
 	for _, supKey := range m.supervisor.SupervisedNames() {
 		if _, ok := wanted[supKey]; ok {
 			continue
@@ -267,6 +267,9 @@ func (m *ServerManager) reconcileBinaryServices(ctx context.Context) error {
 			continue
 		}
 		if myErr != nil && strings.HasPrefix(supKey, "mysql-") {
+			continue
+		}
+		if redisErr != nil && strings.HasPrefix(supKey, "redis-") {
 			continue
 		}
 		if err := m.supervisor.Stop(supKey, 10*time.Second); err != nil {

--- a/internal/server/manager.go
+++ b/internal/server/manager.go
@@ -241,13 +241,17 @@ func (m *ServerManager) reconcileBinaryServices(ctx context.Context) error {
 		wanted["mysql-"+version] = proc
 	}
 
-	// Source 4 — redis, single-version, filesystem + state.json.
-	if redis.IsWanted() {
-		proc, err := redis.BuildSupervisorProcess()
+	// Source 4 — redis, per-version, filesystem + state.json.
+	redisVersions, err := redis.WantedVersions()
+	if err != nil {
+		startErrors = append(startErrors, fmt.Sprintf("redis: wanted: %v", err))
+	}
+	for _, version := range redisVersions {
+		proc, err := redis.BuildSupervisorProcess(version)
 		if err != nil {
-			startErrors = append(startErrors, fmt.Sprintf("redis: build: %v", err))
+			startErrors = append(startErrors, fmt.Sprintf("redis-%s: build: %v", version, err))
 		} else {
-			wanted["redis"] = proc
+			wanted["redis-"+version] = proc
 		}
 	}
 

--- a/internal/server/manager_test.go
+++ b/internal/server/manager_test.go
@@ -353,3 +353,47 @@ func TestReconcileBinaryServices_StopsRemovedRedis(t *testing.T) {
 		t.Error("expected redis stopped after wanted flipped to stopped")
 	}
 }
+
+func TestReconcileBinaryServices_KeepsRedisRunningWhenWantedDiscoveryFails(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skipf("fake binary helper not supported on %s", runtime.GOOS)
+	}
+	t.Setenv("HOME", t.TempDir())
+
+	if err := os.MkdirAll(config.RedisVersionDir("8.6"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("go", "build", "-o", filepath.Join(config.RedisVersionDir("8.6"), "redis-server"),
+		filepath.Join("..", "..", "internal", "redis", "testdata", "fake-redis-server.go"))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fake redis-server: %v\n%s", err, out)
+	}
+	if err := redis.SetWanted("8.6", redis.WantedRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	sup := supervisor.New()
+	mgr := NewServerManager(nil, sup)
+	defer sup.StopAll(2 * time.Second)
+
+	if err := mgr.reconcileBinaryServices(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !sup.IsRunning("redis-8.6") {
+		t.Fatal("expected redis running after first reconcile")
+	}
+
+	if err := os.Remove(config.StatePath()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(config.StatePath(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mgr.reconcileBinaryServices(context.Background()); err == nil {
+		t.Fatal("reconcileBinaryServices: want error when redis wanted discovery fails")
+	}
+	if !sup.IsRunning("redis-8.6") {
+		t.Error("redis-8.6 should remain running when wanted discovery fails")
+	}
+}

--- a/internal/server/manager_test.go
+++ b/internal/server/manager_test.go
@@ -291,13 +291,13 @@ func TestReconcileBinaryServices_StartsWantedRedis(t *testing.T) {
 	if err := os.MkdirAll(config.RedisDir(), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("go", "build", "-o", filepath.Join(config.RedisDir(), "redis-server"),
+	cmd := exec.Command("go", "build", "-o", filepath.Join(config.RedisVersionDir("8.6"), "redis-server"),
 		filepath.Join("..", "..", "internal", "redis", "testdata", "fake-redis-server.go"))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("build fake redis-server: %v\n%s", err, out)
 	}
 
-	if err := redis.SetWanted(redis.WantedRunning); err != nil {
+	if err := redis.SetWanted("8.6", redis.WantedRunning); err != nil {
 		t.Fatal(err)
 	}
 
@@ -309,8 +309,8 @@ func TestReconcileBinaryServices_StartsWantedRedis(t *testing.T) {
 		t.Fatalf("reconcileBinaryServices: %v", err)
 	}
 
-	if !sup.IsRunning("redis") {
-		t.Error("expected redis to be supervised after reconcile")
+	if !sup.IsRunning("redis-8.6") {
+		t.Error("expected redis-8.6 to be supervised after reconcile")
 	}
 }
 
@@ -323,12 +323,12 @@ func TestReconcileBinaryServices_StopsRemovedRedis(t *testing.T) {
 	if err := os.MkdirAll(config.RedisDir(), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("go", "build", "-o", filepath.Join(config.RedisDir(), "redis-server"),
+	cmd := exec.Command("go", "build", "-o", filepath.Join(config.RedisVersionDir("8.6"), "redis-server"),
 		filepath.Join("..", "..", "internal", "redis", "testdata", "fake-redis-server.go"))
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("build fake redis-server: %v\n%s", err, out)
 	}
-	if err := redis.SetWanted(redis.WantedRunning); err != nil {
+	if err := redis.SetWanted("8.6", redis.WantedRunning); err != nil {
 		t.Fatal(err)
 	}
 
@@ -339,17 +339,17 @@ func TestReconcileBinaryServices_StopsRemovedRedis(t *testing.T) {
 	if err := mgr.reconcileBinaryServices(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if !sup.IsRunning("redis") {
+	if !sup.IsRunning("redis-8.6") {
 		t.Fatal("expected redis running after first reconcile")
 	}
 
-	if err := redis.SetWanted(redis.WantedStopped); err != nil {
+	if err := redis.SetWanted("8.6", redis.WantedStopped); err != nil {
 		t.Fatal(err)
 	}
 	if err := mgr.reconcileBinaryServices(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if sup.IsRunning("redis") {
+	if sup.IsRunning("redis-8.6") {
 		t.Error("expected redis stopped after wanted flipped to stopped")
 	}
 }

--- a/scripts/e2e/redis-binary.sh
+++ b/scripts/e2e/redis-binary.sh
@@ -43,26 +43,26 @@ YMLEOF
 sudo -E pv link "$ENVTEST_DIR" --name e2e-redis-env >/dev/null 2>&1 || { echo "FAIL: pv link"; exit 1; }
 
 echo "==> Verify binary tree exists"
-test -x "$HOME/.pv/redis/redis-server" || { echo "FAIL: redis-server binary missing"; exit 1; }
-test -x "$HOME/.pv/redis/redis-cli" || { echo "FAIL: redis-cli binary missing"; exit 1; }
+test -x "$HOME/.pv/redis/8.6/redis-server" || { echo "FAIL: redis-server binary missing"; exit 1; }
+test -x "$HOME/.pv/redis/8.6/redis-cli" || { echo "FAIL: redis-cli binary missing"; exit 1; }
 echo "OK: redis binary tree present"
 
-echo "==> Wait for port 6379 to accept connections"
-wait_for_tcp 127.0.0.1 6379 30 || { echo "FAIL: 6379 not reachable"; exit 1; }
-echo "OK: 6379 reachable"
+echo "==> Wait for port 7160 to accept connections"
+wait_for_tcp 127.0.0.1 7160 30 || { echo "FAIL: 7160 not reachable"; exit 1; }
+echo "OK: 7160 reachable"
 
-echo "==> Verify daemon-status.json lists redis"
-grep -q '"redis"' "$HOME/.pv/daemon-status.json" || { echo "FAIL: redis missing from daemon-status.json"; exit 1; }
+echo "==> Verify daemon-status.json lists redis-8.6"
+grep -q '"redis-8.6"' "$HOME/.pv/daemon-status.json" || { echo "FAIL: redis-8.6 missing from daemon-status.json"; exit 1; }
 echo "OK: daemon-status.json advertises redis"
 
 echo "==> redis-cli PING"
-PING=$("$HOME/.pv/redis/redis-cli" -h 127.0.0.1 -p 6379 PING | tr -d '[:space:]')
+PING=$("$HOME/.pv/redis/8.6/redis-cli" -h 127.0.0.1 -p 7160 PING | tr -d '[:space:]')
 [ "$PING" = "PONG" ] || { echo "FAIL: PING returned '$PING', want 'PONG'"; exit 1; }
 echo "OK: PING returned PONG"
 
 echo "==> redis-cli SET/GET roundtrip"
-"$HOME/.pv/redis/redis-cli" -h 127.0.0.1 -p 6379 SET pv_e2e_key "hello-world" >/dev/null
-GOT=$("$HOME/.pv/redis/redis-cli" -h 127.0.0.1 -p 6379 GET pv_e2e_key)
+"$HOME/.pv/redis/8.6/redis-cli" -h 127.0.0.1 -p 7160 SET pv_e2e_key "hello-world" >/dev/null
+GOT=$("$HOME/.pv/redis/8.6/redis-cli" -h 127.0.0.1 -p 7160 GET pv_e2e_key)
 [ "$GOT" = "hello-world" ] || { echo "FAIL: GET returned '$GOT', want 'hello-world'"; exit 1; }
 echo "OK: SET/GET roundtrip"
 
@@ -76,38 +76,38 @@ grep -q "REDIS_HOST=127.0.0.1" "$ENVTEST_DIR/.env" || {
     cat "$ENVTEST_DIR/.env";
     exit 1;
 }
-grep -q "REDIS_PORT=6379" "$ENVTEST_DIR/.env" || { echo "FAIL: missing REDIS_PORT=6379"; exit 1; }
+grep -q "REDIS_PORT=7160" "$ENVTEST_DIR/.env" || { echo "FAIL: missing REDIS_PORT=7160"; exit 1; }
 grep -q "REDIS_PASSWORD=null" "$ENVTEST_DIR/.env" || { echo "FAIL: missing REDIS_PASSWORD=null"; exit 1; }
 echo "OK: linked project .env has REDIS_*"
 
 echo "==> redis:list shows the row"
 LIST=$(sudo -E pv redis:list 2>&1)
-echo "$LIST" | strip_ansi | grep -q "6379" || { echo "FAIL: list missing port 6379"; echo "$LIST"; exit 1; }
+echo "$LIST" | strip_ansi | grep -q "7160" || { echo "FAIL: list missing port 7160"; echo "$LIST"; exit 1; }
 echo "OK: redis:list shows the row"
 
 echo "==> redis:stop"
 sudo -E pv redis:stop
 for i in $(seq 1 10); do
-    if ! nc -z 127.0.0.1 6379 2>/dev/null; then break; fi
+    if ! nc -z 127.0.0.1 7160 2>/dev/null; then break; fi
     sleep 1
 done
-if nc -z 127.0.0.1 6379 2>/dev/null; then echo "FAIL: 6379 still answering after stop"; exit 1; fi
+if nc -z 127.0.0.1 7160 2>/dev/null; then echo "FAIL: 7160 still answering after stop"; exit 1; fi
 echo "OK: redis stopped"
 
 echo "==> redis:start"
 sudo -E pv redis:start
-wait_for_tcp 127.0.0.1 6379 30 || { echo "FAIL: 6379 not reachable after start"; exit 1; }
+wait_for_tcp 127.0.0.1 7160 30 || { echo "FAIL: 7160 not reachable after start"; exit 1; }
 echo "OK: redis back online"
 
 echo "==> redis:uninstall --force"
 sudo -E pv redis:uninstall --force
-test ! -d "$HOME/.pv/redis" || { echo "FAIL: redis binary tree not removed"; exit 1; }
-test ! -d "$HOME/.pv/data/redis" || { echo "FAIL: redis data dir not removed"; exit 1; }
+test ! -d "$HOME/.pv/redis/8.6" || { echo "FAIL: redis 8.6 binary tree not removed"; exit 1; }
+test ! -d "$HOME/.pv/data/redis/8.6" || { echo "FAIL: redis 8.6 data dir not removed"; exit 1; }
 echo "OK: redis fully removed"
 
-echo "==> daemon-status.json no longer lists redis"
+echo "==> daemon-status.json no longer lists redis-8.6"
 sleep 2
-grep -q '"redis"' "$HOME/.pv/daemon-status.json" && { echo "FAIL: redis still in daemon-status after uninstall"; exit 1; } || true
+grep -q '"redis-8.6"' "$HOME/.pv/daemon-status.json" && { echo "FAIL: redis-8.6 still in daemon-status after uninstall"; exit 1; } || true
 echo "OK: redis cleared from daemon-status"
 
 echo "==> pv stop"


### PR DESCRIPTION
## Summary

Refactor `internal/redis/` from flat single-version to version-parameterized API matching `internal/mysql/`.

- All public functions now take a `version string` parameter
- Binary paths: `~/.pv/redis/{version}/`
- Data paths: `~/.pv/data/redis/{version}/`
- State: `{"redis": {"versions": {"8.6": {"wanted": "running"}}}}`
- Registry: `ProjectServices.Redis` `bool` → `string` with JSON backward compat
- Port: `6300 + major*100 + minor*10` (8.6 → 7160)
- Supervisor: processes named `redis-{version}`, iterates `WantedVersions()`
- Commands: all `redis:*` commands accept optional `version` arg defaulting to `"8.6"`
- `UnbindRedisVersion(version)` helper added to registry

## Key design decisions

- **Versioned paths**: `~/.pv/redis/{version}/` matching postgres/mysql pattern
- **State shape**: versioned map matching mysql exactly for future common package extraction
- **Backward compat**: old flat state `{"wanted":"running"}` auto-migrated to versioned format on read; old registry `"redis": true` handled via custom `UnmarshalJSON`
- **Port formula**: `6300 + major*100 + minor*10` matching mysql's convention
- **8.6 default**: matches current artifacts pipeline output