### PR TITLE
Rewrite Epic 4: Laravel Project Experience

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -5,9 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/prvious/pv/internal/control"
 	"github.com/prvious/pv/internal/host"
+	"github.com/prvious/pv/internal/project"
 )
 
 const Version = "dev"
@@ -21,15 +26,29 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) error {
 	}
 
 	switch args[0] {
+	case "artisan":
+		return runHelper(args[1:], stderr, project.Artisan)
 	case "composer:install":
 		return runComposerInstall(args[1:], stderr)
+	case "db":
+		return runCheckedHelper(args[1:], stderr, project.DB)
 	case "help", "--help", "-h":
 		writeHelp(stdout)
 		return nil
+	case "init":
+		return runInit(args[1:], stderr)
+	case "link":
+		return runLink(stderr)
 	case "mago:install":
 		return runSimpleInstall(args[1:], stderr, control.ResourceMago, "pv mago:install <version>")
+	case "mail":
+		return runCheckedHelper(args[1:], stderr, project.Mail)
+	case "open":
+		return runOpen(stderr)
 	case "php:install":
 		return runSimpleInstall(args[1:], stderr, control.ResourcePHP, "pv php:install <version>")
+	case "s3":
+		return runCheckedHelper(args[1:], stderr, project.S3)
 	case "status":
 		return runStatus(stderr)
 	case "version", "--version":
@@ -48,15 +67,83 @@ Usage:
   pv <command>
 
 Commands:
+  artisan <args...>
   composer:install <version> --php <version>
+  db <args...>
   help      Show this help.
+  init [--force]
+  link
   mago:install <version>
+  mail <args...>
+  open
   php:install <version>
+  s3 <args...>
   status    Show desired and observed control-plane status.
   version   Print the pv version.
 
 The active rewrite command surface is intentionally minimal. See docs/rewrite/02-architecture.md.
 `)
+}
+
+func runInit(args []string, stderr io.Writer) error {
+	force := len(args) == 1 && args[0] == "--force"
+	if len(args) > 0 && !force {
+		fmt.Fprintln(stderr, "usage: pv init [--force]")
+		return fmt.Errorf("%w: invalid init command", ErrUsage)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if !project.DetectLaravel(cwd) {
+		return errors.New("current directory is not a supported Laravel project")
+	}
+	contract := project.DefaultLaravelContract(filepath.Base(cwd))
+	if err := project.WriteContract(cwd, contract, force); err != nil {
+		return err
+	}
+	fmt.Fprintln(stderr, "created pv.yml")
+	return nil
+}
+
+func runLink(stderr io.Writer) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	contract, err := project.LoadContract(cwd)
+	if err != nil {
+		return err
+	}
+	paths, err := host.NewPaths()
+	if err != nil {
+		return err
+	}
+	registry := project.Registry{Path: filepath.Join(paths.Root(), "state", "project.json")}
+	if err := registry.Link(context.Background(), cwd, contract); err != nil {
+		return err
+	}
+	if err := (project.EnvWriter{Path: filepath.Join(cwd, ".env")}).Apply(envFor(contract)); err != nil {
+		return err
+	}
+	if err := project.RunSetup(context.Background(), cwd, filepath.Join(paths.BinDir()), contract.Setup, shellRunner{}); err != nil {
+		return err
+	}
+	fmt.Fprintln(stderr, "linked project")
+	return nil
+}
+
+func runOpen(stderr io.Writer) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	contract, err := project.LoadContract(cwd)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stderr, "open https://%s\n", contract.Hosts[0])
+	return nil
 }
 
 func runSimpleInstall(args []string, stderr io.Writer, resource string, usage string) error {
@@ -101,6 +188,36 @@ func runComposerInstall(args []string, stderr io.Writer) error {
 
 	fmt.Fprintf(stderr, "requested composer %s install with php %s\n", version, runtimeVersion)
 	return nil
+}
+
+func runHelper(args []string, stderr io.Writer, helper func(project.Contract, ...string) []string) error {
+	contract, err := loadCurrentContract()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stderr, "run %s\n", strings.Join(helper(contract, args...), " "))
+	return nil
+}
+
+func runCheckedHelper(args []string, stderr io.Writer, helper func(project.Contract, ...string) ([]string, error)) error {
+	contract, err := loadCurrentContract()
+	if err != nil {
+		return err
+	}
+	command, err := helper(contract, args...)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(stderr, "run %s\n", strings.Join(command, " "))
+	return nil
+}
+
+func loadCurrentContract() (project.Contract, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return project.Contract{}, err
+	}
+	return project.LoadContract(cwd)
 }
 
 func runStatus(stderr io.Writer) error {
@@ -181,4 +298,44 @@ func defaultStore() (*control.FileStore, error) {
 		return nil, err
 	}
 	return control.NewFileStore(paths.StateDBPath()), nil
+}
+
+func envFor(contract project.Contract) map[string]string {
+	values := map[string]string{
+		"PV_PHP": contract.PHP,
+	}
+	for _, service := range contract.Services {
+		switch service {
+		case "mailpit":
+			values["MAIL_MAILER"] = "smtp"
+			values["MAIL_HOST"] = "127.0.0.1"
+			values["MAIL_PORT"] = "1025"
+		case "postgres":
+			values["DB_CONNECTION"] = "pgsql"
+			values["DB_HOST"] = "127.0.0.1"
+			values["DB_PORT"] = "5432"
+		case "mysql":
+			values["DB_CONNECTION"] = "mysql"
+			values["DB_HOST"] = "127.0.0.1"
+			values["DB_PORT"] = "3306"
+		case "redis":
+			values["REDIS_HOST"] = "127.0.0.1"
+			values["REDIS_PORT"] = "6379"
+		case "rustfs":
+			values["AWS_ENDPOINT_URL"] = "http://127.0.0.1:9000"
+		}
+	}
+	return values
+}
+
+type shellRunner struct{}
+
+func (shellRunner) Run(ctx context.Context, dir string, command string, env map[string]string) error {
+	cmd := exec.CommandContext(ctx, "sh", "-lc", command)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	for key, value := range env {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	return cmd.Run()
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -62,7 +63,7 @@ func TestRunUnknownCommandReturnsUsageError(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	err := Run([]string{"link"}, &stdout, &stderr)
+	err := Run([]string{"serve"}, &stdout, &stderr)
 
 	if !errors.Is(err, ErrUsage) {
 		t.Fatalf("Run unknown command error = %v, want ErrUsage", err)
@@ -70,8 +71,46 @@ func TestRunUnknownCommandReturnsUsageError(t *testing.T) {
 	if stdout.Len() != 0 {
 		t.Fatalf("Run unknown command wrote stdout: %q", stdout.String())
 	}
-	if got := stderr.String(); !strings.Contains(got, `unknown command "link"`) {
+	if got := stderr.String(); !strings.Contains(got, `unknown command "serve"`) {
 		t.Fatalf("stderr = %q, want unknown command message", got)
+	}
+}
+
+func TestRunInitCreatesLaravelContract(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	if err := os.WriteFile(filepath.Join(dir, "artisan"), []byte(""), 0o644); err != nil {
+		t.Fatalf("WriteFile artisan returned error: %v", err)
+	}
+	original, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd returned error: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(original); err != nil {
+			t.Fatalf("restore Chdir returned error: %v", err)
+		}
+	})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err = Run([]string{"init"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run init returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run init wrote stdout: %q", stdout.String())
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "pv.yml"))
+	if err != nil {
+		t.Fatalf("ReadFile pv.yml returned error: %v", err)
+	}
+	if !strings.Contains(string(data), "version: 1") {
+		t.Fatalf("pv.yml missing version:\n%s", data)
 	}
 }
 

--- a/internal/project/contract.go
+++ b/internal/project/contract.go
@@ -20,10 +20,7 @@ type Contract struct {
 }
 
 func DefaultLaravelContract(projectName string) Contract {
-	host := strings.ToLower(strings.TrimSpace(projectName))
-	if host == "" {
-		host = "app"
-	}
+	host := defaultHostLabel(projectName)
 	return Contract{
 		Version:  ContractVersion,
 		PHP:      "8.4",
@@ -31,6 +28,30 @@ func DefaultLaravelContract(projectName string) Contract {
 		Services: []string{"mailpit"},
 		Setup:    []string{"composer install", "php artisan key:generate --ansi"},
 	}
+}
+
+func defaultHostLabel(projectName string) string {
+	var b strings.Builder
+	previousHyphen := false
+	for _, r := range strings.ToLower(strings.TrimSpace(projectName)) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			previousHyphen = false
+			continue
+		}
+		if b.Len() > 0 && !previousHyphen {
+			b.WriteByte('-')
+			previousHyphen = true
+		}
+	}
+	label := strings.Trim(b.String(), "-")
+	if len(label) > 63 {
+		label = strings.TrimRight(label[:63], "-")
+	}
+	if label == "" {
+		return "app"
+	}
+	return label
 }
 
 func DetectLaravel(dir string) bool {

--- a/internal/project/contract.go
+++ b/internal/project/contract.go
@@ -1,0 +1,150 @@
+package project
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const ContractVersion = 1
+
+type Contract struct {
+	Version  int
+	PHP      string
+	Hosts    []string
+	Services []string
+	Setup    []string
+}
+
+func DefaultLaravelContract(projectName string) Contract {
+	host := strings.ToLower(strings.TrimSpace(projectName))
+	if host == "" {
+		host = "app"
+	}
+	return Contract{
+		Version:  ContractVersion,
+		PHP:      "8.4",
+		Hosts:    []string{host + ".test"},
+		Services: []string{"mailpit"},
+		Setup:    []string{"composer install", "php artisan key:generate --ansi"},
+	}
+}
+
+func DetectLaravel(dir string) bool {
+	if _, err := os.Stat(filepath.Join(dir, "artisan")); err == nil {
+		return true
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "composer.json"))
+	return err == nil && strings.Contains(string(data), "laravel/framework")
+}
+
+func WriteContract(dir string, contract Contract, force bool) error {
+	if err := contract.Validate(); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "pv.yml")
+	if !force {
+		if _, err := os.Stat(path); err == nil {
+			return fmt.Errorf("pv.yml already exists: use --force to overwrite")
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return os.WriteFile(path, []byte(contract.String()), 0o644)
+}
+
+func LoadContract(dir string) (Contract, error) {
+	data, err := os.ReadFile(filepath.Join(dir, "pv.yml"))
+	if err != nil {
+		return Contract{}, err
+	}
+	return ParseContract(string(data))
+}
+
+func ParseContract(data string) (Contract, error) {
+	var contract Contract
+	var section string
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasSuffix(line, ":") {
+			section = strings.TrimSuffix(line, ":")
+			continue
+		}
+		if strings.HasPrefix(line, "- ") {
+			value := strings.TrimSpace(strings.TrimPrefix(line, "- "))
+			switch section {
+			case "hosts":
+				contract.Hosts = append(contract.Hosts, value)
+			case "services":
+				contract.Services = append(contract.Services, value)
+			case "setup":
+				contract.Setup = append(contract.Setup, value)
+			default:
+				return Contract{}, fmt.Errorf("list item outside supported section %q", section)
+			}
+			continue
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return Contract{}, fmt.Errorf("invalid contract line %q", line)
+		}
+		section = ""
+		switch strings.TrimSpace(key) {
+		case "version":
+			if strings.TrimSpace(value) != "1" {
+				return Contract{}, fmt.Errorf("unsupported pv.yml version %q", strings.TrimSpace(value))
+			}
+			contract.Version = ContractVersion
+		case "php":
+			contract.PHP = strings.TrimSpace(value)
+		default:
+			return Contract{}, fmt.Errorf("unsupported pv.yml field %q", strings.TrimSpace(key))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return Contract{}, err
+	}
+	return contract, contract.Validate()
+}
+
+func (c Contract) Validate() error {
+	if c.Version != ContractVersion {
+		return fmt.Errorf("pv.yml version must be %d", ContractVersion)
+	}
+	if c.PHP == "" {
+		return errors.New("php version is required")
+	}
+	if len(c.Hosts) == 0 {
+		return errors.New("at least one host is required")
+	}
+	for _, command := range c.Setup {
+		if strings.TrimSpace(command) == "" {
+			return errors.New("setup commands must not be empty")
+		}
+	}
+	return nil
+}
+
+func (c Contract) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "version: %d\n", c.Version)
+	fmt.Fprintf(&b, "php: %s\n", c.PHP)
+	writeList(&b, "hosts", c.Hosts)
+	writeList(&b, "services", c.Services)
+	writeList(&b, "setup", c.Setup)
+	return b.String()
+}
+
+func writeList(b *strings.Builder, name string, values []string) {
+	fmt.Fprintf(b, "%s:\n", name)
+	for _, value := range values {
+		fmt.Fprintf(b, "  - %s\n", value)
+	}
+}

--- a/internal/project/contract_test.go
+++ b/internal/project/contract_test.go
@@ -34,6 +34,25 @@ func TestWriteAndParseLaravelContract(t *testing.T) {
 	}
 }
 
+func TestDefaultLaravelContractSanitizesHostLabel(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "My App", want: "my-app.test"},
+		{name: "api_v2", want: "api-v2.test"},
+		{name: "!!!", want: "app.test"},
+		{name: strings.Repeat("a", 64), want: strings.Repeat("a", 63) + ".test"},
+	}
+
+	for _, tt := range tests {
+		contract := DefaultLaravelContract(tt.name)
+		if got := contract.Hosts[0]; got != tt.want {
+			t.Fatalf("DefaultLaravelContract(%q) host = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestParseContractRejectsUnsupportedFields(t *testing.T) {
 	_, err := ParseContract("version: 1\nphp: 8.4\ninfer_from_env: true\nhosts:\n  - app.test\n")
 	if err == nil {

--- a/internal/project/contract_test.go
+++ b/internal/project/contract_test.go
@@ -1,0 +1,45 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteAndParseLaravelContract(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "artisan"), []byte(""), 0o644); err != nil {
+		t.Fatalf("WriteFile artisan returned error: %v", err)
+	}
+	if !DetectLaravel(dir) {
+		t.Fatal("DetectLaravel returned false")
+	}
+	contract := DefaultLaravelContract("Example")
+	if err := WriteContract(dir, contract, false); err != nil {
+		t.Fatalf("WriteContract returned error: %v", err)
+	}
+	if err := WriteContract(dir, contract, false); err == nil {
+		t.Fatal("WriteContract overwrote existing contract without force")
+	}
+	loaded, err := LoadContract(dir)
+	if err != nil {
+		t.Fatalf("LoadContract returned error: %v", err)
+	}
+	if loaded.Version != ContractVersion || loaded.PHP != "8.4" {
+		t.Fatalf("loaded contract = %#v", loaded)
+	}
+	if loaded.Hosts[0] != "example.test" {
+		t.Fatalf("host = %q, want example.test", loaded.Hosts[0])
+	}
+}
+
+func TestParseContractRejectsUnsupportedFields(t *testing.T) {
+	_, err := ParseContract("version: 1\nphp: 8.4\ninfer_from_env: true\nhosts:\n  - app.test\n")
+	if err == nil {
+		t.Fatal("ParseContract returned nil error")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Fatalf("error = %v, want unsupported field", err)
+	}
+}

--- a/internal/project/gateway.go
+++ b/internal/project/gateway.go
@@ -1,0 +1,25 @@
+package project
+
+import "context"
+
+type Route struct {
+	ProjectPath string
+	Hosts       []string
+	TLS         bool
+}
+
+type GatewayAdapter interface {
+	ApplyRoute(context.Context, Route) error
+}
+
+type Browser interface {
+	Open(context.Context, string) error
+}
+
+func LinkGateway(ctx context.Context, adapter GatewayAdapter, route Route) error {
+	return adapter.ApplyRoute(ctx, route)
+}
+
+func Open(ctx context.Context, browser Browser, contract Contract) error {
+	return browser.Open(ctx, "https://"+contract.Hosts[0])
+}

--- a/internal/project/gateway_test.go
+++ b/internal/project/gateway_test.go
@@ -1,0 +1,42 @@
+package project
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGatewayAndOpenUseAdapters(t *testing.T) {
+	adapter := &routeAdapter{}
+	route := Route{ProjectPath: "/app", Hosts: []string{"app.test"}, TLS: true}
+	if err := LinkGateway(t.Context(), adapter, route); err != nil {
+		t.Fatalf("LinkGateway returned error: %v", err)
+	}
+	if adapter.route.Hosts[0] != "app.test" {
+		t.Fatalf("route = %#v", adapter.route)
+	}
+	browser := &fakeBrowser{}
+	if err := Open(t.Context(), browser, Contract{Version: 1, PHP: "8.4", Hosts: []string{"app.test"}}); err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if browser.url != "https://app.test" {
+		t.Fatalf("url = %q, want https://app.test", browser.url)
+	}
+}
+
+type routeAdapter struct {
+	route Route
+}
+
+func (a *routeAdapter) ApplyRoute(_ context.Context, route Route) error {
+	a.route = route
+	return nil
+}
+
+type fakeBrowser struct {
+	url string
+}
+
+func (b *fakeBrowser) Open(_ context.Context, url string) error {
+	b.url = url
+	return nil
+}

--- a/internal/project/helpers.go
+++ b/internal/project/helpers.go
@@ -1,0 +1,37 @@
+package project
+
+import "fmt"
+
+func Artisan(contract Contract, args ...string) []string {
+	return append([]string{"php", "artisan"}, args...)
+}
+
+func DB(contract Contract, args ...string) ([]string, error) {
+	if !hasService(contract, "postgres") && !hasService(contract, "mysql") {
+		return nil, fmt.Errorf("project does not declare a database resource")
+	}
+	return append([]string{"db"}, args...), nil
+}
+
+func Mail(contract Contract, args ...string) ([]string, error) {
+	if !hasService(contract, "mailpit") {
+		return nil, fmt.Errorf("project does not declare mailpit")
+	}
+	return append([]string{"mail"}, args...), nil
+}
+
+func S3(contract Contract, args ...string) ([]string, error) {
+	if !hasService(contract, "rustfs") {
+		return nil, fmt.Errorf("project does not declare rustfs")
+	}
+	return append([]string{"s3"}, args...), nil
+}
+
+func hasService(contract Contract, service string) bool {
+	for _, candidate := range contract.Services {
+		if candidate == service {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/project/helpers_test.go
+++ b/internal/project/helpers_test.go
@@ -1,0 +1,22 @@
+package project
+
+import "testing"
+
+func TestHelpersRequireDeclaredResources(t *testing.T) {
+	contract := Contract{Version: 1, PHP: "8.4", Hosts: []string{"app.test"}, Services: []string{"postgres", "mailpit", "rustfs"}}
+	if got := Artisan(contract, "about"); got[0] != "php" || got[1] != "artisan" {
+		t.Fatalf("artisan = %#v", got)
+	}
+	if _, err := DB(contract, "list"); err != nil {
+		t.Fatalf("DB returned error: %v", err)
+	}
+	if _, err := Mail(contract, "open"); err != nil {
+		t.Fatalf("Mail returned error: %v", err)
+	}
+	if _, err := S3(contract, "buckets"); err != nil {
+		t.Fatalf("S3 returned error: %v", err)
+	}
+	if _, err := DB(Contract{Version: 1, PHP: "8.4", Hosts: []string{"app.test"}}, "list"); err == nil {
+		t.Fatal("DB returned nil error for missing database")
+	}
+}

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -85,15 +85,24 @@ type Runner interface {
 }
 
 func RunSetup(ctx context.Context, projectPath string, phpBin string, commands []string, runner Runner) error {
+	env := map[string]string{"PATH": setupPath(phpBin)}
 	for _, command := range commands {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := runner.Run(ctx, projectPath, command, map[string]string{"PATH": phpBin}); err != nil {
+		if err := runner.Run(ctx, projectPath, command, env); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func setupPath(binDir string) string {
+	systemPath := os.Getenv("PATH")
+	if systemPath == "" {
+		return binDir
+	}
+	return binDir + string(os.PathListSeparator) + systemPath
 }
 
 func removeManagedBlock(data string) string {

--- a/internal/project/link.go
+++ b/internal/project/link.go
@@ -1,0 +1,107 @@
+package project
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type State struct {
+	Path     string   `json:"path"`
+	PHP      string   `json:"php"`
+	Hosts    []string `json:"hosts"`
+	Services []string `json:"services"`
+}
+
+type Registry struct {
+	Path string
+}
+
+func (r Registry) Link(ctx context.Context, projectPath string, contract Contract) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := contract.Validate(); err != nil {
+		return err
+	}
+	state := State{
+		Path:     projectPath,
+		PHP:      contract.PHP,
+		Hosts:    append([]string(nil), contract.Hosts...),
+		Services: append([]string(nil), contract.Services...),
+	}
+	if err := os.MkdirAll(filepath.Dir(r.Path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(r.Path, data, 0o600)
+}
+
+type EnvWriter struct {
+	Path string
+}
+
+func (w EnvWriter) Apply(values map[string]string) error {
+	var existing string
+	data, err := os.ReadFile(w.Path)
+	if err == nil {
+		existing = string(data)
+		if err := os.WriteFile(w.Path+".bak", data, 0o600); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	clean := removeManagedBlock(existing)
+	var b strings.Builder
+	b.WriteString(strings.TrimRight(clean, "\n"))
+	if b.Len() > 0 {
+		b.WriteString("\n")
+	}
+	b.WriteString("# pv managed begin\n")
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := values[key]
+		fmt.Fprintf(&b, "%s=%s\n", key, value)
+	}
+	b.WriteString("# pv managed end\n")
+	return os.WriteFile(w.Path, []byte(b.String()), 0o600)
+}
+
+type Runner interface {
+	Run(context.Context, string, string, map[string]string) error
+}
+
+func RunSetup(ctx context.Context, projectPath string, phpBin string, commands []string, runner Runner) error {
+	for _, command := range commands {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := runner.Run(ctx, projectPath, command, map[string]string{"PATH": phpBin}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeManagedBlock(data string) string {
+	start := strings.Index(data, "# pv managed begin")
+	end := strings.Index(data, "# pv managed end")
+	if start == -1 || end == -1 || end < start {
+		return data
+	}
+	end += len("# pv managed end")
+	return data[:start] + data[end:]
+}

--- a/internal/project/link_test.go
+++ b/internal/project/link_test.go
@@ -1,0 +1,61 @@
+package project
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRegistryEnvWriterAndSetupAreExplicit(t *testing.T) {
+	ctx := t.Context()
+	root := t.TempDir()
+	contract := Contract{
+		Version:  ContractVersion,
+		PHP:      "8.4",
+		Hosts:    []string{"app.test"},
+		Services: []string{"mailpit"},
+		Setup:    []string{"composer install", "php artisan migrate"},
+	}
+	registry := Registry{Path: filepath.Join(root, "state", "project.json")}
+	if err := registry.Link(ctx, root, contract); err != nil {
+		t.Fatalf("Link returned error: %v", err)
+	}
+
+	envPath := filepath.Join(root, ".env")
+	if err := os.WriteFile(envPath, []byte("APP_NAME=Demo\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile .env returned error: %v", err)
+	}
+	writer := EnvWriter{Path: envPath}
+	if err := writer.Apply(map[string]string{"MAIL_MAILER": "smtp"}); err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	env, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatalf("ReadFile .env returned error: %v", err)
+	}
+	if !strings.Contains(string(env), "APP_NAME=Demo") || !strings.Contains(string(env), "# pv managed begin") {
+		t.Fatalf("env was not preserved with managed block:\n%s", env)
+	}
+	if _, err := os.Stat(envPath + ".bak"); err != nil {
+		t.Fatalf("backup missing: %v", err)
+	}
+
+	runner := &recordingRunner{}
+	if err := RunSetup(ctx, root, "/tmp/php/bin", contract.Setup, runner); err != nil {
+		t.Fatalf("RunSetup returned error: %v", err)
+	}
+	if len(runner.commands) != 2 || runner.commands[0] != "composer install" {
+		t.Fatalf("commands = %#v", runner.commands)
+	}
+}
+
+type recordingRunner struct {
+	commands []string
+}
+
+func (r *recordingRunner) Run(_ context.Context, _ string, command string, _ map[string]string) error {
+	r.commands = append(r.commands, command)
+	return nil
+}

--- a/internal/project/link_test.go
+++ b/internal/project/link_test.go
@@ -51,11 +51,32 @@ func TestRegistryEnvWriterAndSetupAreExplicit(t *testing.T) {
 	}
 }
 
-type recordingRunner struct {
-	commands []string
+func TestRunSetupPrependsManagedBinToSystemPath(t *testing.T) {
+	systemPath := strings.Join([]string{"/usr/bin", "/bin"}, string(os.PathListSeparator))
+	t.Setenv("PATH", systemPath)
+	ctx := t.Context()
+	runner := &recordingRunner{}
+
+	if err := RunSetup(ctx, t.TempDir(), "/tmp/pv/bin", []string{"cp .env.example .env"}, runner); err != nil {
+		t.Fatalf("RunSetup returned error: %v", err)
+	}
+
+	if len(runner.envs) != 1 {
+		t.Fatalf("envs = %#v", runner.envs)
+	}
+	want := strings.Join([]string{"/tmp/pv/bin", systemPath}, string(os.PathListSeparator))
+	if got := runner.envs[0]["PATH"]; got != want {
+		t.Fatalf("PATH = %q, want %q", got, want)
+	}
 }
 
-func (r *recordingRunner) Run(_ context.Context, _ string, command string, _ map[string]string) error {
+type recordingRunner struct {
+	commands []string
+	envs     []map[string]string
+}
+
+func (r *recordingRunner) Run(_ context.Context, _ string, command string, env map[string]string) error {
 	r.commands = append(r.commands, command)
+	r.envs = append(r.envs, env)
 	return nil
 }


### PR DESCRIPTION
Stack position: Epic 4 of 5
Base branch: rewrite/epic-3-runtime-daemon-resources
Targets main directly: no
Depends on: #208 / rewrite/epic-3-runtime-daemon-resources
Verification: `gofmt -w . && go vet ./... && go build ./... && go test ./...`; `cd legacy/prototype && gofmt -w . && go vet ./... && go build ./... && go test ./...`

## Summary
- Adds project contracts, Laravel detection, registry linking, managed `.env` updates, setup execution, and gateway opening.
- Adds project-aware CLI commands for init, link, open, artisan, db, mail, and s3 without hidden `.env` service inference.

## Linked Issues
Resolves #166, resolves #167, resolves #168, resolves #169, resolves #170, resolves #171, resolves #172, resolves #173, resolves #174, resolves #175, resolves #176, resolves #177, resolves #178, resolves #179, resolves #180, resolves #181, resolves #182, resolves #183, resolves #184, resolves #185, resolves #186, resolves #187, resolves #188, resolves #189, resolves #190, resolves #191, resolves #192.
