### PR TITLE
Rewrite Epic 3: Runtime, Daemon, And Resources

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -14,6 +14,17 @@ const Version = "dev"
 
 var ErrUsage = errors.New("usage error")
 
+var statusResources = [...]string{
+	control.ResourcePHP,
+	control.ResourceComposer,
+	control.ResourceMago,
+	control.ResourceMailpit,
+	control.ResourceMySQL,
+	control.ResourcePostgres,
+	control.ResourceRedis,
+	control.ResourceRustFS,
+}
+
 func Run(args []string, stdout io.Writer, stderr io.Writer) error {
 	if len(args) == 0 {
 		writeHelp(stdout)
@@ -111,7 +122,7 @@ func runStatus(stderr io.Writer) error {
 
 	ctx := context.Background()
 	anyDesired := false
-	for _, resource := range [...]string{control.ResourcePHP, control.ResourceComposer, control.ResourceMago} {
+	for _, resource := range statusResources {
 		desired, desiredOK, err := store.Desired(ctx, resource)
 		if err != nil {
 			return err

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -21,11 +21,15 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) error {
 	}
 
 	switch args[0] {
+	case "composer:install":
+		return runComposerInstall(args[1:], stderr)
 	case "help", "--help", "-h":
 		writeHelp(stdout)
 		return nil
 	case "mago:install":
-		return runMagoInstall(args[1:], stderr)
+		return runSimpleInstall(args[1:], stderr, control.ResourceMago, "pv mago:install <version>")
+	case "php:install":
+		return runSimpleInstall(args[1:], stderr, control.ResourcePHP, "pv php:install <version>")
 	case "status":
 		return runStatus(stderr)
 	case "version", "--version":
@@ -44,8 +48,10 @@ Usage:
   pv <command>
 
 Commands:
+  composer:install <version> --php <version>
   help      Show this help.
   mago:install <version>
+  php:install <version>
   status    Show desired and observed control-plane status.
   version   Print the pv version.
 
@@ -53,30 +59,47 @@ The active rewrite command surface is intentionally minimal. See docs/rewrite/02
 `)
 }
 
-func runMagoInstall(args []string, stderr io.Writer) error {
+func runSimpleInstall(args []string, stderr io.Writer, resource string, usage string) error {
 	if len(args) != 1 {
-		fmt.Fprintln(stderr, "usage: pv mago:install <version>")
-		return fmt.Errorf("%w: invalid mago:install command", ErrUsage)
+		fmt.Fprintf(stderr, "usage: %s\n", usage)
+		return fmt.Errorf("%w: invalid %s:install command", ErrUsage, resource)
 	}
 
 	version := args[0]
-	if err := control.ValidateVersion(version); err != nil {
-		fmt.Fprintf(stderr, "pv: %v\n", err)
-		return fmt.Errorf("%w: %v", ErrUsage, err)
-	}
-
-	store, err := defaultStore()
-	if err != nil {
+	if err := validateVersionArg(stderr, version); err != nil {
 		return err
 	}
-	if err := store.PutDesired(context.Background(), control.DesiredResource{
-		Resource: control.ResourceMago,
-		Version:  version,
+	if err := putDesired(control.DesiredResource{Resource: resource, Version: version}); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(stderr, "requested %s %s install\n", resource, version)
+	return nil
+}
+
+func runComposerInstall(args []string, stderr io.Writer) error {
+	if len(args) != 3 || args[1] != "--php" {
+		fmt.Fprintln(stderr, "usage: pv composer:install <version> --php <version>")
+		return fmt.Errorf("%w: invalid composer:install command", ErrUsage)
+	}
+
+	version := args[0]
+	runtimeVersion := args[2]
+	if err := validateVersionArg(stderr, version); err != nil {
+		return err
+	}
+	if err := validateVersionArg(stderr, runtimeVersion); err != nil {
+		return err
+	}
+	if err := putDesired(control.DesiredResource{
+		Resource:       control.ResourceComposer,
+		Version:        version,
+		RuntimeVersion: runtimeVersion,
 	}); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(stderr, "requested mago %s install\n", version)
+	fmt.Fprintf(stderr, "requested composer %s install with php %s\n", version, runtimeVersion)
 	return nil
 }
 
@@ -87,36 +110,69 @@ func runStatus(stderr io.Writer) error {
 	}
 
 	ctx := context.Background()
-	desired, desiredOK, err := store.Desired(ctx, control.ResourceMago)
-	if err != nil {
-		return err
-	}
-	observed, observedOK, err := store.Observed(ctx, control.ResourceMago)
-	if err != nil {
-		return err
+	anyDesired := false
+	for _, resource := range [...]string{control.ResourcePHP, control.ResourceComposer, control.ResourceMago} {
+		desired, desiredOK, err := store.Desired(ctx, resource)
+		if err != nil {
+			return err
+		}
+		if !desiredOK {
+			continue
+		}
+		anyDesired = true
+		printDesired(stderr, desired)
+
+		observed, observedOK, err := store.Observed(ctx, resource)
+		if err != nil {
+			return err
+		}
+		if !observedOK {
+			fmt.Fprintf(stderr, "observed: %s pending\n", resource)
+			fmt.Fprintln(stderr, "next action: run reconciliation")
+			continue
+		}
+		printObserved(stderr, observed)
 	}
 
-	if !desiredOK {
+	if !anyDesired {
 		fmt.Fprintln(stderr, "desired: none")
-		return nil
-	}
-
-	fmt.Fprintf(stderr, "desired: mago %s install\n", desired.Version)
-	if !observedOK {
-		fmt.Fprintln(stderr, "observed: mago pending")
-		fmt.Fprintln(stderr, "next action: run reconciliation")
-		return nil
-	}
-
-	fmt.Fprintf(stderr, "observed: mago %s %s\n", observed.DesiredVersion, observed.State)
-	fmt.Fprintf(stderr, "last reconcile: %s\n", observed.LastReconcileTime)
-	if observed.LastError != "" {
-		fmt.Fprintf(stderr, "last error: %s\n", observed.LastError)
-	}
-	if observed.NextAction != "" {
-		fmt.Fprintf(stderr, "next action: %s\n", observed.NextAction)
 	}
 	return nil
+}
+
+func validateVersionArg(stderr io.Writer, version string) error {
+	if err := control.ValidateVersion(version); err != nil {
+		fmt.Fprintf(stderr, "pv: %v\n", err)
+		return fmt.Errorf("%w: %v", ErrUsage, err)
+	}
+	return nil
+}
+
+func putDesired(desired control.DesiredResource) error {
+	store, err := defaultStore()
+	if err != nil {
+		return err
+	}
+	return store.PutDesired(context.Background(), desired)
+}
+
+func printDesired(w io.Writer, desired control.DesiredResource) {
+	if desired.RuntimeVersion != "" {
+		fmt.Fprintf(w, "desired: %s %s install with php %s\n", desired.Resource, desired.Version, desired.RuntimeVersion)
+		return
+	}
+	fmt.Fprintf(w, "desired: %s %s install\n", desired.Resource, desired.Version)
+}
+
+func printObserved(w io.Writer, observed control.ObservedStatus) {
+	fmt.Fprintf(w, "observed: %s %s %s\n", observed.Resource, observed.DesiredVersion, observed.State)
+	fmt.Fprintf(w, "last reconcile: %s\n", observed.LastReconcileTime)
+	if observed.LastError != "" {
+		fmt.Fprintf(w, "last error: %s\n", observed.LastError)
+	}
+	if observed.NextAction != "" {
+		fmt.Fprintf(w, "next action: %s\n", observed.NextAction)
+	}
 }
 
 func defaultStore() (*control.FileStore, error) {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -327,6 +327,58 @@ func TestRunStatusReportsPHPAndComposer(t *testing.T) {
 	}
 }
 
+func TestRunStatusReportsBackingResources(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	ctx := t.Context()
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
+	for _, resource := range []string{
+		control.ResourceMailpit,
+		control.ResourceMySQL,
+		control.ResourcePostgres,
+		control.ResourceRedis,
+		control.ResourceRustFS,
+	} {
+		if err := store.PutDesired(ctx, control.DesiredResource{
+			Resource: resource,
+			Version:  "1.0.0",
+		}); err != nil {
+			t.Fatalf("PutDesired %s returned error: %v", resource, err)
+		}
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"status"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run status returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run status wrote stdout: %q", stdout.String())
+	}
+	output := stderr.String()
+	if strings.Contains(output, "desired: none") {
+		t.Fatalf("status output reported no desired resources:\n%s", output)
+	}
+	for _, want := range []string{
+		"desired: mailpit 1.0.0 install",
+		"observed: mailpit pending",
+		"desired: mysql 1.0.0 install",
+		"observed: mysql pending",
+		"desired: postgres 1.0.0 install",
+		"observed: postgres pending",
+		"desired: redis 1.0.0 install",
+		"observed: redis pending",
+		"desired: rustfs 1.0.0 install",
+		"observed: rustfs pending",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("status output missing %q:\n%s", want, output)
+		}
+	}
+}
+
 func fixedClock(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -31,14 +30,14 @@ func TestRunHelpWritesRewriteHelp(t *testing.T) {
 		"pv rewrite control plane",
 		"Usage:",
 		"pv <command>",
+		"composer:install",
+		"mago:install",
+		"php:install",
 		"version",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("help output missing %q:\n%s", want, out)
 		}
-	}
-	if strings.Contains(out, "php:install") {
-		t.Fatalf("help output copied prototype command surface:\n%s", out)
 	}
 }
 
@@ -95,7 +94,7 @@ func TestRunMagoInstallRecordsDesiredStateWithoutInstalling(t *testing.T) {
 	}
 
 	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
-	desired, ok, err := store.Desired(context.Background(), control.ResourceMago)
+	desired, ok, err := store.Desired(t.Context(), control.ResourceMago)
 	if err != nil {
 		t.Fatalf("Desired returned error: %v", err)
 	}
@@ -105,7 +104,7 @@ func TestRunMagoInstallRecordsDesiredStateWithoutInstalling(t *testing.T) {
 	if desired.Version != "1.2.3" {
 		t.Fatalf("desired version = %q, want 1.2.3", desired.Version)
 	}
-	if _, ok, err := store.Observed(context.Background(), control.ResourceMago); err != nil {
+	if _, ok, err := store.Observed(t.Context(), control.ResourceMago); err != nil {
 		t.Fatalf("Observed returned error: %v", err)
 	} else if ok {
 		t.Fatal("mago install command wrote observed status directly")
@@ -120,8 +119,8 @@ func TestRunMagoInstallRecordsDesiredStateWithoutInstalling(t *testing.T) {
 func TestRunStatusReportsDesiredAndObservedStatus(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	ctx := context.Background()
 	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
+	ctx := t.Context()
 	if err := store.PutDesired(ctx, control.DesiredResource{
 		Resource: control.ResourceMago,
 		Version:  "1.2.3",
@@ -161,7 +160,7 @@ func TestRunStatusReportsDesiredAndObservedStatus(t *testing.T) {
 func TestControlPlaneTracerRecordsDesiredThenObserved(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	ctx := context.Background()
+	ctx := t.Context()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
@@ -198,6 +197,133 @@ func TestControlPlaneTracerRecordsDesiredThenObserved(t *testing.T) {
 	}
 	if observed.State != control.StateReady {
 		t.Fatalf("observed state = %q, want ready", observed.State)
+	}
+}
+
+func TestRunPHPInstallRecordsDesiredRuntimeState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"php:install", "8.4"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run php install returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run php install wrote stdout: %q", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "requested php 8.4 install") {
+		t.Fatalf("stderr = %q, want requested message", got)
+	}
+
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
+	desired, ok, err := store.Desired(t.Context(), control.ResourcePHP)
+	if err != nil {
+		t.Fatalf("Desired returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Desired did not find PHP resource")
+	}
+	if desired.Version != "8.4" {
+		t.Fatalf("desired version = %q, want 8.4", desired.Version)
+	}
+}
+
+func TestRunComposerInstallRecordsRuntimeDependency(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"composer:install", "2.8.0", "--php", "8.4"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run composer install returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run composer install wrote stdout: %q", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "requested composer 2.8.0 install with php 8.4") {
+		t.Fatalf("stderr = %q, want requested message", got)
+	}
+
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
+	desired, ok, err := store.Desired(t.Context(), control.ResourceComposer)
+	if err != nil {
+		t.Fatalf("Desired returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Desired did not find Composer resource")
+	}
+	if desired.Version != "2.8.0" {
+		t.Fatalf("desired version = %q, want 2.8.0", desired.Version)
+	}
+	if desired.RuntimeVersion != "8.4" {
+		t.Fatalf("runtime version = %q, want 8.4", desired.RuntimeVersion)
+	}
+}
+
+func TestRunStatusReportsPHPAndComposer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	ctx := t.Context()
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource: control.ResourcePHP,
+		Version:  "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired PHP returned error: %v", err)
+	}
+	if err := store.PutObserved(ctx, control.ObservedStatus{
+		Resource:          control.ResourcePHP,
+		DesiredVersion:    "8.4",
+		State:             control.StateReady,
+		LastReconcileTime: "2026-05-15T19:00:00Z",
+	}); err != nil {
+		t.Fatalf("PutObserved PHP returned error: %v", err)
+	}
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource:       control.ResourceComposer,
+		Version:        "2.8.0",
+		RuntimeVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired Composer returned error: %v", err)
+	}
+	if err := store.PutObserved(ctx, control.ObservedStatus{
+		Resource:          control.ResourceComposer,
+		DesiredVersion:    "2.8.0",
+		RuntimeVersion:    "8.4",
+		State:             control.StateBlocked,
+		LastReconcileTime: "2026-05-15T19:10:00Z",
+		LastError:         "PHP runtime 8.4 is not installed",
+		NextAction:        "run pv php:install 8.4",
+	}); err != nil {
+		t.Fatalf("PutObserved Composer returned error: %v", err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"status"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run status returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run status wrote stdout: %q", stdout.String())
+	}
+	for _, want := range []string{
+		"desired: php 8.4 install",
+		"observed: php 8.4 ready",
+		"desired: composer 2.8.0 install with php 8.4",
+		"observed: composer 2.8.0 blocked",
+		"last error: PHP runtime 8.4 is not installed",
+		"next action: run pv php:install 8.4",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("status output missing %q:\n%s", want, stderr.String())
+		}
 	}
 }
 

--- a/internal/control/daemon.go
+++ b/internal/control/daemon.go
@@ -1,0 +1,36 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+type Controller interface {
+	Resource() string
+	Reconcile(context.Context) error
+}
+
+type Daemon struct {
+	Controllers []Controller
+}
+
+func (d Daemon) Reconcile(ctx context.Context) error {
+	if len(d.Controllers) == 0 {
+		return nil
+	}
+	var err error
+	for _, controller := range d.Controllers {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if controller == nil {
+			err = errors.Join(err, errors.New("daemon controller is nil"))
+			continue
+		}
+		if reconcileErr := controller.Reconcile(ctx); reconcileErr != nil {
+			err = errors.Join(err, fmt.Errorf("reconcile %s: %w", controller.Resource(), reconcileErr))
+		}
+	}
+	return err
+}

--- a/internal/control/daemon_test.go
+++ b/internal/control/daemon_test.go
@@ -1,0 +1,55 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestDaemonReconcilesControllersInOrder(t *testing.T) {
+	var called []string
+	daemon := Daemon{Controllers: []Controller{
+		fakeController{resource: ResourcePHP, called: &called},
+		fakeController{resource: ResourceComposer, called: &called},
+	}}
+
+	if err := daemon.Reconcile(t.Context()); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	want := []string{ResourcePHP, ResourceComposer}
+	for i := range want {
+		if called[i] != want[i] {
+			t.Fatalf("called[%d] = %q, want %q", i, called[i], want[i])
+		}
+	}
+}
+
+func TestDaemonWrapsControllerFailures(t *testing.T) {
+	cause := errors.New("install failed")
+	daemon := Daemon{Controllers: []Controller{
+		fakeController{resource: ResourcePHP, err: cause},
+	}}
+
+	err := daemon.Reconcile(context.Background())
+
+	if !errors.Is(err, cause) {
+		t.Fatalf("Reconcile error = %v, want %v", err, cause)
+	}
+}
+
+type fakeController struct {
+	resource string
+	called   *[]string
+	err      error
+}
+
+func (c fakeController) Resource() string {
+	return c.resource
+}
+
+func (c fakeController) Reconcile(context.Context) error {
+	if c.called != nil {
+		*c.called = append(*c.called, c.resource)
+	}
+	return c.err
+}

--- a/internal/control/store.go
+++ b/internal/control/store.go
@@ -13,22 +13,34 @@ import (
 const (
 	CurrentSchemaVersion = 1
 
-	ResourceMago = "mago"
+	ResourceComposer = "composer"
+	ResourceMailpit  = "mailpit"
+	ResourceMago     = "mago"
+	ResourceMySQL    = "mysql"
+	ResourcePostgres = "postgres"
+	ResourcePHP      = "php"
+	ResourceRedis    = "redis"
+	ResourceRustFS   = "rustfs"
 
-	StateReady  = "ready"
-	StateFailed = "failed"
+	StateBlocked = "blocked"
+	StateMissing = "missing"
+	StateReady   = "ready"
+	StateStopped = "stopped"
+	StateFailed  = "failed"
 )
 
 var versionPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
 
 type DesiredResource struct {
-	Resource string `json:"resource"`
-	Version  string `json:"version"`
+	Resource       string `json:"resource"`
+	Version        string `json:"version"`
+	RuntimeVersion string `json:"runtime_version,omitempty"`
 }
 
 type ObservedStatus struct {
 	Resource          string `json:"resource"`
 	DesiredVersion    string `json:"desired_version"`
+	RuntimeVersion    string `json:"runtime_version,omitempty"`
 	State             string `json:"state"`
 	LastReconcileTime string `json:"last_reconcile_time"`
 	LastError         string `json:"last_error,omitempty"`
@@ -90,10 +102,7 @@ func (s *FileStore) PutDesired(ctx context.Context, desired DesiredResource) err
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if desired.Resource == "" {
-		return errors.New("desired resource is required")
-	}
-	if err := ValidateVersion(desired.Version); err != nil {
+	if err := validateDesiredResource(desired); err != nil {
 		return err
 	}
 
@@ -153,6 +162,19 @@ func ValidateVersion(version string) error {
 		return fmt.Errorf("invalid version %q", version)
 	}
 	return nil
+}
+
+func validateDesiredResource(desired DesiredResource) error {
+	if desired.Resource == "" {
+		return errors.New("desired resource is required")
+	}
+	if err := ValidateVersion(desired.Version); err != nil {
+		return err
+	}
+	if desired.RuntimeVersion == "" {
+		return nil
+	}
+	return ValidateVersion(desired.RuntimeVersion)
 }
 
 type AppliedMigration struct {

--- a/internal/resources/composer/controller.go
+++ b/internal/resources/composer/controller.go
@@ -33,6 +33,10 @@ type Controller struct {
 	Clock     func() time.Time
 }
 
+func (c Controller) Resource() string {
+	return control.ResourceComposer
+}
+
 func (c Controller) Reconcile(ctx context.Context) error {
 	desired, ok, err := c.Store.Desired(ctx, control.ResourceComposer)
 	if err != nil {

--- a/internal/resources/composer/controller.go
+++ b/internal/resources/composer/controller.go
@@ -1,0 +1,178 @@
+package composer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+	"github.com/prvious/pv/internal/host"
+	"github.com/prvious/pv/internal/installer"
+)
+
+type Runtime interface {
+	Installed(string) bool
+}
+
+type Installer interface {
+	Install(context.Context, InstallRequest) error
+}
+
+type InstallRequest struct {
+	Version        string
+	RuntimeVersion string
+}
+
+type Controller struct {
+	Store     control.Store
+	Installer Installer
+	Runtime   Runtime
+	Clock     func() time.Time
+}
+
+func (c Controller) Reconcile(ctx context.Context) error {
+	desired, ok, err := c.Store.Desired(ctx, control.ResourceComposer)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	reconciledAt := c.now().UTC().Format(time.RFC3339)
+	if err := validateDesired(desired); err != nil {
+		return c.recordFailure(ctx, desired, control.StateFailed, reconciledAt, err, "fix the Composer desired state and run reconciliation again")
+	}
+
+	if !c.Runtime.Installed(desired.RuntimeVersion) {
+		err := fmt.Errorf("PHP runtime %s is not installed", desired.RuntimeVersion)
+		return c.recordFailure(ctx, desired, control.StateBlocked, reconciledAt, err, fmt.Sprintf("run pv php:install %s", desired.RuntimeVersion))
+	}
+
+	if err := c.Installer.Install(ctx, InstallRequest{
+		Version:        desired.Version,
+		RuntimeVersion: desired.RuntimeVersion,
+	}); err != nil {
+		return c.recordFailure(ctx, desired, control.StateFailed, reconciledAt, err, "fix the Composer install failure and run reconciliation again")
+	}
+
+	return c.Store.PutObserved(ctx, control.ObservedStatus{
+		Resource:          control.ResourceComposer,
+		DesiredVersion:    desired.Version,
+		RuntimeVersion:    desired.RuntimeVersion,
+		State:             control.StateReady,
+		LastReconcileTime: reconciledAt,
+	})
+}
+
+func validateDesired(desired control.DesiredResource) error {
+	if err := control.ValidateVersion(desired.Version); err != nil {
+		return err
+	}
+	if desired.RuntimeVersion == "" {
+		return errors.New("composer runtime version is required")
+	}
+	return control.ValidateVersion(desired.RuntimeVersion)
+}
+
+func (c Controller) recordFailure(ctx context.Context, desired control.DesiredResource, state string, reconciledAt string, cause error, nextAction string) error {
+	status := control.ObservedStatus{
+		Resource:          control.ResourceComposer,
+		DesiredVersion:    desired.Version,
+		RuntimeVersion:    desired.RuntimeVersion,
+		State:             state,
+		LastReconcileTime: reconciledAt,
+		LastError:         cause.Error(),
+		NextAction:        nextAction,
+	}
+	if err := c.Store.PutObserved(ctx, status); err != nil {
+		return err
+	}
+	if state == control.StateBlocked {
+		return nil
+	}
+	return cause
+}
+
+func (c Controller) now() time.Time {
+	if c.Clock != nil {
+		return c.Clock()
+	}
+	return time.Now()
+}
+
+type MarkerInstaller struct {
+	root string
+}
+
+func NewMarkerInstaller(root string) MarkerInstaller {
+	return MarkerInstaller{root: root}
+}
+
+func (i MarkerInstaller) Install(ctx context.Context, request InstallRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := control.ValidateVersion(request.Version); err != nil {
+		return err
+	}
+	if err := control.ValidateVersion(request.RuntimeVersion); err != nil {
+		return err
+	}
+
+	marker := i.markerPath(request.Version)
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(marker, []byte(fmt.Sprintf("composer %s\n", request.Version)), 0o644); err != nil {
+		return err
+	}
+
+	return i.writeShim(ctx, request)
+}
+
+func (i MarkerInstaller) Installed(version string) bool {
+	_, err := os.Stat(i.markerPath(version))
+	return err == nil
+}
+
+func (i MarkerInstaller) ShimExists() bool {
+	paths, err := host.NewPathsFromRoot(i.root)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(paths.BinDir(), "composer"))
+	return err == nil
+}
+
+func (i MarkerInstaller) markerPath(version string) string {
+	paths, err := host.NewPathsFromRoot(i.root)
+	if err != nil {
+		return filepath.Join(i.root, "tools", "composer", version, "installed")
+	}
+	dir, err := paths.ToolDir(control.ResourceComposer, version)
+	if err != nil {
+		return filepath.Join(i.root, "tools", "composer", version, "installed")
+	}
+	return filepath.Join(dir, "installed")
+}
+
+func (i MarkerInstaller) writeShim(ctx context.Context, request InstallRequest) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	paths, err := host.NewPathsFromRoot(i.root)
+	if err != nil {
+		return err
+	}
+	const shimTemplate = `#!/bin/sh
+# composer %s via php %s
+exec "$(dirname "$0")/../runtimes/php/%s/php" "$(dirname "$0")/../tools/composer/%s/composer.phar" "$@"
+`
+	content := fmt.Sprintf(shimTemplate, request.Version, request.RuntimeVersion, request.RuntimeVersion, request.Version)
+	return installer.WriteShimAtomic(filepath.Join(paths.BinDir(), "composer"), []byte(content))
+}

--- a/internal/resources/composer/controller_test.go
+++ b/internal/resources/composer/controller_test.go
@@ -1,0 +1,167 @@
+package composer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+	"github.com/prvious/pv/internal/resources/php"
+)
+
+func TestControllerBlocksComposerWhenRuntimeIsMissing(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+	store := control.NewFileStore(filepath.Join(root, "pv.db"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource:       control.ResourceComposer,
+		Version:        "2.8.0",
+		RuntimeVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+
+	installer := NewMarkerInstaller(root)
+	controller := Controller{
+		Store:     store,
+		Installer: installer,
+		Runtime:   php.NewMarkerInstaller(root),
+		Clock:     fixedClock("2026-05-15T19:10:00Z"),
+	}
+
+	if err := controller.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	if installer.Installed("2.8.0") {
+		t.Fatal("Composer installed without its PHP runtime")
+	}
+	if installer.ShimExists() {
+		t.Fatal("Composer shim exists without its PHP runtime")
+	}
+
+	observed, ok, err := store.Observed(ctx, control.ResourceComposer)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Observed did not find Composer status")
+	}
+	if observed.State != control.StateBlocked {
+		t.Fatalf("State = %q, want blocked", observed.State)
+	}
+	if observed.LastError != "PHP runtime 8.4 is not installed" {
+		t.Fatalf("LastError = %q", observed.LastError)
+	}
+	if !strings.Contains(observed.NextAction, "php:install 8.4") {
+		t.Fatalf("NextAction = %q, want php:install guidance", observed.NextAction)
+	}
+}
+
+func TestControllerInstallsComposerAndExposesShimWhenRuntimeExists(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+	store := control.NewFileStore(filepath.Join(root, "pv.db"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource:       control.ResourceComposer,
+		Version:        "2.8.0",
+		RuntimeVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+	runtime := php.NewMarkerInstaller(root)
+	if err := runtime.Install(ctx, "8.4"); err != nil {
+		t.Fatalf("PHP Install returned error: %v", err)
+	}
+
+	installer := NewMarkerInstaller(root)
+	controller := Controller{
+		Store:     store,
+		Installer: installer,
+		Runtime:   runtime,
+		Clock:     fixedClock("2026-05-15T19:10:00Z"),
+	}
+
+	if err := controller.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	if !installer.Installed("2.8.0") {
+		t.Fatal("Composer marker was not installed")
+	}
+	shim, err := os.ReadFile(filepath.Join(root, "bin", "composer"))
+	if err != nil {
+		t.Fatalf("ReadFile shim returned error: %v", err)
+	}
+	for _, want := range []string{"composer 2.8.0", "php 8.4"} {
+		if !strings.Contains(string(shim), want) {
+			t.Fatalf("shim missing %q:\n%s", want, string(shim))
+		}
+	}
+
+	observed, ok, err := store.Observed(ctx, control.ResourceComposer)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Observed did not find Composer status")
+	}
+	want := control.ObservedStatus{
+		Resource:          control.ResourceComposer,
+		DesiredVersion:    "2.8.0",
+		RuntimeVersion:    "8.4",
+		State:             control.StateReady,
+		LastReconcileTime: "2026-05-15T19:10:00Z",
+	}
+	if observed != want {
+		t.Fatalf("Observed = %#v, want %#v", observed, want)
+	}
+}
+
+func TestMarkerInstallerReplacesComposerShimAtomically(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+	bin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("MkdirAll returned error: %v", err)
+	}
+	shim := filepath.Join(bin, "composer")
+	if err := os.WriteFile(shim, []byte("old shim\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile old shim returned error: %v", err)
+	}
+
+	installer := NewMarkerInstaller(root)
+	if err := installer.Install(ctx, InstallRequest{
+		Version:        "2.8.0",
+		RuntimeVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(shim)
+	if err != nil {
+		t.Fatalf("ReadFile shim returned error: %v", err)
+	}
+	if string(got) == "old shim\n" {
+		t.Fatal("composer shim was not replaced")
+	}
+	matches, err := filepath.Glob(filepath.Join(bin, ".composer-*"))
+	if err != nil {
+		t.Fatalf("Glob returned error: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("temporary shim files were not cleaned up: %v", matches)
+	}
+}
+
+func fixedClock(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time {
+		return parsed
+	}
+}

--- a/internal/resources/composer/controller_test.go
+++ b/internal/resources/composer/controller_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/prvious/pv/internal/resources/php"
 )
 
+var _ control.Controller = Controller{}
+
+func TestControllerResource(t *testing.T) {
+	if got := (Controller{}).Resource(); got != control.ResourceComposer {
+		t.Fatalf("Resource = %q, want %q", got, control.ResourceComposer)
+	}
+}
+
 func TestControllerBlocksComposerWhenRuntimeIsMissing(t *testing.T) {
 	ctx := t.Context()
 	root := t.TempDir()

--- a/internal/resources/mago/controller.go
+++ b/internal/resources/mago/controller.go
@@ -21,6 +21,10 @@ type Controller struct {
 	Clock     func() time.Time
 }
 
+func (c Controller) Resource() string {
+	return control.ResourceMago
+}
+
 func (c Controller) Reconcile(ctx context.Context) error {
 	desired, ok, err := c.Store.Desired(ctx, control.ResourceMago)
 	if err != nil {

--- a/internal/resources/mago/controller_test.go
+++ b/internal/resources/mago/controller_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/prvious/pv/internal/control"
 )
 
+var _ control.Controller = Controller{}
+
+func TestControllerResource(t *testing.T) {
+	if got := (Controller{}).Resource(); got != control.ResourceMago {
+		t.Fatalf("Resource = %q, want %q", got, control.ResourceMago)
+	}
+}
+
 func TestControllerReconcilesDesiredMagoInstallToObservedReady(t *testing.T) {
 	ctx := context.Background()
 	store := control.NewFileStore(filepath.Join(t.TempDir(), "pv.json"))

--- a/internal/resources/mailpit/controller.go
+++ b/internal/resources/mailpit/controller.go
@@ -1,0 +1,97 @@
+package mailpit
+
+import (
+	"context"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+	"github.com/prvious/pv/internal/host"
+	"github.com/prvious/pv/internal/supervisor"
+)
+
+type Supervisor interface {
+	Start(context.Context, supervisor.ProcessDefinition) (supervisor.ProcessStatus, error)
+}
+
+type Controller struct {
+	Store      control.Store
+	Paths      host.Paths
+	Supervisor Supervisor
+	Clock      func() time.Time
+}
+
+func (c Controller) Resource() string {
+	return control.ResourceMailpit
+}
+
+func (c Controller) Reconcile(ctx context.Context) error {
+	desired, ok, err := c.Store.Desired(ctx, control.ResourceMailpit)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	definition, err := c.ProcessDefinition(desired.Version)
+	if err != nil {
+		return c.record(ctx, desired.Version, control.StateFailed, err, "")
+	}
+	status, err := c.Supervisor.Start(ctx, definition)
+	if err != nil {
+		return c.record(ctx, desired.Version, control.StateFailed, err, "inspect the Mailpit log and run reconciliation again")
+	}
+	state := control.StateStopped
+	if status.Running {
+		state = control.StateReady
+	}
+	return c.record(ctx, desired.Version, state, nil, "")
+}
+
+func (c Controller) ProcessDefinition(version string) (supervisor.ProcessDefinition, error) {
+	bin, err := c.Paths.ServiceBinDir(control.ResourceMailpit, version)
+	if err != nil {
+		return supervisor.ProcessDefinition{}, err
+	}
+	logPath, err := c.Paths.LogPath(control.ResourceMailpit, version)
+	if err != nil {
+		return supervisor.ProcessDefinition{}, err
+	}
+	return supervisor.ProcessDefinition{
+		Name:    control.ResourceMailpit,
+		Version: version,
+		Command: bin + "/mailpit",
+		Args:    []string{"--smtp", "127.0.0.1:1025", "--listen", "127.0.0.1:8025"},
+		Env:     Env(),
+		LogPath: logPath,
+	}, nil
+}
+
+func Env() map[string]string {
+	return map[string]string{
+		"MAIL_MAILER": "smtp",
+		"MAIL_HOST":   "127.0.0.1",
+		"MAIL_PORT":   "1025",
+	}
+}
+
+func (c Controller) record(ctx context.Context, version string, state string, cause error, nextAction string) error {
+	status := control.ObservedStatus{
+		Resource:          control.ResourceMailpit,
+		DesiredVersion:    version,
+		State:             state,
+		LastReconcileTime: c.now().UTC().Format(time.RFC3339),
+		NextAction:        nextAction,
+	}
+	if cause != nil {
+		status.LastError = cause.Error()
+	}
+	return c.Store.PutObserved(ctx, status)
+}
+
+func (c Controller) now() time.Time {
+	if c.Clock != nil {
+		return c.Clock()
+	}
+	return time.Now()
+}

--- a/internal/resources/mailpit/controller.go
+++ b/internal/resources/mailpit/controller.go
@@ -39,7 +39,10 @@ func (c Controller) Reconcile(ctx context.Context) error {
 	}
 	status, err := c.Supervisor.Start(ctx, definition)
 	if err != nil {
-		return c.record(ctx, desired.Version, control.StateFailed, err, "inspect the Mailpit log and run reconciliation again")
+		if recordErr := c.record(ctx, desired.Version, control.StateFailed, err, "inspect the Mailpit log and run reconciliation again"); recordErr != nil {
+			return recordErr
+		}
+		return err
 	}
 	state := control.StateStopped
 	if status.Running {

--- a/internal/resources/mailpit/controller_test.go
+++ b/internal/resources/mailpit/controller_test.go
@@ -1,0 +1,68 @@
+package mailpit
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+	"github.com/prvious/pv/internal/host"
+	"github.com/prvious/pv/internal/supervisor"
+)
+
+func TestControllerStartsMailpitThroughSupervisor(t *testing.T) {
+	ctx := t.Context()
+	root := filepath.Join(t.TempDir(), ".pv")
+	paths, err := host.NewPathsFromRoot(root)
+	if err != nil {
+		t.Fatalf("NewPathsFromRoot returned error: %v", err)
+	}
+	store := control.NewFileStore(filepath.Join(root, "state", "pv.db"))
+	if err := store.PutDesired(ctx, control.DesiredResource{Resource: control.ResourceMailpit, Version: "1.0.0"}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+	supervisor := &fakeSupervisor{}
+	controller := Controller{
+		Store:      store,
+		Paths:      paths,
+		Supervisor: supervisor,
+		Clock:      fixedClock("2026-05-15T20:00:00Z"),
+	}
+
+	if err := controller.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+	if supervisor.started.Name != control.ResourceMailpit {
+		t.Fatalf("started process = %#v", supervisor.started)
+	}
+	if supervisor.started.Env["MAIL_PORT"] != "1025" {
+		t.Fatalf("Mailpit env = %#v", supervisor.started.Env)
+	}
+	observed, ok, err := store.Observed(ctx, control.ResourceMailpit)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok || observed.State != control.StateReady {
+		t.Fatalf("observed = %#v, ok=%v", observed, ok)
+	}
+}
+
+type fakeSupervisor struct {
+	started supervisor.ProcessDefinition
+}
+
+func (s *fakeSupervisor) Start(_ context.Context, definition supervisor.ProcessDefinition) (supervisor.ProcessStatus, error) {
+	s.started = definition
+	return supervisor.ProcessStatus{Name: definition.Name, Running: true, PID: 42, LogPath: definition.LogPath}, nil
+}
+
+func fixedClock(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time {
+		return parsed
+	}
+}

--- a/internal/resources/mailpit/controller_test.go
+++ b/internal/resources/mailpit/controller_test.go
@@ -2,6 +2,7 @@ package mailpit
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -48,12 +49,55 @@ func TestControllerStartsMailpitThroughSupervisor(t *testing.T) {
 	}
 }
 
+func TestControllerReturnsStartErrorAfterRecordingFailure(t *testing.T) {
+	ctx := t.Context()
+	root := filepath.Join(t.TempDir(), ".pv")
+	paths, err := host.NewPathsFromRoot(root)
+	if err != nil {
+		t.Fatalf("NewPathsFromRoot returned error: %v", err)
+	}
+	store := control.NewFileStore(filepath.Join(root, "state", "pv.db"))
+	if err := store.PutDesired(ctx, control.DesiredResource{Resource: control.ResourceMailpit, Version: "1.0.0"}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+	startErr := errors.New("mailpit start failed")
+	controller := Controller{
+		Store:      store,
+		Paths:      paths,
+		Supervisor: &fakeSupervisor{err: startErr},
+		Clock:      fixedClock("2026-05-15T20:00:00Z"),
+	}
+
+	err = controller.Reconcile(ctx)
+
+	if !errors.Is(err, startErr) {
+		t.Fatalf("Reconcile error = %v, want %v", err, startErr)
+	}
+	observed, ok, err := store.Observed(ctx, control.ResourceMailpit)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Observed did not find mailpit status")
+	}
+	if observed.State != control.StateFailed {
+		t.Fatalf("observed state = %q, want failed", observed.State)
+	}
+	if observed.LastError != startErr.Error() {
+		t.Fatalf("last error = %q, want %q", observed.LastError, startErr.Error())
+	}
+}
+
 type fakeSupervisor struct {
 	started supervisor.ProcessDefinition
+	err     error
 }
 
 func (s *fakeSupervisor) Start(_ context.Context, definition supervisor.ProcessDefinition) (supervisor.ProcessStatus, error) {
 	s.started = definition
+	if s.err != nil {
+		return supervisor.ProcessStatus{}, s.err
+	}
 	return supervisor.ProcessStatus{Name: definition.Name, Running: true, PID: 42, LogPath: definition.LogPath}, nil
 }
 

--- a/internal/resources/mysql/resource.go
+++ b/internal/resources/mysql/resource.go
@@ -1,0 +1,42 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+type Database interface {
+	Create(context.Context, string) error
+	Drop(context.Context, string) error
+	List(context.Context) ([]string, error)
+}
+
+type Commands struct {
+	DB Database
+}
+
+func Env(version string) map[string]string {
+	return map[string]string{
+		"DB_CONNECTION": "mysql",
+		"DB_HOST":       "127.0.0.1",
+		"DB_PORT":       "3306",
+		"PV_MYSQL":      version,
+	}
+}
+
+func Desired(version string) control.DesiredResource {
+	return control.DesiredResource{Resource: control.ResourceMySQL, Version: version}
+}
+
+func (c Commands) Create(ctx context.Context, name string) error {
+	return c.DB.Create(ctx, name)
+}
+
+func (c Commands) Drop(ctx context.Context, name string) error {
+	return c.DB.Drop(ctx, name)
+}
+
+func (c Commands) List(ctx context.Context) ([]string, error) {
+	return c.DB.List(ctx)
+}

--- a/internal/resources/mysql/resource_test.go
+++ b/internal/resources/mysql/resource_test.go
@@ -1,0 +1,18 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+func TestMySQLResourceIsExplicit(t *testing.T) {
+	desired := Desired("9.7")
+	if desired.Resource != control.ResourceMySQL {
+		t.Fatalf("resource = %q", desired.Resource)
+	}
+	env := Env("9.7")
+	if env["DB_CONNECTION"] != "mysql" || env["PV_MYSQL"] != "9.7" {
+		t.Fatalf("env = %#v", env)
+	}
+}

--- a/internal/resources/php/controller.go
+++ b/internal/resources/php/controller.go
@@ -1,0 +1,135 @@
+package php
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+	"github.com/prvious/pv/internal/host"
+	"github.com/prvious/pv/internal/installer"
+)
+
+type Installer interface {
+	Install(context.Context, string) error
+}
+
+type Controller struct {
+	Store     control.Store
+	Installer Installer
+	Clock     func() time.Time
+}
+
+func (c Controller) Reconcile(ctx context.Context) error {
+	desired, ok, err := c.Store.Desired(ctx, control.ResourcePHP)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	reconciledAt := c.now().UTC().Format(time.RFC3339)
+	if err := control.ValidateVersion(desired.Version); err != nil {
+		return c.recordFailure(ctx, desired.Version, reconciledAt, err)
+	}
+
+	if err := c.Installer.Install(ctx, desired.Version); err != nil {
+		return c.recordFailure(ctx, desired.Version, reconciledAt, err)
+	}
+
+	return c.Store.PutObserved(ctx, control.ObservedStatus{
+		Resource:          control.ResourcePHP,
+		DesiredVersion:    desired.Version,
+		State:             control.StateReady,
+		LastReconcileTime: reconciledAt,
+	})
+}
+
+func (c Controller) recordFailure(ctx context.Context, version string, reconciledAt string, cause error) error {
+	status := control.ObservedStatus{
+		Resource:          control.ResourcePHP,
+		DesiredVersion:    version,
+		State:             control.StateFailed,
+		LastReconcileTime: reconciledAt,
+		LastError:         cause.Error(),
+		NextAction:        "fix the PHP runtime install failure and run reconciliation again",
+	}
+	if err := c.Store.PutObserved(ctx, status); err != nil {
+		return err
+	}
+	return cause
+}
+
+func (c Controller) now() time.Time {
+	if c.Clock != nil {
+		return c.Clock()
+	}
+	return time.Now()
+}
+
+type MarkerInstaller struct {
+	root string
+}
+
+func NewMarkerInstaller(root string) MarkerInstaller {
+	return MarkerInstaller{root: root}
+}
+
+func (i MarkerInstaller) Install(ctx context.Context, version string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := control.ValidateVersion(version); err != nil {
+		return err
+	}
+
+	marker := i.markerPath(version)
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(marker, []byte(fmt.Sprintf("php %s\n", version)), 0o644); err != nil {
+		return err
+	}
+	return i.writeShim(version)
+}
+
+func (i MarkerInstaller) Installed(version string) bool {
+	_, err := os.Stat(i.markerPath(version))
+	return err == nil
+}
+
+func (i MarkerInstaller) ShimExists() bool {
+	paths, err := host.NewPathsFromRoot(i.root)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(filepath.Join(paths.BinDir(), "php"))
+	return err == nil
+}
+
+func (i MarkerInstaller) markerPath(version string) string {
+	paths, err := host.NewPathsFromRoot(i.root)
+	if err != nil {
+		return filepath.Join(i.root, "runtimes", "php", version, "installed")
+	}
+	dir, err := paths.PHPRuntimeDir(version)
+	if err != nil {
+		return filepath.Join(i.root, "runtimes", "php", version, "installed")
+	}
+	return filepath.Join(dir, "installed")
+}
+
+func (i MarkerInstaller) writeShim(version string) error {
+	paths, err := host.NewPathsFromRoot(i.root)
+	if err != nil {
+		return err
+	}
+	const shimTemplate = `#!/bin/sh
+# php %s
+exec "$(dirname "$0")/../runtimes/php/%s/php" "$@"
+`
+	return installer.WriteShimAtomic(filepath.Join(paths.BinDir(), "php"), []byte(fmt.Sprintf(shimTemplate, version, version)))
+}

--- a/internal/resources/php/controller.go
+++ b/internal/resources/php/controller.go
@@ -22,6 +22,10 @@ type Controller struct {
 	Clock     func() time.Time
 }
 
+func (c Controller) Resource() string {
+	return control.ResourcePHP
+}
+
 func (c Controller) Reconcile(ctx context.Context) error {
 	desired, ok, err := c.Store.Desired(ctx, control.ResourcePHP)
 	if err != nil {

--- a/internal/resources/php/controller_test.go
+++ b/internal/resources/php/controller_test.go
@@ -10,6 +10,14 @@ import (
 	"github.com/prvious/pv/internal/control"
 )
 
+var _ control.Controller = Controller{}
+
+func TestControllerResource(t *testing.T) {
+	if got := (Controller{}).Resource(); got != control.ResourcePHP {
+		t.Fatalf("Resource = %q, want %q", got, control.ResourcePHP)
+	}
+}
+
 func TestControllerReconcilesDesiredPHPRuntime(t *testing.T) {
 	ctx := t.Context()
 	store := control.NewFileStore(filepath.Join(t.TempDir(), "pv.db"))

--- a/internal/resources/php/controller_test.go
+++ b/internal/resources/php/controller_test.go
@@ -1,0 +1,113 @@
+package php
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+func TestControllerReconcilesDesiredPHPRuntime(t *testing.T) {
+	ctx := t.Context()
+	store := control.NewFileStore(filepath.Join(t.TempDir(), "pv.db"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource: control.ResourcePHP,
+		Version:  "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+
+	installer := NewMarkerInstaller(t.TempDir())
+	controller := Controller{
+		Store:     store,
+		Installer: installer,
+		Clock:     fixedClock("2026-05-15T19:00:00Z"),
+	}
+
+	if err := controller.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	if !installer.Installed("8.4") {
+		t.Fatal("PHP runtime marker was not installed")
+	}
+	if !installer.ShimExists() {
+		t.Fatal("PHP runtime shim was not exposed")
+	}
+	observed, ok, err := store.Observed(ctx, control.ResourcePHP)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Observed did not find PHP status")
+	}
+	want := control.ObservedStatus{
+		Resource:          control.ResourcePHP,
+		DesiredVersion:    "8.4",
+		State:             control.StateReady,
+		LastReconcileTime: "2026-05-15T19:00:00Z",
+	}
+	if observed != want {
+		t.Fatalf("Observed = %#v, want %#v", observed, want)
+	}
+}
+
+func TestControllerRecordsPHPRuntimeInstallFailure(t *testing.T) {
+	ctx := t.Context()
+	store := control.NewFileStore(filepath.Join(t.TempDir(), "pv.db"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource: control.ResourcePHP,
+		Version:  "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired returned error: %v", err)
+	}
+
+	installErr := errors.New("download unavailable")
+	controller := Controller{
+		Store:     store,
+		Installer: failingInstaller{err: installErr},
+		Clock:     fixedClock("2026-05-15T19:00:00Z"),
+	}
+
+	if err := controller.Reconcile(ctx); !errors.Is(err, installErr) {
+		t.Fatalf("Reconcile error = %v, want %v", err, installErr)
+	}
+
+	observed, ok, err := store.Observed(ctx, control.ResourcePHP)
+	if err != nil {
+		t.Fatalf("Observed returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("Observed did not find PHP status")
+	}
+	if observed.State != control.StateFailed {
+		t.Fatalf("State = %q, want failed", observed.State)
+	}
+	if observed.LastError != "download unavailable" {
+		t.Fatalf("LastError = %q, want download unavailable", observed.LastError)
+	}
+	if observed.NextAction == "" {
+		t.Fatal("NextAction is empty for failed PHP reconcile")
+	}
+}
+
+type failingInstaller struct {
+	err error
+}
+
+func (i failingInstaller) Install(context.Context, string) error {
+	return i.err
+}
+
+func fixedClock(value string) func() time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return func() time.Time {
+		return parsed
+	}
+}

--- a/internal/resources/postgres/resource.go
+++ b/internal/resources/postgres/resource.go
@@ -1,0 +1,42 @@
+package postgres
+
+import (
+	"context"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+type Database interface {
+	Create(context.Context, string) error
+	Drop(context.Context, string) error
+	List(context.Context) ([]string, error)
+}
+
+type Commands struct {
+	DB Database
+}
+
+func Env(version string) map[string]string {
+	return map[string]string{
+		"DB_CONNECTION": "pgsql",
+		"DB_HOST":       "127.0.0.1",
+		"DB_PORT":       "5432",
+		"PV_POSTGRES":   version,
+	}
+}
+
+func Desired(version string) control.DesiredResource {
+	return control.DesiredResource{Resource: control.ResourcePostgres, Version: version}
+}
+
+func (c Commands) Create(ctx context.Context, name string) error {
+	return c.DB.Create(ctx, name)
+}
+
+func (c Commands) Drop(ctx context.Context, name string) error {
+	return c.DB.Drop(ctx, name)
+}
+
+func (c Commands) List(ctx context.Context) ([]string, error) {
+	return c.DB.List(ctx)
+}

--- a/internal/resources/postgres/resource_test.go
+++ b/internal/resources/postgres/resource_test.go
@@ -1,0 +1,43 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+func TestPostgresResourceIsExplicit(t *testing.T) {
+	desired := Desired("18.0")
+	if desired.Resource != control.ResourcePostgres {
+		t.Fatalf("resource = %q", desired.Resource)
+	}
+	if Env("18.0")["DB_CONNECTION"] != "pgsql" {
+		t.Fatalf("env = %#v", Env("18.0"))
+	}
+	db := &fakeDB{}
+	commands := Commands{DB: db}
+	if err := commands.Create(t.Context(), "app"); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if db.created != "app" {
+		t.Fatalf("created = %q, want app", db.created)
+	}
+}
+
+type fakeDB struct {
+	created string
+}
+
+func (db *fakeDB) Create(_ context.Context, name string) error {
+	db.created = name
+	return nil
+}
+
+func (db *fakeDB) Drop(context.Context, string) error {
+	return nil
+}
+
+func (db *fakeDB) List(context.Context) ([]string, error) {
+	return nil, nil
+}

--- a/internal/resources/redis/resource.go
+++ b/internal/resources/redis/resource.go
@@ -1,0 +1,15 @@
+package redis
+
+import "github.com/prvious/pv/internal/control"
+
+func Desired(version string) control.DesiredResource {
+	return control.DesiredResource{Resource: control.ResourceRedis, Version: version}
+}
+
+func Env(version string) map[string]string {
+	return map[string]string{
+		"REDIS_HOST": "127.0.0.1",
+		"REDIS_PORT": "6379",
+		"PV_REDIS":   version,
+	}
+}

--- a/internal/resources/redis/resource_test.go
+++ b/internal/resources/redis/resource_test.go
@@ -1,0 +1,17 @@
+package redis
+
+import (
+	"testing"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+func TestRedisResourceIsRunnableCache(t *testing.T) {
+	desired := Desired("8.0")
+	if desired.Resource != control.ResourceRedis {
+		t.Fatalf("resource = %q", desired.Resource)
+	}
+	if Env("8.0")["REDIS_PORT"] != "6379" {
+		t.Fatalf("env = %#v", Env("8.0"))
+	}
+}

--- a/internal/resources/rustfs/resource.go
+++ b/internal/resources/rustfs/resource.go
@@ -1,0 +1,34 @@
+package rustfs
+
+import "github.com/prvious/pv/internal/control"
+
+type Credentials struct {
+	AccessKey string
+	SecretKey string
+}
+
+func Desired(version string) control.DesiredResource {
+	return control.DesiredResource{Resource: control.ResourceRustFS, Version: version}
+}
+
+func Env(version string, credentials Credentials) map[string]string {
+	return map[string]string{
+		"AWS_ACCESS_KEY_ID":     credentials.AccessKey,
+		"AWS_SECRET_ACCESS_KEY": credentials.SecretKey,
+		"AWS_ENDPOINT_URL":      "http://127.0.0.1:9000",
+		"PV_RUSTFS":             version,
+	}
+}
+
+func RedactedStatus(credentials Credentials) map[string]string {
+	status := map[string]string{
+		"AWS_ENDPOINT_URL": "http://127.0.0.1:9000",
+	}
+	if credentials.AccessKey != "" {
+		status["AWS_ACCESS_KEY_ID"] = "<redacted>"
+	}
+	if credentials.SecretKey != "" {
+		status["AWS_SECRET_ACCESS_KEY"] = "<redacted>"
+	}
+	return status
+}

--- a/internal/resources/rustfs/resource.go
+++ b/internal/resources/rustfs/resource.go
@@ -2,6 +2,8 @@ package rustfs
 
 import "github.com/prvious/pv/internal/control"
 
+const endpoint = "http://127.0.0.1:9000"
+
 type Credentials struct {
 	AccessKey string
 	SecretKey string
@@ -13,16 +15,18 @@ func Desired(version string) control.DesiredResource {
 
 func Env(version string, credentials Credentials) map[string]string {
 	return map[string]string{
-		"AWS_ACCESS_KEY_ID":     credentials.AccessKey,
-		"AWS_SECRET_ACCESS_KEY": credentials.SecretKey,
-		"AWS_ENDPOINT_URL":      "http://127.0.0.1:9000",
-		"PV_RUSTFS":             version,
+		"AWS_ACCESS_KEY_ID":           credentials.AccessKey,
+		"AWS_SECRET_ACCESS_KEY":       credentials.SecretKey,
+		"AWS_ENDPOINT":                endpoint,
+		"AWS_USE_PATH_STYLE_ENDPOINT": "true",
+		"PV_RUSTFS":                   version,
 	}
 }
 
 func RedactedStatus(credentials Credentials) map[string]string {
 	status := map[string]string{
-		"AWS_ENDPOINT_URL": "http://127.0.0.1:9000",
+		"AWS_ENDPOINT":                endpoint,
+		"AWS_USE_PATH_STYLE_ENDPOINT": "true",
 	}
 	if credentials.AccessKey != "" {
 		status["AWS_ACCESS_KEY_ID"] = "<redacted>"

--- a/internal/resources/rustfs/resource_test.go
+++ b/internal/resources/rustfs/resource_test.go
@@ -1,0 +1,23 @@
+package rustfs
+
+import (
+	"testing"
+
+	"github.com/prvious/pv/internal/control"
+)
+
+func TestRustFSRedactsCredentialsFromStatus(t *testing.T) {
+	desired := Desired("1.0.0")
+	if desired.Resource != control.ResourceRustFS {
+		t.Fatalf("resource = %q", desired.Resource)
+	}
+	credentials := Credentials{AccessKey: "local", SecretKey: "secret"}
+	env := Env("1.0.0", credentials)
+	if env["AWS_SECRET_ACCESS_KEY"] != "secret" {
+		t.Fatalf("env should retain secret for rendering: %#v", env)
+	}
+	status := RedactedStatus(credentials)
+	if status["AWS_ACCESS_KEY_ID"] != "<redacted>" || status["AWS_SECRET_ACCESS_KEY"] != "<redacted>" {
+		t.Fatalf("status did not redact credentials: %#v", status)
+	}
+}

--- a/internal/resources/rustfs/resource_test.go
+++ b/internal/resources/rustfs/resource_test.go
@@ -16,8 +16,28 @@ func TestRustFSRedactsCredentialsFromStatus(t *testing.T) {
 	if env["AWS_SECRET_ACCESS_KEY"] != "secret" {
 		t.Fatalf("env should retain secret for rendering: %#v", env)
 	}
+	if env["AWS_ENDPOINT"] != "http://127.0.0.1:9000" {
+		t.Fatalf("AWS_ENDPOINT = %q, want http://127.0.0.1:9000", env["AWS_ENDPOINT"])
+	}
+	if env["AWS_USE_PATH_STYLE_ENDPOINT"] != "true" {
+		t.Fatalf("AWS_USE_PATH_STYLE_ENDPOINT = %q, want true", env["AWS_USE_PATH_STYLE_ENDPOINT"])
+	}
+	for _, key := range []string{"AWS_ENDPOINT_URL", "AWS_URL"} {
+		if _, ok := env[key]; ok {
+			t.Fatalf("env should not include %s before bucket is known: %#v", key, env)
+		}
+	}
 	status := RedactedStatus(credentials)
 	if status["AWS_ACCESS_KEY_ID"] != "<redacted>" || status["AWS_SECRET_ACCESS_KEY"] != "<redacted>" {
 		t.Fatalf("status did not redact credentials: %#v", status)
+	}
+	if status["AWS_ENDPOINT"] != "http://127.0.0.1:9000" {
+		t.Fatalf("status AWS_ENDPOINT = %q, want http://127.0.0.1:9000", status["AWS_ENDPOINT"])
+	}
+	if status["AWS_USE_PATH_STYLE_ENDPOINT"] != "true" {
+		t.Fatalf("status AWS_USE_PATH_STYLE_ENDPOINT = %q, want true", status["AWS_USE_PATH_STYLE_ENDPOINT"])
+	}
+	if _, ok := status["AWS_ENDPOINT_URL"]; ok {
+		t.Fatalf("status should not include AWS_ENDPOINT_URL: %#v", status)
 	}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1,0 +1,63 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+)
+
+type ProcessDefinition struct {
+	Name    string
+	Version string
+	Command string
+	Args    []string
+	Env     map[string]string
+	LogPath string
+}
+
+type ProcessStatus struct {
+	Name    string
+	Running bool
+	PID     int
+	LogPath string
+	Error   string
+}
+
+type Host interface {
+	Start(context.Context, ProcessDefinition) (ProcessStatus, error)
+	Stop(context.Context, string) error
+	Check(context.Context, string) (ProcessStatus, error)
+}
+
+type Supervisor struct {
+	Host Host
+}
+
+func (s Supervisor) Start(ctx context.Context, definition ProcessDefinition) (ProcessStatus, error) {
+	if s.Host == nil {
+		return ProcessStatus{}, errors.New("supervisor host is required")
+	}
+	if definition.Name == "" {
+		return ProcessStatus{}, errors.New("process name is required")
+	}
+	return s.Host.Start(ctx, definition)
+}
+
+func (s Supervisor) Stop(ctx context.Context, name string) error {
+	if s.Host == nil {
+		return errors.New("supervisor host is required")
+	}
+	if name == "" {
+		return errors.New("process name is required")
+	}
+	return s.Host.Stop(ctx, name)
+}
+
+func (s Supervisor) Check(ctx context.Context, name string) (ProcessStatus, error) {
+	if s.Host == nil {
+		return ProcessStatus{}, errors.New("supervisor host is required")
+	}
+	if name == "" {
+		return ProcessStatus{}, errors.New("process name is required")
+	}
+	return s.Host.Check(ctx, name)
+}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,0 +1,46 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSupervisorDelegatesWithoutResourceKnowledge(t *testing.T) {
+	host := &fakeHost{}
+	supervisor := Supervisor{Host: host}
+	definition := ProcessDefinition{
+		Name:    "worker",
+		Version: "1.0.0",
+		Command: "/bin/worker",
+		LogPath: "/tmp/worker.log",
+	}
+
+	status, err := supervisor.Start(t.Context(), definition)
+
+	if err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+	if !status.Running || status.Name != "worker" {
+		t.Fatalf("status = %#v", status)
+	}
+	if host.started.Command != "/bin/worker" {
+		t.Fatalf("started definition = %#v", host.started)
+	}
+}
+
+type fakeHost struct {
+	started ProcessDefinition
+}
+
+func (h *fakeHost) Start(_ context.Context, definition ProcessDefinition) (ProcessStatus, error) {
+	h.started = definition
+	return ProcessStatus{Name: definition.Name, Running: true, PID: 42, LogPath: definition.LogPath}, nil
+}
+
+func (h *fakeHost) Stop(context.Context, string) error {
+	return nil
+}
+
+func (h *fakeHost) Check(_ context.Context, name string) (ProcessStatus, error) {
+	return ProcessStatus{Name: name, Running: true}, nil
+}


### PR DESCRIPTION
Stack position: Epic 3 of 5
Base branch: rewrite/epic-2-store-host-install
Targets main directly: no
Depends on: #207 / rewrite/epic-2-store-host-install
Verification: `gofmt -w . && go vet ./... && go build ./... && go test ./...`; `cd legacy/prototype && gofmt -w . && go vet ./... && go build ./... && go test ./...`

## Summary
- Adds PHP and Composer resource controllers, markers, and atomic shim handling.
- Adds daemon state tracking, a resource supervisor, Mailpit, database/cache/object-storage resource contracts, and redaction coverage.

## Linked Issues
Resolves #142, resolves #143, resolves #144, resolves #145, resolves #146, resolves #147, resolves #148, resolves #149, resolves #150, resolves #151, resolves #152, resolves #153, resolves #154, resolves #155, resolves #156, resolves #157, resolves #158, resolves #159, resolves #160, resolves #161, resolves #162, resolves #163, resolves #164, resolves #165.
