### PR TITLE
fix(mysql): wait for PID file disappearance in WaitStopped

### DIFF
--- a/internal/mysql/waitstopped.go
+++ b/internal/mysql/waitstopped.go
@@ -3,13 +3,17 @@ package mysql
 import (
 	"fmt"
 	"net"
+	"os"
+	"strconv"
+	"syscall"
 	"time"
 )
 
 // WaitStopped polls the mysql version's TCP port until connections are
-// refused, or until timeout. Used by uninstall/update before destructive
-// on-disk operations: a fixed sleep doesn't account for InnoDB redo-log
-// flush, large buffer pool, etc., so we verify shutdown directly.
+// refused, then waits for the PID file to disappear (confirming the
+// process has fully exited). Used by uninstall/update before destructive
+// on-disk operations: mysqld can close its listener while still flushing
+// InnoDB redo logs, so the port closing is necessary but not sufficient.
 func WaitStopped(version string, timeout time.Duration) error {
 	port, err := PortFor(version)
 	if err != nil {
@@ -17,13 +21,33 @@ func WaitStopped(version string, timeout time.Duration) error {
 	}
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	deadline := time.Now().Add(timeout)
+
+	// Phase 1: wait for TCP port to close.
 	for time.Now().Before(deadline) {
 		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
 		if err != nil {
-			return nil
+			break
 		}
 		c.Close()
 		time.Sleep(200 * time.Millisecond)
 	}
+
+	// Phase 2: wait for PID file to disappear or process to exit.
+	pidFile := "/tmp/pv-mysql-" + version + ".pid"
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return nil
+		}
+		pid, _ := strconv.Atoi(string(data))
+		if pid > 0 && !processExists(pid) {
+			return nil
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 	return fmt.Errorf("mysql %s did not stop within %s", version, timeout)
+}
+
+func processExists(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
 }

--- a/internal/mysql/waitstopped_test.go
+++ b/internal/mysql/waitstopped_test.go
@@ -1,0 +1,53 @@
+package mysql
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWaitStopped_NoPortNoPID_ReturnsImmediately(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	start := time.Now()
+	if err := WaitStopped("8.4", 5*time.Second); err != nil {
+		t.Fatalf("WaitStopped: %v", err)
+	}
+	if time.Since(start) > 1*time.Second {
+		t.Errorf("WaitStopped took too long: %s", time.Since(start))
+	}
+}
+
+func TestWaitStopped_PortOpen_TimesOut(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	port, _ := PortFor("8.4")
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Skipf("cannot bind port %d: %v", port, err)
+	}
+	defer ln.Close()
+
+	start := time.Now()
+	if err := WaitStopped("8.4", 500*time.Millisecond); err == nil {
+		t.Fatal("expected timeout")
+	}
+	if time.Since(start) < 400*time.Millisecond {
+		t.Errorf("expected to wait at least 400ms, got %s", time.Since(start))
+	}
+}
+
+func TestWaitStopped_PortClosed_PIDFileWithDeadProcess_Returns(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	pidFile := "/tmp/pv-mysql-8.4.pid"
+	os.WriteFile(pidFile, []byte("999999"), 0o644)
+	defer os.Remove(pidFile)
+
+	start := time.Now()
+	if err := WaitStopped("8.4", 5*time.Second); err != nil {
+		t.Fatalf("WaitStopped: %v", err)
+	}
+	if time.Since(start) > 1*time.Second {
+		t.Errorf("WaitStopped took too long: %s", time.Since(start))
+	}
+}


### PR DESCRIPTION
## Problem

`mysql:uninstall --force` intermittently fails in CI with:

```
unlinkat /Users/runner/.pv/data/mysql/8.4/#innodb_redo: directory not empty
```

This happens because `WaitStopped` returned as soon as the TCP port refused connections — but `mysqld` closes its listener **before** it fully exits and releases InnoDB file locks. The uninstall then races with the shutdown.

## Fix

`WaitStopped` now has two phases:

1. **Phase 1** (existing): poll the TCP port until connections are refused.
2. **Phase 2** (new): poll the PID file at `/tmp/pv-mysql-<version>.pid` until it disappears or the referenced process is no longer running (`kill -0` fails).

This ensures `mysql:uninstall --force` only deletes the data directory after `mysqld` has fully exited.

## Test Plan

- Added `waitstopped_test.go` with three scenarios:
  - Port closed + no PID file → returns immediately
  - Port open → times out as expected
  - Port closed + PID file with dead process → returns immediately
- `go test ./internal/mysql` — all pass

## Stacked PR

This PR should merge first. #92 (`feat/rustfs-mailpit-parity`) depends on it for green CI.