### PR TITLE
Rewrite: add PHP and Composer tracer

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -22,11 +22,15 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) error {
 	}
 
 	switch args[0] {
+	case "composer:install":
+		return runComposerInstall(args[1:], stderr)
 	case "help", "--help", "-h":
 		writeHelp(stdout)
 		return nil
 	case "mago:install":
-		return runMagoInstall(args[1:], stderr)
+		return runSimpleInstall(args[1:], stderr, control.ResourceMago, "pv mago:install <version>")
+	case "php:install":
+		return runSimpleInstall(args[1:], stderr, control.ResourcePHP, "pv php:install <version>")
 	case "status":
 		return runStatus(stderr)
 	case "version", "--version":
@@ -45,8 +49,10 @@ Usage:
   pv <command>
 
 Commands:
+  composer:install <version> --php <version>
   help      Show this help.
   mago:install <version>
+  php:install <version>
   status    Show desired and observed control-plane status.
   version   Print the pv version.
 
@@ -54,30 +60,47 @@ The active rewrite command surface is intentionally minimal. See docs/rewrite/02
 `)
 }
 
-func runMagoInstall(args []string, stderr io.Writer) error {
+func runSimpleInstall(args []string, stderr io.Writer, resource string, usage string) error {
 	if len(args) != 1 {
-		fmt.Fprintln(stderr, "usage: pv mago:install <version>")
-		return fmt.Errorf("%w: invalid mago:install command", ErrUsage)
+		fmt.Fprintf(stderr, "usage: %s\n", usage)
+		return fmt.Errorf("%w: invalid %s:install command", ErrUsage, resource)
 	}
 
 	version := args[0]
-	if err := control.ValidateVersion(version); err != nil {
-		fmt.Fprintf(stderr, "pv: %v\n", err)
-		return fmt.Errorf("%w: %v", ErrUsage, err)
-	}
-
-	store, err := defaultStore()
-	if err != nil {
+	if err := validateVersionArg(stderr, version); err != nil {
 		return err
 	}
-	if err := store.PutDesired(context.Background(), control.DesiredResource{
-		Resource: control.ResourceMago,
-		Version:  version,
+	if err := putDesired(control.DesiredResource{Resource: resource, Version: version}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stderr, "requested %s %s install\n", resource, version)
+	return nil
+}
+
+func runComposerInstall(args []string, stderr io.Writer) error {
+	if len(args) != 3 || args[1] != "--php" {
+		fmt.Fprintln(stderr, "usage: pv composer:install <version> --php <version>")
+		return fmt.Errorf("%w: invalid composer:install command", ErrUsage)
+	}
+
+	version := args[0]
+	runtimeVersion := args[2]
+	if err := validateVersionArg(stderr, version); err != nil {
+		return err
+	}
+	if err := validateVersionArg(stderr, runtimeVersion); err != nil {
+		return err
+	}
+	if err := putDesired(control.DesiredResource{
+		Resource:       control.ResourceComposer,
+		Version:        version,
+		RuntimeVersion: runtimeVersion,
 	}); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(stderr, "requested mago %s install\n", version)
+	fmt.Fprintf(stderr, "requested composer %s install with php %s\n", version, runtimeVersion)
 	return nil
 }
 
@@ -88,36 +111,69 @@ func runStatus(stderr io.Writer) error {
 	}
 
 	ctx := context.Background()
-	desired, desiredOK, err := store.Desired(ctx, control.ResourceMago)
-	if err != nil {
-		return err
-	}
-	observed, observedOK, err := store.Observed(ctx, control.ResourceMago)
-	if err != nil {
-		return err
+	anyDesired := false
+	for _, resource := range [...]string{control.ResourcePHP, control.ResourceComposer, control.ResourceMago} {
+		desired, desiredOK, err := store.Desired(ctx, resource)
+		if err != nil {
+			return err
+		}
+		if !desiredOK {
+			continue
+		}
+		anyDesired = true
+		printDesired(stderr, desired)
+
+		observed, observedOK, err := store.Observed(ctx, resource)
+		if err != nil {
+			return err
+		}
+		if !observedOK {
+			fmt.Fprintf(stderr, "observed: %s pending\n", resource)
+			fmt.Fprintln(stderr, "next action: run reconciliation")
+			continue
+		}
+		printObserved(stderr, observed)
 	}
 
-	if !desiredOK {
+	if !anyDesired {
 		fmt.Fprintln(stderr, "desired: none")
-		return nil
-	}
-
-	fmt.Fprintf(stderr, "desired: mago %s install\n", desired.Version)
-	if !observedOK {
-		fmt.Fprintln(stderr, "observed: mago pending")
-		fmt.Fprintln(stderr, "next action: run reconciliation")
-		return nil
-	}
-
-	fmt.Fprintf(stderr, "observed: mago %s %s\n", observed.DesiredVersion, observed.State)
-	fmt.Fprintf(stderr, "last reconcile: %s\n", observed.LastReconcileTime)
-	if observed.LastError != "" {
-		fmt.Fprintf(stderr, "last error: %s\n", observed.LastError)
-	}
-	if observed.NextAction != "" {
-		fmt.Fprintf(stderr, "next action: %s\n", observed.NextAction)
 	}
 	return nil
+}
+
+func validateVersionArg(stderr io.Writer, version string) error {
+	if err := control.ValidateVersion(version); err != nil {
+		fmt.Fprintf(stderr, "pv: %v\n", err)
+		return fmt.Errorf("%w: %v", ErrUsage, err)
+	}
+	return nil
+}
+
+func putDesired(desired control.DesiredResource) error {
+	store, err := defaultStore()
+	if err != nil {
+		return err
+	}
+	return store.PutDesired(context.Background(), desired)
+}
+
+func printDesired(w io.Writer, desired control.DesiredResource) {
+	if desired.RuntimeVersion != "" {
+		fmt.Fprintf(w, "desired: %s %s install with php %s\n", desired.Resource, desired.Version, desired.RuntimeVersion)
+		return
+	}
+	fmt.Fprintf(w, "desired: %s %s install\n", desired.Resource, desired.Version)
+}
+
+func printObserved(w io.Writer, observed control.ObservedStatus) {
+	fmt.Fprintf(w, "observed: %s %s %s\n", observed.Resource, observed.DesiredVersion, observed.State)
+	fmt.Fprintf(w, "last reconcile: %s\n", observed.LastReconcileTime)
+	if observed.LastError != "" {
+		fmt.Fprintf(w, "last error: %s\n", observed.LastError)
+	}
+	if observed.NextAction != "" {
+		fmt.Fprintf(w, "next action: %s\n", observed.NextAction)
+	}
 }
 
 func defaultStore() (*control.FileStore, error) {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -31,14 +30,14 @@ func TestRunHelpWritesRewriteHelp(t *testing.T) {
 		"pv rewrite control plane",
 		"Usage:",
 		"pv <command>",
+		"composer:install",
+		"mago:install",
+		"php:install",
 		"version",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("help output missing %q:\n%s", want, out)
 		}
-	}
-	if strings.Contains(out, "php:install") {
-		t.Fatalf("help output copied prototype command surface:\n%s", out)
 	}
 }
 
@@ -95,7 +94,7 @@ func TestRunMagoInstallRecordsDesiredStateWithoutInstalling(t *testing.T) {
 	}
 
 	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.json"))
-	desired, ok, err := store.Desired(context.Background(), control.ResourceMago)
+	desired, ok, err := store.Desired(t.Context(), control.ResourceMago)
 	if err != nil {
 		t.Fatalf("Desired returned error: %v", err)
 	}
@@ -105,7 +104,7 @@ func TestRunMagoInstallRecordsDesiredStateWithoutInstalling(t *testing.T) {
 	if desired.Version != "1.2.3" {
 		t.Fatalf("desired version = %q, want 1.2.3", desired.Version)
 	}
-	if _, ok, err := store.Observed(context.Background(), control.ResourceMago); err != nil {
+	if _, ok, err := store.Observed(t.Context(), control.ResourceMago); err != nil {
 		t.Fatalf("Observed returned error: %v", err)
 	} else if ok {
 		t.Fatal("mago install command wrote observed status directly")
@@ -120,7 +119,7 @@ func TestRunMagoInstallRecordsDesiredStateWithoutInstalling(t *testing.T) {
 func TestRunStatusReportsDesiredAndObservedStatus(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	ctx := context.Background()
+	ctx := t.Context()
 	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.json"))
 	if err := store.PutDesired(ctx, control.DesiredResource{
 		Resource: control.ResourceMago,
@@ -161,7 +160,7 @@ func TestRunStatusReportsDesiredAndObservedStatus(t *testing.T) {
 func TestControlPlaneTracerRecordsDesiredThenObserved(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	ctx := context.Background()
+	ctx := t.Context()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
@@ -198,6 +197,133 @@ func TestControlPlaneTracerRecordsDesiredThenObserved(t *testing.T) {
 	}
 	if observed.State != control.StateReady {
 		t.Fatalf("observed state = %q, want ready", observed.State)
+	}
+}
+
+func TestRunPHPInstallRecordsDesiredRuntimeState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"php:install", "8.4"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run php install returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run php install wrote stdout: %q", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "requested php 8.4 install") {
+		t.Fatalf("stderr = %q, want requested message", got)
+	}
+
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.json"))
+	desired, ok, err := store.Desired(t.Context(), control.ResourcePHP)
+	if err != nil {
+		t.Fatalf("Desired returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Desired did not find PHP resource")
+	}
+	if desired.Version != "8.4" {
+		t.Fatalf("desired version = %q, want 8.4", desired.Version)
+	}
+}
+
+func TestRunComposerInstallRecordsRuntimeDependency(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"composer:install", "2.8.0", "--php", "8.4"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run composer install returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run composer install wrote stdout: %q", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "requested composer 2.8.0 install with php 8.4") {
+		t.Fatalf("stderr = %q, want requested message", got)
+	}
+
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.json"))
+	desired, ok, err := store.Desired(t.Context(), control.ResourceComposer)
+	if err != nil {
+		t.Fatalf("Desired returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Desired did not find Composer resource")
+	}
+	if desired.Version != "2.8.0" {
+		t.Fatalf("desired version = %q, want 2.8.0", desired.Version)
+	}
+	if desired.RuntimeVersion != "8.4" {
+		t.Fatalf("runtime version = %q, want 8.4", desired.RuntimeVersion)
+	}
+}
+
+func TestRunStatusReportsPHPAndComposer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	ctx := t.Context()
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.json"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource: control.ResourcePHP,
+		Version:  "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired PHP returned error: %v", err)
+	}
+	if err := store.PutObserved(ctx, control.ObservedStatus{
+		Resource:          control.ResourcePHP,
+		DesiredVersion:    "8.4",
+		State:             control.StateReady,
+		LastReconcileTime: "2026-05-15T19:00:00Z",
+	}); err != nil {
+		t.Fatalf("PutObserved PHP returned error: %v", err)
+	}
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource:       control.ResourceComposer,
+		Version:        "2.8.0",
+		RuntimeVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired Composer returned error: %v", err)
+	}
+	if err := store.PutObserved(ctx, control.ObservedStatus{
+		Resource:          control.ResourceComposer,
+		DesiredVersion:    "2.8.0",
+		RuntimeVersion:    "8.4",
+		State:             control.StateBlocked,
+		LastReconcileTime: "2026-05-15T19:10:00Z",
+		LastError:         "PHP runtime 8.4 is not installed",
+		NextAction:        "run pv php:install 8.4",
+	}); err != nil {
+		t.Fatalf("PutObserved Composer returned error: %v", err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"status"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run status returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run status wrote stdout: %q", stdout.String())
+	}
+	for _, want := range []string{
+		"desired: php 8.4 install",
+		"observed: php 8.4 ready",
+		"desired: composer 2.8.0 install with php 8.4",
+		"observed: composer 2.8.0 blocked",
+		"last error: PHP runtime 8.4 is not installed",
+		"next action: run pv php:install 8.4",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("status output missing %q:\n%s", want, stderr.String())
+		}
 	}
 }
 

--- a/internal/control/store.go
+++ b/internal/control/store.go
@@ -11,22 +11,27 @@ import (
 )
 
 const (
-	ResourceMago = "mago"
+	ResourceComposer = "composer"
+	ResourceMago     = "mago"
+	ResourcePHP      = "php"
 
-	StateReady  = "ready"
-	StateFailed = "failed"
+	StateBlocked = "blocked"
+	StateReady   = "ready"
+	StateFailed  = "failed"
 )
 
 var versionPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
 
 type DesiredResource struct {
-	Resource string `json:"resource"`
-	Version  string `json:"version"`
+	Resource       string `json:"resource"`
+	Version        string `json:"version"`
+	RuntimeVersion string `json:"runtime_version,omitempty"`
 }
 
 type ObservedStatus struct {
 	Resource          string `json:"resource"`
 	DesiredVersion    string `json:"desired_version"`
+	RuntimeVersion    string `json:"runtime_version,omitempty"`
 	State             string `json:"state"`
 	LastReconcileTime string `json:"last_reconcile_time"`
 	LastError         string `json:"last_error,omitempty"`
@@ -56,10 +61,7 @@ func (s *FileStore) PutDesired(ctx context.Context, desired DesiredResource) err
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if desired.Resource == "" {
-		return errors.New("desired resource is required")
-	}
-	if err := ValidateVersion(desired.Version); err != nil {
+	if err := validateDesiredResource(desired); err != nil {
 		return err
 	}
 
@@ -119,6 +121,19 @@ func ValidateVersion(version string) error {
 		return fmt.Errorf("invalid version %q", version)
 	}
 	return nil
+}
+
+func validateDesiredResource(desired DesiredResource) error {
+	if desired.Resource == "" {
+		return errors.New("desired resource is required")
+	}
+	if err := ValidateVersion(desired.Version); err != nil {
+		return err
+	}
+	if desired.RuntimeVersion == "" {
+		return nil
+	}
+	return ValidateVersion(desired.RuntimeVersion)
 }
 
 type snapshot struct {

--- a/internal/resources/composer/controller.go
+++ b/internal/resources/composer/controller.go
@@ -1,0 +1,183 @@
+package composer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+type Runtime interface {
+	Installed(string) bool
+}
+
+type Installer interface {
+	Install(context.Context, InstallRequest) error
+}
+
+type InstallRequest struct {
+	Version        string
+	RuntimeVersion string
+}
+
+type Controller struct {
+	Store     control.Store
+	Installer Installer
+	Runtime   Runtime
+	Clock     func() time.Time
+}
+
+func (c Controller) Reconcile(ctx context.Context) error {
+	desired, ok, err := c.Store.Desired(ctx, control.ResourceComposer)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	reconciledAt := c.now().UTC().Format(time.RFC3339)
+	if err := validateDesired(desired); err != nil {
+		return c.recordFailure(ctx, desired, control.StateFailed, reconciledAt, err, "fix the Composer desired state and run reconciliation again")
+	}
+
+	if !c.Runtime.Installed(desired.RuntimeVersion) {
+		err := fmt.Errorf("PHP runtime %s is not installed", desired.RuntimeVersion)
+		return c.recordFailure(ctx, desired, control.StateBlocked, reconciledAt, err, fmt.Sprintf("run pv php:install %s", desired.RuntimeVersion))
+	}
+
+	if err := c.Installer.Install(ctx, InstallRequest{
+		Version:        desired.Version,
+		RuntimeVersion: desired.RuntimeVersion,
+	}); err != nil {
+		return c.recordFailure(ctx, desired, control.StateFailed, reconciledAt, err, "fix the Composer install failure and run reconciliation again")
+	}
+
+	return c.Store.PutObserved(ctx, control.ObservedStatus{
+		Resource:          control.ResourceComposer,
+		DesiredVersion:    desired.Version,
+		RuntimeVersion:    desired.RuntimeVersion,
+		State:             control.StateReady,
+		LastReconcileTime: reconciledAt,
+	})
+}
+
+func validateDesired(desired control.DesiredResource) error {
+	if err := control.ValidateVersion(desired.Version); err != nil {
+		return err
+	}
+	if desired.RuntimeVersion == "" {
+		return errors.New("composer runtime version is required")
+	}
+	return control.ValidateVersion(desired.RuntimeVersion)
+}
+
+func (c Controller) recordFailure(ctx context.Context, desired control.DesiredResource, state string, reconciledAt string, cause error, nextAction string) error {
+	status := control.ObservedStatus{
+		Resource:          control.ResourceComposer,
+		DesiredVersion:    desired.Version,
+		RuntimeVersion:    desired.RuntimeVersion,
+		State:             state,
+		LastReconcileTime: reconciledAt,
+		LastError:         cause.Error(),
+		NextAction:        nextAction,
+	}
+	if err := c.Store.PutObserved(ctx, status); err != nil {
+		return err
+	}
+	if state == control.StateBlocked {
+		return nil
+	}
+	return cause
+}
+
+func (c Controller) now() time.Time {
+	if c.Clock != nil {
+		return c.Clock()
+	}
+	return time.Now()
+}
+
+type MarkerInstaller struct {
+	root string
+}
+
+func NewMarkerInstaller(root string) MarkerInstaller {
+	return MarkerInstaller{root: root}
+}
+
+func (i MarkerInstaller) Install(ctx context.Context, request InstallRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := control.ValidateVersion(request.Version); err != nil {
+		return err
+	}
+	if err := control.ValidateVersion(request.RuntimeVersion); err != nil {
+		return err
+	}
+
+	marker := i.markerPath(request.Version)
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(marker, []byte(fmt.Sprintf("composer %s\n", request.Version)), 0o644); err != nil {
+		return err
+	}
+
+	return i.writeShim(ctx, request)
+}
+
+func (i MarkerInstaller) Installed(version string) bool {
+	_, err := os.Stat(i.markerPath(version))
+	return err == nil
+}
+
+func (i MarkerInstaller) ShimExists() bool {
+	_, err := os.Stat(filepath.Join(i.root, "bin", "composer"))
+	return err == nil
+}
+
+func (i MarkerInstaller) markerPath(version string) string {
+	return filepath.Join(i.root, "tools", "composer", version, "installed")
+}
+
+func (i MarkerInstaller) writeShim(ctx context.Context, request InstallRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	bin := filepath.Join(i.root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		return err
+	}
+
+	temp, err := os.CreateTemp(bin, ".composer-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+
+	const shimTemplate = `#!/bin/sh
+# composer %s via php %s
+exec "$(dirname "$0")/../runtimes/php/%s/php" "$(dirname "$0")/../tools/composer/%s/composer.phar" "$@"
+`
+	content := fmt.Sprintf(shimTemplate, request.Version, request.RuntimeVersion, request.RuntimeVersion, request.Version)
+	if _, err := temp.WriteString(content); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Chmod(0o755); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, filepath.Join(bin, "composer"))
+}

--- a/internal/resources/composer/controller_test.go
+++ b/internal/resources/composer/controller_test.go
@@ -1,0 +1,167 @@
+package composer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+	"github.com/prvious/pv/internal/resources/php"
+)
+
+func TestControllerBlocksComposerWhenRuntimeIsMissing(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+	store := control.NewFileStore(filepath.Join(root, "pv.json"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource:       control.ResourceComposer,
+		Version:        "2.8.0",
+		RuntimeVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+
+	installer := NewMarkerInstaller(root)
+	controller := Controller{
+		Store:     store,
+		Installer: installer,
+		Runtime:   php.NewMarkerInstaller(root),
+		Clock:     fixedClock("2026-05-15T19:10:00Z"),
+	}
+
+	if err := controller.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	if installer.Installed("2.8.0") {
+		t.Fatal("Composer installed without its PHP runtime")
+	}
+	if installer.ShimExists() {
+		t.Fatal("Composer shim exists without its PHP runtime")
+	}
+
+	observed, ok, err := store.Observed(ctx, control.ResourceComposer)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Observed did not find Composer status")
+	}
+	if observed.State != control.StateBlocked {
+		t.Fatalf("State = %q, want blocked", observed.State)
+	}
+	if observed.LastError != "PHP runtime 8.4 is not installed" {
+		t.Fatalf("LastError = %q", observed.LastError)
+	}
+	if !strings.Contains(observed.NextAction, "php:install 8.4") {
+		t.Fatalf("NextAction = %q, want php:install guidance", observed.NextAction)
+	}
+}
+
+func TestControllerInstallsComposerAndExposesShimWhenRuntimeExists(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+	store := control.NewFileStore(filepath.Join(root, "pv.json"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource:       control.ResourceComposer,
+		Version:        "2.8.0",
+		RuntimeVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+	runtime := php.NewMarkerInstaller(root)
+	if err := runtime.Install(ctx, "8.4"); err != nil {
+		t.Fatalf("PHP Install returned error: %v", err)
+	}
+
+	installer := NewMarkerInstaller(root)
+	controller := Controller{
+		Store:     store,
+		Installer: installer,
+		Runtime:   runtime,
+		Clock:     fixedClock("2026-05-15T19:10:00Z"),
+	}
+
+	if err := controller.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	if !installer.Installed("2.8.0") {
+		t.Fatal("Composer marker was not installed")
+	}
+	shim, err := os.ReadFile(filepath.Join(root, "bin", "composer"))
+	if err != nil {
+		t.Fatalf("ReadFile shim returned error: %v", err)
+	}
+	for _, want := range []string{"composer 2.8.0", "php 8.4"} {
+		if !strings.Contains(string(shim), want) {
+			t.Fatalf("shim missing %q:\n%s", want, string(shim))
+		}
+	}
+
+	observed, ok, err := store.Observed(ctx, control.ResourceComposer)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Observed did not find Composer status")
+	}
+	want := control.ObservedStatus{
+		Resource:          control.ResourceComposer,
+		DesiredVersion:    "2.8.0",
+		RuntimeVersion:    "8.4",
+		State:             control.StateReady,
+		LastReconcileTime: "2026-05-15T19:10:00Z",
+	}
+	if observed != want {
+		t.Fatalf("Observed = %#v, want %#v", observed, want)
+	}
+}
+
+func TestMarkerInstallerReplacesComposerShimAtomically(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	shim := filepath.Join(bin, "composer")
+	if err := os.WriteFile(shim, []byte("old shim\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile old shim returned error: %v", err)
+	}
+
+	installer := NewMarkerInstaller(root)
+	if err := installer.Install(ctx, InstallRequest{
+		Version:        "2.8.0",
+		RuntimeVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(shim)
+	if err != nil {
+		t.Fatalf("ReadFile shim returned error: %v", err)
+	}
+	if string(got) == "old shim\n" {
+		t.Fatal("composer shim was not replaced")
+	}
+	matches, err := filepath.Glob(filepath.Join(bin, ".composer-*"))
+	if err != nil {
+		t.Fatalf("Glob returned error: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary shim files were not cleaned up: %v", matches)
+	}
+}
+
+func fixedClock(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time {
+		return parsed
+	}
+}

--- a/internal/resources/php/controller.go
+++ b/internal/resources/php/controller.go
@@ -1,0 +1,101 @@
+package php
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+type Installer interface {
+	Install(context.Context, string) error
+}
+
+type Controller struct {
+	Store     control.Store
+	Installer Installer
+	Clock     func() time.Time
+}
+
+func (c Controller) Reconcile(ctx context.Context) error {
+	desired, ok, err := c.Store.Desired(ctx, control.ResourcePHP)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	reconciledAt := c.now().UTC().Format(time.RFC3339)
+	if err := control.ValidateVersion(desired.Version); err != nil {
+		return c.recordFailure(ctx, desired.Version, reconciledAt, err)
+	}
+
+	if err := c.Installer.Install(ctx, desired.Version); err != nil {
+		return c.recordFailure(ctx, desired.Version, reconciledAt, err)
+	}
+
+	return c.Store.PutObserved(ctx, control.ObservedStatus{
+		Resource:          control.ResourcePHP,
+		DesiredVersion:    desired.Version,
+		State:             control.StateReady,
+		LastReconcileTime: reconciledAt,
+	})
+}
+
+func (c Controller) recordFailure(ctx context.Context, version string, reconciledAt string, cause error) error {
+	status := control.ObservedStatus{
+		Resource:          control.ResourcePHP,
+		DesiredVersion:    version,
+		State:             control.StateFailed,
+		LastReconcileTime: reconciledAt,
+		LastError:         cause.Error(),
+		NextAction:        "fix the PHP runtime install failure and run reconciliation again",
+	}
+	if err := c.Store.PutObserved(ctx, status); err != nil {
+		return err
+	}
+	return cause
+}
+
+func (c Controller) now() time.Time {
+	if c.Clock != nil {
+		return c.Clock()
+	}
+	return time.Now()
+}
+
+type MarkerInstaller struct {
+	root string
+}
+
+func NewMarkerInstaller(root string) MarkerInstaller {
+	return MarkerInstaller{root: root}
+}
+
+func (i MarkerInstaller) Install(ctx context.Context, version string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := control.ValidateVersion(version); err != nil {
+		return err
+	}
+
+	marker := i.markerPath(version)
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(marker, []byte(fmt.Sprintf("php %s\n", version)), 0o644)
+}
+
+func (i MarkerInstaller) Installed(version string) bool {
+	_, err := os.Stat(i.markerPath(version))
+	return err == nil
+}
+
+func (i MarkerInstaller) markerPath(version string) string {
+	return filepath.Join(i.root, "runtimes", "php", version, "installed")
+}

--- a/internal/resources/php/controller_test.go
+++ b/internal/resources/php/controller_test.go
@@ -1,0 +1,110 @@
+package php
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+func TestControllerReconcilesDesiredPHPRuntime(t *testing.T) {
+	ctx := t.Context()
+	store := control.NewFileStore(filepath.Join(t.TempDir(), "pv.json"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource: control.ResourcePHP,
+		Version:  "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+
+	installer := NewMarkerInstaller(t.TempDir())
+	controller := Controller{
+		Store:     store,
+		Installer: installer,
+		Clock:     fixedClock("2026-05-15T19:00:00Z"),
+	}
+
+	if err := controller.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	if !installer.Installed("8.4") {
+		t.Fatal("PHP runtime marker was not installed")
+	}
+	observed, ok, err := store.Observed(ctx, control.ResourcePHP)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Observed did not find PHP status")
+	}
+	want := control.ObservedStatus{
+		Resource:          control.ResourcePHP,
+		DesiredVersion:    "8.4",
+		State:             control.StateReady,
+		LastReconcileTime: "2026-05-15T19:00:00Z",
+	}
+	if observed != want {
+		t.Fatalf("Observed = %#v, want %#v", observed, want)
+	}
+}
+
+func TestControllerRecordsPHPRuntimeInstallFailure(t *testing.T) {
+	ctx := t.Context()
+	store := control.NewFileStore(filepath.Join(t.TempDir(), "pv.json"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource: control.ResourcePHP,
+		Version:  "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+
+	installErr := errors.New("download unavailable")
+	controller := Controller{
+		Store:     store,
+		Installer: failingInstaller{err: installErr},
+		Clock:     fixedClock("2026-05-15T19:00:00Z"),
+	}
+
+	if err := controller.Reconcile(ctx); !errors.Is(err, installErr) {
+		t.Fatalf("Reconcile error = %v, want %v", err, installErr)
+	}
+
+	observed, ok, err := store.Observed(ctx, control.ResourcePHP)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Observed did not find PHP status")
+	}
+	if observed.State != control.StateFailed {
+		t.Fatalf("State = %q, want failed", observed.State)
+	}
+	if observed.LastError != "download unavailable" {
+		t.Fatalf("LastError = %q, want download unavailable", observed.LastError)
+	}
+	if observed.NextAction == "" {
+		t.Fatal("NextAction is empty for failed PHP reconcile")
+	}
+}
+
+type failingInstaller struct {
+	err error
+}
+
+func (i failingInstaller) Install(context.Context, string) error {
+	return i.err
+}
+
+func fixedClock(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time {
+		return parsed
+	}
+}


### PR DESCRIPTION
## Summary
- Add PHP runtime desired-state reconciliation with observed status.
- Add Composer desired-state reconciliation that blocks until its pinned PHP runtime exists.
- Add atomic Composer shim exposure through the rewrite model.
- Extend the minimal root CLI and status output for PHP and Composer tracer commands.

## Test Plan
- [x] Root: `gofmt -w .`
- [x] Root: `go vet ./...`
- [x] Root: `go build ./...`
- [x] Root: `go test ./...`
- [x] Prototype: `go vet ./...`
- [x] Prototype: `go build ./...`
- [x] Prototype: `go test ./...`

Depends on #114
Closes #100