### PR TITLE
Rewrite Epic 2: Store, Host, And Install Infrastructure

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,10 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/prvious/pv/internal/control"
+	"github.com/prvious/pv/internal/host"
 )
 
 const Version = "dev"
@@ -121,9 +120,9 @@ func runStatus(stderr io.Writer) error {
 }
 
 func defaultStore() (*control.FileStore, error) {
-	home, err := os.UserHomeDir()
+	paths, err := host.NewPaths()
 	if err != nil {
 		return nil, err
 	}
-	return control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.json")), nil
+	return control.NewFileStore(paths.StateDBPath()), nil
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -94,7 +94,7 @@ func TestRunMagoInstallRecordsDesiredStateWithoutInstalling(t *testing.T) {
 		t.Fatalf("stderr = %q, want requested message", got)
 	}
 
-	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.json"))
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
 	desired, ok, err := store.Desired(context.Background(), control.ResourceMago)
 	if err != nil {
 		t.Fatalf("Desired returned error: %v", err)
@@ -121,7 +121,7 @@ func TestRunStatusReportsDesiredAndObservedStatus(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	ctx := context.Background()
-	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.json"))
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
 	if err := store.PutDesired(ctx, control.DesiredResource{
 		Resource: control.ResourceMago,
 		Version:  "1.2.3",
@@ -169,7 +169,7 @@ func TestControlPlaneTracerRecordsDesiredThenObserved(t *testing.T) {
 		t.Fatalf("Run mago install returned error: %v", err)
 	}
 
-	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.json"))
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
 	controller := mago.Controller{
 		Store:     store,
 		Installer: mago.NewMarkerInstaller(filepath.Join(home, ".pv")),

--- a/internal/control/store.go
+++ b/internal/control/store.go
@@ -11,6 +11,8 @@ import (
 )
 
 const (
+	CurrentSchemaVersion = 1
+
 	ResourceMago = "mago"
 
 	StateReady  = "ready"
@@ -34,6 +36,8 @@ type ObservedStatus struct {
 }
 
 type Store interface {
+	Migrate(context.Context) error
+	SchemaVersion(context.Context) (int, error)
 	PutDesired(context.Context, DesiredResource) error
 	Desired(context.Context, string) (DesiredResource, bool, error)
 	PutObserved(context.Context, ObservedStatus) error
@@ -41,15 +45,45 @@ type Store interface {
 }
 
 type FileStore struct {
-	path string
+	path   string
+	runner MigrationRunner
 }
 
 func NewFileStore(path string) *FileStore {
-	return &FileStore{path: path}
+	return &FileStore{
+		path:   path,
+		runner: NewMigrationRunner(defaultMigrations()),
+	}
+}
+
+func NewFileStoreWithRunner(path string, runner MigrationRunner) *FileStore {
+	if runner == nil {
+		runner = NewMigrationRunner(defaultMigrations())
+	}
+	return &FileStore{path: path, runner: runner}
 }
 
 func (s *FileStore) Path() string {
 	return s.path
+}
+
+func (s *FileStore) Migrate(ctx context.Context) error {
+	current, migrated, err := s.loadMigrated(ctx)
+	if err != nil {
+		return err
+	}
+	if !migrated {
+		return nil
+	}
+	return s.save(ctx, current)
+}
+
+func (s *FileStore) SchemaVersion(ctx context.Context) (int, error) {
+	current, _, err := s.loadMigrated(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return current.SchemaVersion, nil
 }
 
 func (s *FileStore) PutDesired(ctx context.Context, desired DesiredResource) error {
@@ -63,7 +97,7 @@ func (s *FileStore) PutDesired(ctx context.Context, desired DesiredResource) err
 		return err
 	}
 
-	snapshot, err := s.load(ctx)
+	snapshot, _, err := s.loadMigrated(ctx)
 	if err != nil {
 		return err
 	}
@@ -75,7 +109,7 @@ func (s *FileStore) Desired(ctx context.Context, resource string) (DesiredResour
 	if err := ctx.Err(); err != nil {
 		return DesiredResource{}, false, err
 	}
-	snapshot, err := s.load(ctx)
+	snapshot, _, err := s.loadMigrated(ctx)
 	if err != nil {
 		return DesiredResource{}, false, err
 	}
@@ -94,7 +128,7 @@ func (s *FileStore) PutObserved(ctx context.Context, observed ObservedStatus) er
 		return errors.New("observed state is required")
 	}
 
-	snapshot, err := s.load(ctx)
+	snapshot, _, err := s.loadMigrated(ctx)
 	if err != nil {
 		return err
 	}
@@ -106,7 +140,7 @@ func (s *FileStore) Observed(ctx context.Context, resource string) (ObservedStat
 	if err := ctx.Err(); err != nil {
 		return ObservedStatus{}, false, err
 	}
-	snapshot, err := s.load(ctx)
+	snapshot, _, err := s.loadMigrated(ctx)
 	if err != nil {
 		return ObservedStatus{}, false, err
 	}
@@ -121,21 +155,106 @@ func ValidateVersion(version string) error {
 	return nil
 }
 
-type snapshot struct {
-	Desired  map[string]DesiredResource `json:"desired"`
-	Observed map[string]ObservedStatus  `json:"observed"`
+type AppliedMigration struct {
+	ID string `json:"id"`
 }
 
-func newSnapshot() snapshot {
-	return snapshot{
+type StoreSnapshot struct {
+	SchemaVersion     int                        `json:"schema_version"`
+	AppliedMigrations []AppliedMigration         `json:"applied_migrations"`
+	Desired           map[string]DesiredResource `json:"desired"`
+	Observed          map[string]ObservedStatus  `json:"observed"`
+}
+
+func newSnapshot() StoreSnapshot {
+	return StoreSnapshot{
 		Desired:  make(map[string]DesiredResource),
 		Observed: make(map[string]ObservedStatus),
 	}
 }
 
-func (s *FileStore) load(ctx context.Context) (snapshot, error) {
+type Migration struct {
+	ID    string
+	Apply func(context.Context, StoreSnapshot) (StoreSnapshot, error)
+}
+
+type MigrationRunner interface {
+	Run(context.Context, StoreSnapshot) (StoreSnapshot, bool, error)
+}
+
+type ForwardMigrationRunner struct {
+	migrations []Migration
+}
+
+func NewMigrationRunner(migrations []Migration) ForwardMigrationRunner {
+	return ForwardMigrationRunner{migrations: migrations}
+}
+
+func (r ForwardMigrationRunner) Run(ctx context.Context, current StoreSnapshot) (StoreSnapshot, bool, error) {
+	if current.SchemaVersion > CurrentSchemaVersion {
+		return StoreSnapshot{}, false, fmt.Errorf("store schema version %d is newer than supported version %d", current.SchemaVersion, CurrentSchemaVersion)
+	}
+
+	applied := make(map[string]bool, len(current.AppliedMigrations))
+	for _, migration := range current.AppliedMigrations {
+		applied[migration.ID] = true
+	}
+
+	changed := false
+	for _, migration := range r.migrations {
+		if err := ctx.Err(); err != nil {
+			return StoreSnapshot{}, false, err
+		}
+		if applied[migration.ID] {
+			continue
+		}
+		next, err := migration.Apply(ctx, current)
+		if err != nil {
+			return StoreSnapshot{}, false, fmt.Errorf("apply migration %s: %w", migration.ID, err)
+		}
+		current = next
+		current.AppliedMigrations = append(current.AppliedMigrations, AppliedMigration{ID: migration.ID})
+		changed = true
+	}
+	return current, changed, nil
+}
+
+func defaultMigrations() []Migration {
+	return []Migration{
+		{
+			ID: "0001_initial_json_store",
+			Apply: func(ctx context.Context, current StoreSnapshot) (StoreSnapshot, error) {
+				if err := ctx.Err(); err != nil {
+					return StoreSnapshot{}, err
+				}
+				current.SchemaVersion = CurrentSchemaVersion
+				if current.Desired == nil {
+					current.Desired = make(map[string]DesiredResource)
+				}
+				if current.Observed == nil {
+					current.Observed = make(map[string]ObservedStatus)
+				}
+				return current, nil
+			},
+		},
+	}
+}
+
+func (s *FileStore) loadMigrated(ctx context.Context) (StoreSnapshot, bool, error) {
+	current, err := s.load(ctx)
+	if err != nil {
+		return StoreSnapshot{}, false, err
+	}
+	migrated, changed, err := s.runner.Run(ctx, current)
+	if err != nil {
+		return StoreSnapshot{}, false, err
+	}
+	return migrated, changed, nil
+}
+
+func (s *FileStore) load(ctx context.Context) (StoreSnapshot, error) {
 	if err := ctx.Err(); err != nil {
-		return snapshot{}, err
+		return StoreSnapshot{}, err
 	}
 
 	data, err := os.ReadFile(s.path)
@@ -143,12 +262,12 @@ func (s *FileStore) load(ctx context.Context) (snapshot, error) {
 		return newSnapshot(), nil
 	}
 	if err != nil {
-		return snapshot{}, err
+		return StoreSnapshot{}, err
 	}
 
 	current := newSnapshot()
 	if err := json.Unmarshal(data, &current); err != nil {
-		return snapshot{}, err
+		return StoreSnapshot{}, fmt.Errorf("load store state %s: %w", s.path, err)
 	}
 	if current.Desired == nil {
 		current.Desired = make(map[string]DesiredResource)
@@ -159,7 +278,7 @@ func (s *FileStore) load(ctx context.Context) (snapshot, error) {
 	return current, nil
 }
 
-func (s *FileStore) save(ctx context.Context, current snapshot) error {
+func (s *FileStore) save(ctx context.Context, current StoreSnapshot) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/internal/control/store_test.go
+++ b/internal/control/store_test.go
@@ -2,7 +2,9 @@ package control
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -75,5 +77,61 @@ func TestValidateVersionRejectsUnsafeVersion(t *testing.T) {
 		if err := ValidateVersion(version); err == nil {
 			t.Fatalf("ValidateVersion(%q) returned nil, want error", version)
 		}
+	}
+}
+
+func TestFileStoreRecordsSchemaVersionAndAppliedMigrations(t *testing.T) {
+	ctx := context.Background()
+	store := NewFileStore(filepath.Join(t.TempDir(), "pv.db"))
+
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	version, err := store.SchemaVersion(ctx)
+	if err != nil {
+		t.Fatalf("SchemaVersion returned error: %v", err)
+	}
+	if version != CurrentSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", version, CurrentSchemaVersion)
+	}
+
+	data, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if !strings.Contains(string(data), `"id": "0001_initial_json_store"`) {
+		t.Fatalf("store file did not record initial migration:\n%s", data)
+	}
+}
+
+func TestFileStoreRejectsCorruptedState(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "pv.db")
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	_, _, err := NewFileStore(path).Desired(ctx, ResourceMago)
+	if err == nil {
+		t.Fatal("Desired returned nil error")
+	}
+	if !strings.Contains(err.Error(), "load store state") {
+		t.Fatalf("error = %v, want clear load store state message", err)
+	}
+}
+
+func TestFileStoreRejectsNewerSchema(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "pv.db")
+	if err := os.WriteFile(path, []byte(`{"schema_version":99,"desired":{},"observed":{}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile returned error: %v", err)
+	}
+
+	_, err := NewFileStore(path).SchemaVersion(ctx)
+	if err == nil {
+		t.Fatal("SchemaVersion returned nil error")
+	}
+	if !strings.Contains(err.Error(), "newer than supported") {
+		t.Fatalf("error = %v, want newer schema message", err)
 	}
 }

--- a/internal/host/paths.go
+++ b/internal/host/paths.go
@@ -1,0 +1,135 @@
+package host
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var segmentPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
+
+type Paths struct {
+	root string
+}
+
+func NewPaths() (Paths, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Paths{}, err
+	}
+	return NewPathsFromHome(home)
+}
+
+func NewPathsFromHome(home string) (Paths, error) {
+	if home == "" {
+		return Paths{}, errors.New("home directory is required")
+	}
+	return NewPathsFromRoot(filepath.Join(home, ".pv"))
+}
+
+func NewPathsFromRoot(root string) (Paths, error) {
+	if root == "" {
+		return Paths{}, errors.New("pv root is required")
+	}
+	return Paths{root: filepath.Clean(root)}, nil
+}
+
+func (p Paths) Root() string {
+	return p.root
+}
+
+func (p Paths) BinDir() string {
+	return filepath.Join(p.root, "bin")
+}
+
+func (p Paths) PHPRuntimeDir(version string) (string, error) {
+	if err := validateSegment("version", version); err != nil {
+		return "", err
+	}
+	return filepath.Join(p.root, "runtimes", "php", version), nil
+}
+
+func (p Paths) ToolDir(name string, version string) (string, error) {
+	if err := validateSegment("tool name", name); err != nil {
+		return "", err
+	}
+	if err := validateSegment("version", version); err != nil {
+		return "", err
+	}
+	return filepath.Join(p.root, "tools", name, version), nil
+}
+
+func (p Paths) ServiceBinDir(name string, version string) (string, error) {
+	if err := validateSegment("service name", name); err != nil {
+		return "", err
+	}
+	if err := validateSegment("version", version); err != nil {
+		return "", err
+	}
+	return filepath.Join(p.root, "services", name, version, "bin"), nil
+}
+
+func (p Paths) DataDir(name string, version string) (string, error) {
+	if err := validateSegment("resource name", name); err != nil {
+		return "", err
+	}
+	if err := validateSegment("version", version); err != nil {
+		return "", err
+	}
+	return filepath.Join(p.root, "data", name, version), nil
+}
+
+func (p Paths) LogPath(name string, version string) (string, error) {
+	if err := validateSegment("resource name", name); err != nil {
+		return "", err
+	}
+	if err := validateSegment("version", version); err != nil {
+		return "", err
+	}
+	return filepath.Join(p.root, "logs", name, version+".log"), nil
+}
+
+func (p Paths) StateDBPath() string {
+	return filepath.Join(p.root, "state", "pv.db")
+}
+
+func (p Paths) CacheArtifactsDir() string {
+	return filepath.Join(p.root, "cache", "artifacts")
+}
+
+func (p Paths) ConfigDir() string {
+	return filepath.Join(p.root, "config")
+}
+
+func (p Paths) ValidateManagedPath(path string) error {
+	clean := filepath.Clean(path)
+	if clean == p.BinDir() {
+		return errors.New("bin directory is reserved for shims only")
+	}
+	if !isWithin(clean, p.root) {
+		return fmt.Errorf("path %q is outside pv root", path)
+	}
+	dataRoot := filepath.Join(p.root, "data")
+	if isWithin(clean, filepath.Join(p.root, "services")) && strings.Contains(clean, string(filepath.Separator)+"data"+string(filepath.Separator)) {
+		return fmt.Errorf("data path %q must use %s", path, dataRoot)
+	}
+	return nil
+}
+
+func validateSegment(label string, value string) error {
+	if !segmentPattern.MatchString(value) {
+		return fmt.Errorf("invalid %s %q", label, value)
+	}
+	return nil
+}
+
+func isWithin(path string, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}

--- a/internal/host/paths.go
+++ b/internal/host/paths.go
@@ -113,7 +113,9 @@ func (p Paths) ValidateManagedPath(path string) error {
 		return fmt.Errorf("path %q is outside pv root", path)
 	}
 	dataRoot := filepath.Join(p.root, "data")
-	if isWithin(clean, filepath.Join(p.root, "services")) && strings.Contains(clean, string(filepath.Separator)+"data"+string(filepath.Separator)) {
+	separator := string(filepath.Separator)
+	hasDataSegment := strings.Contains(clean, separator+"data"+separator) || strings.HasSuffix(clean, separator+"data")
+	if isWithin(clean, filepath.Join(p.root, "services")) && hasDataSegment {
 		return fmt.Errorf("data path %q must use %s", path, dataRoot)
 	}
 	return nil

--- a/internal/host/paths_test.go
+++ b/internal/host/paths_test.go
@@ -86,6 +86,7 @@ func TestPathsRejectAmbiguousManagedLocations(t *testing.T) {
 
 	for _, path := range []string{
 		filepath.Join(root, "bin"),
+		filepath.Join(root, "services", "postgres", "18.0", "data"),
 		filepath.Join(root, "services", "postgres", "18.0", "data", "cluster"),
 		filepath.Join(t.TempDir(), "outside"),
 	} {

--- a/internal/host/paths_test.go
+++ b/internal/host/paths_test.go
@@ -1,0 +1,96 @@
+package host
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPathsBuildCanonicalFamilies(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	paths, err := NewPaths()
+	if err != nil {
+		t.Fatalf("NewPaths returned error: %v", err)
+	}
+
+	php, err := paths.PHPRuntimeDir("8.4.1")
+	if err != nil {
+		t.Fatalf("PHPRuntimeDir returned error: %v", err)
+	}
+	tool, err := paths.ToolDir("composer", "2.9.2")
+	if err != nil {
+		t.Fatalf("ToolDir returned error: %v", err)
+	}
+	serviceBin, err := paths.ServiceBinDir("postgres", "18.0")
+	if err != nil {
+		t.Fatalf("ServiceBinDir returned error: %v", err)
+	}
+	data, err := paths.DataDir("postgres", "18.0")
+	if err != nil {
+		t.Fatalf("DataDir returned error: %v", err)
+	}
+	log, err := paths.LogPath("postgres", "18.0")
+	if err != nil {
+		t.Fatalf("LogPath returned error: %v", err)
+	}
+
+	root := filepath.Join(t.TempDir(), ".pv")
+	explicit, err := NewPathsFromRoot(root)
+	if err != nil {
+		t.Fatalf("NewPathsFromRoot returned error: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(paths.BinDir(), "pv"),
+		php,
+		tool,
+		serviceBin,
+		data,
+		log,
+		paths.StateDBPath(),
+		paths.CacheArtifactsDir(),
+		paths.ConfigDir(),
+	} {
+		if err := paths.ValidateManagedPath(path); err != nil {
+			t.Fatalf("ValidateManagedPath(%q) returned error: %v", path, err)
+		}
+	}
+	if explicit.Root() != root {
+		t.Fatalf("explicit root = %q, want %q", explicit.Root(), root)
+	}
+}
+
+func TestPathsRejectUnsafeSegments(t *testing.T) {
+	paths, err := NewPathsFromRoot(filepath.Join(t.TempDir(), ".pv"))
+	if err != nil {
+		t.Fatalf("NewPathsFromRoot returned error: %v", err)
+	}
+
+	for _, version := range []string{"", "../8.4", "8.4/bad", "two words"} {
+		if _, err := paths.PHPRuntimeDir(version); err == nil {
+			t.Fatalf("PHPRuntimeDir(%q) returned nil error", version)
+		}
+	}
+	for _, name := range []string{"", "../postgres", "post/gres", "two words"} {
+		if _, err := paths.ServiceBinDir(name, "18.0"); err == nil {
+			t.Fatalf("ServiceBinDir(%q) returned nil error", name)
+		}
+	}
+}
+
+func TestPathsRejectAmbiguousManagedLocations(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".pv")
+	paths, err := NewPathsFromRoot(root)
+	if err != nil {
+		t.Fatalf("NewPathsFromRoot returned error: %v", err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(root, "bin"),
+		filepath.Join(root, "services", "postgres", "18.0", "data", "cluster"),
+		filepath.Join(t.TempDir(), "outside"),
+	} {
+		if err := paths.ValidateManagedPath(path); err == nil {
+			t.Fatalf("ValidateManagedPath(%q) returned nil error", path)
+		}
+	}
+}

--- a/internal/installer/download.go
+++ b/internal/installer/download.go
@@ -1,0 +1,58 @@
+package installer
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type Downloader interface {
+	Download(context.Context, Item) error
+}
+
+type DownloadResult struct {
+	ID  Identity
+	Err error
+}
+
+func Download(ctx context.Context, items []Item, maxParallel int, downloader Downloader) ([]DownloadResult, error) {
+	if maxParallel < 1 {
+		return nil, errors.New("max parallel downloads must be at least 1")
+	}
+	if downloader == nil {
+		return nil, errors.New("downloader is required")
+	}
+
+	results := make([]DownloadResult, len(items))
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	workers := min(maxParallel, len(items))
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				item := items[index]
+				results[index] = DownloadResult{
+					ID:  item.ID,
+					Err: downloader.Download(ctx, item),
+				}
+			}
+		}()
+	}
+
+	for index := range items {
+		if err := ctx.Err(); err != nil {
+			close(jobs)
+			wg.Wait()
+			for i := index; i < len(items); i++ {
+				results[i] = DownloadResult{ID: items[i].ID, Err: err}
+			}
+			return results, err
+		}
+		jobs <- index
+	}
+	close(jobs)
+	wg.Wait()
+	return results, ctx.Err()
+}

--- a/internal/installer/download_test.go
+++ b/internal/installer/download_test.go
@@ -1,0 +1,91 @@
+package installer
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestDownloadBoundsParallelismAndKeepsResultOrder(t *testing.T) {
+	items := []Item{
+		{ID: Identity{Kind: KindRuntime, Name: "php", Version: "8.4.1"}},
+		{ID: Identity{Kind: KindTool, Name: "composer", Version: "2.9.2"}},
+		{ID: Identity{Kind: KindService, Name: "mailpit", Version: "1.0.0"}},
+	}
+	downloader := &countingDownloader{release: make(chan struct{})}
+	done := make(chan []DownloadResult, 1)
+	go func() {
+		results, err := Download(context.Background(), items, 2, downloader)
+		if err != nil {
+			t.Errorf("Download returned error: %v", err)
+		}
+		done <- results
+	}()
+
+	downloader.waitForActive(t, 2)
+	if got := downloader.maxActive(); got > 2 {
+		t.Fatalf("max active downloads = %d, want <= 2", got)
+	}
+	close(downloader.release)
+	results := <-done
+	for i, result := range results {
+		if result.ID != items[i].ID {
+			t.Fatalf("results[%d] = %s, want %s", i, result.ID, items[i].ID)
+		}
+		if result.Err != nil {
+			t.Fatalf("results[%d] error = %v", i, result.Err)
+		}
+	}
+}
+
+type countingDownloader struct {
+	release chan struct{}
+
+	mu       sync.Mutex
+	active   int
+	max      int
+	activeCh chan struct{}
+}
+
+func (d *countingDownloader) Download(context.Context, Item) error {
+	d.mu.Lock()
+	if d.activeCh == nil {
+		d.activeCh = make(chan struct{})
+	}
+	d.active++
+	d.max = max(d.max, d.active)
+	close(d.activeCh)
+	d.activeCh = make(chan struct{})
+	d.mu.Unlock()
+
+	<-d.release
+
+	d.mu.Lock()
+	d.active--
+	d.mu.Unlock()
+	return nil
+}
+
+func (d *countingDownloader) waitForActive(t *testing.T, want int) {
+	t.Helper()
+	for {
+		d.mu.Lock()
+		active := d.active
+		ch := d.activeCh
+		if ch == nil {
+			ch = make(chan struct{})
+			d.activeCh = ch
+		}
+		d.mu.Unlock()
+		if active >= want {
+			return
+		}
+		<-ch
+	}
+}
+
+func (d *countingDownloader) maxActive() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.max
+}

--- a/internal/installer/execute.go
+++ b/internal/installer/execute.go
@@ -1,0 +1,74 @@
+package installer
+
+import (
+	"context"
+	"errors"
+)
+
+type Installer interface {
+	Install(context.Context, Item) error
+}
+
+type ResultState string
+
+const (
+	ResultReady   ResultState = "ready"
+	ResultSkipped ResultState = "skipped"
+	ResultFailed  ResultState = "failed"
+)
+
+type InstallResult struct {
+	ID     Identity
+	State  ResultState
+	Reason string
+	Err    error
+}
+
+func Execute(ctx context.Context, plan Plan, installer Installer) ([]InstallResult, error) {
+	if installer == nil {
+		return nil, errors.New("installer is required")
+	}
+	if err := plan.Validate(); err != nil {
+		return nil, err
+	}
+	ordered, err := plan.Order()
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]InstallResult, 0, len(ordered))
+	failed := make(map[string]error)
+	for _, item := range ordered {
+		if err := ctx.Err(); err != nil {
+			results = append(results, InstallResult{ID: item.ID, State: ResultFailed, Reason: "context cancelled", Err: err})
+			failed[item.ID.String()] = err
+			continue
+		}
+		if dependencyErr := firstFailedDependency(item, failed); dependencyErr != nil {
+			results = append(results, InstallResult{
+				ID:     item.ID,
+				State:  ResultSkipped,
+				Reason: "dependency failed",
+				Err:    dependencyErr,
+			})
+			failed[item.ID.String()] = dependencyErr
+			continue
+		}
+		if err := installer.Install(ctx, item); err != nil {
+			results = append(results, InstallResult{ID: item.ID, State: ResultFailed, Reason: err.Error(), Err: err})
+			failed[item.ID.String()] = err
+			continue
+		}
+		results = append(results, InstallResult{ID: item.ID, State: ResultReady})
+	}
+	return results, nil
+}
+
+func firstFailedDependency(item Item, failed map[string]error) error {
+	for _, dependency := range item.DependsOn {
+		if err, ok := failed[dependency.String()]; ok {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/installer/execute_test.go
+++ b/internal/installer/execute_test.go
@@ -1,0 +1,40 @@
+package installer
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestExecuteSkipsDependentsAfterFailure(t *testing.T) {
+	php := Identity{Kind: KindRuntime, Name: "php", Version: "8.4.1"}
+	composer := Identity{Kind: KindTool, Name: "composer", Version: "2.9.2"}
+	plan := Plan{Items: []Item{
+		{ID: php},
+		{ID: composer, DependsOn: []Identity{php}},
+	}}
+	cause := errors.New("download missing")
+
+	results, err := Execute(context.Background(), plan, fakeInstaller{fail: map[string]error{php.String(): cause}})
+
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if results[0].State != ResultFailed {
+		t.Fatalf("php state = %q, want failed", results[0].State)
+	}
+	if results[1].State != ResultSkipped {
+		t.Fatalf("composer state = %q, want skipped", results[1].State)
+	}
+	if !errors.Is(results[1].Err, cause) {
+		t.Fatalf("composer error = %v, want %v", results[1].Err, cause)
+	}
+}
+
+type fakeInstaller struct {
+	fail map[string]error
+}
+
+func (i fakeInstaller) Install(_ context.Context, item Item) error {
+	return i.fail[item.ID.String()]
+}

--- a/internal/installer/plan.go
+++ b/internal/installer/plan.go
@@ -1,0 +1,120 @@
+package installer
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+type Kind string
+
+const (
+	KindRuntime Kind = "runtime"
+	KindTool    Kind = "tool"
+	KindService Kind = "service"
+)
+
+type Identity struct {
+	Kind    Kind
+	Name    string
+	Version string
+}
+
+func (id Identity) String() string {
+	return string(id.Kind) + ":" + id.Name + ":" + id.Version
+}
+
+type Item struct {
+	ID        Identity
+	DependsOn []Identity
+}
+
+type Plan struct {
+	Items []Item
+}
+
+func (p Plan) Validate() error {
+	seen := make(map[string]Identity, len(p.Items))
+	for _, item := range p.Items {
+		if err := validateIdentity(item.ID); err != nil {
+			return err
+		}
+		key := item.ID.String()
+		if existing, ok := seen[key]; ok {
+			return fmt.Errorf("duplicate install item %s", existing)
+		}
+		seen[key] = item.ID
+	}
+	for _, item := range p.Items {
+		for _, dependency := range item.DependsOn {
+			if err := validateIdentity(dependency); err != nil {
+				return err
+			}
+			if _, ok := seen[dependency.String()]; !ok {
+				return fmt.Errorf("install item %s depends on missing item %s", item.ID, dependency)
+			}
+		}
+	}
+	if _, err := p.Order(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p Plan) Order() ([]Item, error) {
+	items := make(map[string]Item, len(p.Items))
+	dependents := make(map[string][]string, len(p.Items))
+	remaining := make(map[string]int, len(p.Items))
+	for _, item := range p.Items {
+		key := item.ID.String()
+		items[key] = item
+		remaining[key] = len(item.DependsOn)
+		for _, dependency := range item.DependsOn {
+			dependencyKey := dependency.String()
+			dependents[dependencyKey] = append(dependents[dependencyKey], key)
+		}
+	}
+
+	var ready []string
+	for key, count := range remaining {
+		if count == 0 {
+			ready = append(ready, key)
+		}
+	}
+	sort.Strings(ready)
+
+	ordered := make([]Item, 0, len(p.Items))
+	for len(ready) > 0 {
+		key := ready[0]
+		ready = ready[1:]
+		ordered = append(ordered, items[key])
+		for _, dependent := range dependents[key] {
+			remaining[dependent]--
+			if remaining[dependent] == 0 {
+				ready = append(ready, dependent)
+				sort.Strings(ready)
+			}
+		}
+		delete(remaining, key)
+	}
+
+	if len(ordered) != len(p.Items) {
+		return nil, errors.New("install plan contains a dependency cycle")
+	}
+	return ordered, nil
+}
+
+func validateIdentity(id Identity) error {
+	switch id.Kind {
+	case KindRuntime, KindTool, KindService:
+	default:
+		return fmt.Errorf("invalid install item kind %q", id.Kind)
+	}
+	if id.Name == "" {
+		return errors.New("install item name is required")
+	}
+	if id.Version == "" {
+		return errors.New("install item version is required")
+	}
+	return nil
+}

--- a/internal/installer/plan_test.go
+++ b/internal/installer/plan_test.go
@@ -1,0 +1,56 @@
+package installer
+
+import "testing"
+
+func TestPlanOrdersDependenciesDeterministically(t *testing.T) {
+	php := Identity{Kind: KindRuntime, Name: "php", Version: "8.4.1"}
+	composer := Identity{Kind: KindTool, Name: "composer", Version: "2.9.2"}
+	mailpit := Identity{Kind: KindService, Name: "mailpit", Version: "1.0.0"}
+	plan := Plan{Items: []Item{
+		{ID: composer, DependsOn: []Identity{php}},
+		{ID: mailpit},
+		{ID: php},
+	}}
+
+	ordered, err := plan.Order()
+	if err != nil {
+		t.Fatalf("Order returned error: %v", err)
+	}
+	got := []Identity{ordered[0].ID, ordered[1].ID, ordered[2].ID}
+	want := []Identity{php, mailpit, composer}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ordered[%d] = %s, want %s", i, got[i], want[i])
+		}
+	}
+	if err := plan.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+}
+
+func TestPlanRejectsInvalidDependencies(t *testing.T) {
+	php := Identity{Kind: KindRuntime, Name: "php", Version: "8.4.1"}
+	composer := Identity{Kind: KindTool, Name: "composer", Version: "2.9.2"}
+
+	tests := map[string]Plan{
+		"duplicate identity": {
+			Items: []Item{{ID: php}, {ID: php}},
+		},
+		"missing dependency": {
+			Items: []Item{{ID: composer, DependsOn: []Identity{php}}},
+		},
+		"cycle": {
+			Items: []Item{
+				{ID: php, DependsOn: []Identity{composer}},
+				{ID: composer, DependsOn: []Identity{php}},
+			},
+		},
+	}
+	for name, plan := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := plan.Validate(); err == nil {
+				t.Fatal("Validate returned nil error")
+			}
+		})
+	}
+}

--- a/internal/installer/replace_unix.go
+++ b/internal/installer/replace_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package installer
+
+import "os"
+
+func replaceFile(tempPath string, path string) error {
+	return os.Rename(tempPath, path)
+}

--- a/internal/installer/replace_windows.go
+++ b/internal/installer/replace_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+package installer
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	moveFileReplaceExisting = 0x1
+	moveFileWriteThrough    = 0x8
+)
+
+var moveFileExW = syscall.NewLazyDLL("kernel32.dll").NewProc("MoveFileExW")
+
+func replaceFile(tempPath string, path string) error {
+	from, err := syscall.UTF16PtrFromString(tempPath)
+	if err != nil {
+		return err
+	}
+	to, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	result, _, err := moveFileExW.Call(
+		uintptr(unsafe.Pointer(from)),
+		uintptr(unsafe.Pointer(to)),
+		uintptr(moveFileReplaceExisting|moveFileWriteThrough),
+	)
+	if result != 0 {
+		return nil
+	}
+	if err != syscall.Errno(0) {
+		return os.NewSyscallError("MoveFileExW", err)
+	}
+	return os.NewSyscallError("MoveFileExW", errors.New("file replacement failed"))
+}

--- a/internal/installer/shim.go
+++ b/internal/installer/shim.go
@@ -1,0 +1,31 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func WriteShimAtomic(path string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	temp, err := os.CreateTemp(filepath.Dir(path), ".pv-shim-*")
+	if err != nil {
+		return err
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+
+	if _, err := temp.Write(content); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Chmod(0o755); err != nil {
+		temp.Close()
+		return err
+	}
+	if err := temp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, path)
+}

--- a/internal/installer/shim.go
+++ b/internal/installer/shim.go
@@ -27,5 +27,5 @@ func WriteShimAtomic(path string, content []byte) error {
 	if err := temp.Close(); err != nil {
 		return err
 	}
-	return os.Rename(tempPath, path)
+	return replaceFile(tempPath, path)
 }

--- a/internal/installer/shim_test.go
+++ b/internal/installer/shim_test.go
@@ -1,0 +1,40 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteShimAtomicReplacesExistingExecutable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bin", "composer")
+	if err := WriteShimAtomic(path, []byte("#!/bin/sh\necho old\n")); err != nil {
+		t.Fatalf("initial WriteShimAtomic returned error: %v", err)
+	}
+	if err := WriteShimAtomic(path, []byte("#!/bin/sh\necho new\n")); err != nil {
+		t.Fatalf("second WriteShimAtomic returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile returned error: %v", err)
+	}
+	if string(data) != "#!/bin/sh\necho new\n" {
+		t.Fatalf("shim content = %q", data)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat returned error: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("shim mode = %v, want 0755", info.Mode().Perm())
+	}
+
+	matches, err := filepath.Glob(filepath.Join(filepath.Dir(path), ".pv-shim-*"))
+	if err != nil {
+		t.Fatalf("Glob returned error: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary shims left behind: %v", matches)
+	}
+}

--- a/internal/installer/signal.go
+++ b/internal/installer/signal.go
@@ -1,0 +1,13 @@
+package installer
+
+import "context"
+
+func PersistThenSignal(ctx context.Context, persist func(context.Context) error, signal func(context.Context) error) error {
+	if err := persist(ctx); err != nil {
+		return err
+	}
+	if signal == nil {
+		return nil
+	}
+	return signal(ctx)
+}

--- a/internal/installer/signal_test.go
+++ b/internal/installer/signal_test.go
@@ -1,0 +1,43 @@
+package installer
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestPersistThenSignalRunsSignalAfterSuccessfulPersist(t *testing.T) {
+	var order []string
+	err := PersistThenSignal(context.Background(), func(context.Context) error {
+		order = append(order, "persist")
+		return nil
+	}, func(context.Context) error {
+		order = append(order, "signal")
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("PersistThenSignal returned error: %v", err)
+	}
+	if got := order; len(got) != 2 || got[0] != "persist" || got[1] != "signal" {
+		t.Fatalf("order = %v, want [persist signal]", got)
+	}
+}
+
+func TestPersistThenSignalDoesNotSignalAfterPersistFailure(t *testing.T) {
+	cause := errors.New("disk full")
+	signaled := false
+	err := PersistThenSignal(context.Background(), func(context.Context) error {
+		return cause
+	}, func(context.Context) error {
+		signaled = true
+		return nil
+	})
+
+	if !errors.Is(err, cause) {
+		t.Fatalf("error = %v, want %v", err, cause)
+	}
+	if signaled {
+		t.Fatal("signal ran after failed persist")
+	}
+}

--- a/internal/resources/mago/controller.go
+++ b/internal/resources/mago/controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/prvious/pv/internal/control"
+	"github.com/prvious/pv/internal/host"
 )
 
 type Installer interface {
@@ -100,5 +101,13 @@ func (i MarkerInstaller) Installed(version string) bool {
 }
 
 func (i MarkerInstaller) markerPath(version string) string {
-	return filepath.Join(i.root, "tools", "mago", version, "installed")
+	paths, err := host.NewPathsFromRoot(i.root)
+	if err != nil {
+		return filepath.Join(i.root, "tools", "mago", version, "installed")
+	}
+	dir, err := paths.ToolDir(control.ResourceMago, version)
+	if err != nil {
+		return filepath.Join(i.root, "tools", "mago", version, "installed")
+	}
+	return filepath.Join(dir, "installed")
 }


### PR DESCRIPTION
Stack position: Epic 2 of 5
Base branch: rewrite/epic-1-foundation
Targets main directly: no
Depends on: #206 / rewrite/epic-1-foundation
Verification: `gofmt -w . && go vet ./... && go build ./... && go test ./...`; `cd legacy/prototype && gofmt -w . && go vet ./... && go build ./... && go test ./...`

## Summary
- Adds canonical host path helpers and a versioned SQLite store migration layer.
- Adds installer planning, download, execution, shim, and signal primitives for managed tools.

## Linked Issues
Resolves #128 
resolves #129 
resolves #130 
resolves #131 
resolves #132 
resolves #133 
resolves #134 
resolves #135 
resolves #136 
resolves #137 
resolves #138 
resolves #139 
resolves #140 
resolves #141 
