### PR TITLE
Rewrite Epic 5: Status, Quality, And Scope Control

### DIFF
--- a/docs/gh/plan/pv-rewrite/final-qa-evidence.md
+++ b/docs/gh/plan/pv-rewrite/final-qa-evidence.md
@@ -1,0 +1,13 @@
+# Final QA Evidence
+
+This file records the MVP review evidence shape for the stacked rewrite PRs.
+It is intentionally short so each epic PR can keep its own command evidence in
+the PR body.
+
+| Gate | Evidence |
+| --- | --- |
+| Stack shape | `docs/gh/plan/pv-rewrite/stacked-diff-plan.md` names the five branch levels and base branches. |
+| Scope guardrail | `docs/gh/plan/pv-rewrite/mvp-scope-checklist.md` and `post-mvp-backlog.md` define MVP boundaries and deferred capabilities. |
+| Status quality | `internal/status` covers normalized states, targeted views, log/error/next-action fields, and redaction. |
+| Root verification | Each epic PR body must list the exact root verification commands run. |
+| CI | Each epic PR must show a successful `E2E Tests / e2e` check before handoff. |

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -20,6 +20,17 @@ const Version = "dev"
 
 var ErrUsage = errors.New("usage error")
 
+var statusResources = [...]string{
+	control.ResourcePHP,
+	control.ResourceComposer,
+	control.ResourceMago,
+	control.ResourceMailpit,
+	control.ResourceMySQL,
+	control.ResourcePostgres,
+	control.ResourceRedis,
+	control.ResourceRustFS,
+}
+
 func Run(args []string, stdout io.Writer, stderr io.Writer) error {
 	if len(args) == 0 {
 		writeHelp(stdout)
@@ -237,7 +248,7 @@ func runStatus(args []string, stderr io.Writer) error {
 
 	ctx := context.Background()
 	anyDesired := false
-	for _, resource := range [...]string{control.ResourcePHP, control.ResourceComposer, control.ResourceMago} {
+	for _, resource := range statusResources {
 		desired, desiredOK, err := store.Desired(ctx, resource)
 		if err != nil {
 			return err
@@ -267,12 +278,95 @@ func runStatus(args []string, stderr io.Writer) error {
 }
 
 func runTargetedStatus(view status.View, stderr io.Writer) error {
-	rendered, err := status.Render(nil, view)
+	if err := status.ValidateView(view); err != nil {
+		return err
+	}
+	store, err := defaultStore()
+	if err != nil {
+		return err
+	}
+	entries, err := collectStatusEntries(context.Background(), store)
+	if err != nil {
+		return err
+	}
+	rendered, err := status.Render(entries, view)
 	if err != nil {
 		return err
 	}
 	fmt.Fprint(stderr, rendered)
 	return nil
+}
+
+func collectStatusEntries(ctx context.Context, store control.Store) ([]status.Entry, error) {
+	entries := make([]status.Entry, 0, len(statusResources))
+	for _, resource := range statusResources {
+		desired, desiredOK, err := store.Desired(ctx, resource)
+		if err != nil {
+			return nil, err
+		}
+		observed, observedOK, err := store.Observed(ctx, resource)
+		if err != nil {
+			return nil, err
+		}
+		if !desiredOK && !observedOK {
+			continue
+		}
+		entries = append(entries, statusEntry(resource, desired, desiredOK, observed, observedOK))
+	}
+	return entries, nil
+}
+
+func statusEntry(resource string, desired control.DesiredResource, desiredOK bool, observed control.ObservedStatus, observedOK bool) status.Entry {
+	entry := status.Entry{
+		View:  statusView(resource),
+		Name:  resource,
+		State: statusState(observed, observedOK),
+	}
+	if desiredOK {
+		entry.Desired = desiredSummary(desired)
+	}
+	if !observedOK {
+		entry.Observed = fmt.Sprintf("%s pending", resource)
+		entry.NextAction = "run reconciliation"
+		return entry
+	}
+
+	entry.Observed = observedSummary(observed)
+	entry.LastError = observed.LastError
+	entry.NextAction = observed.NextAction
+	if observed.LastReconcileTime != "" {
+		entry.Values = map[string]string{
+			"last_reconcile_time": observed.LastReconcileTime,
+		}
+	}
+	return entry
+}
+
+func statusView(resource string) status.View {
+	if resource == control.ResourcePHP {
+		return status.ViewRuntime
+	}
+	return status.ViewResource
+}
+
+func statusState(observed control.ObservedStatus, ok bool) status.State {
+	if !ok {
+		return status.StateUnknown
+	}
+	switch observed.State {
+	case control.StateReady:
+		return status.StateHealthy
+	case control.StateStopped:
+		return status.StateStopped
+	case control.StateMissing:
+		return status.StateMissingInstall
+	case control.StateBlocked:
+		return status.StateBlocked
+	case control.StateFailed:
+		return status.StateFailed
+	default:
+		return status.StateUnknown
+	}
 }
 
 func validateVersionArg(stderr io.Writer, version string) error {
@@ -292,15 +386,18 @@ func putDesired(desired control.DesiredResource) error {
 }
 
 func printDesired(w io.Writer, desired control.DesiredResource) {
+	fmt.Fprintf(w, "desired: %s\n", desiredSummary(desired))
+}
+
+func desiredSummary(desired control.DesiredResource) string {
 	if desired.RuntimeVersion != "" {
-		fmt.Fprintf(w, "desired: %s %s install with php %s\n", desired.Resource, desired.Version, desired.RuntimeVersion)
-		return
+		return fmt.Sprintf("%s %s install with php %s", desired.Resource, desired.Version, desired.RuntimeVersion)
 	}
-	fmt.Fprintf(w, "desired: %s %s install\n", desired.Resource, desired.Version)
+	return fmt.Sprintf("%s %s install", desired.Resource, desired.Version)
 }
 
 func printObserved(w io.Writer, observed control.ObservedStatus) {
-	fmt.Fprintf(w, "observed: %s %s %s\n", observed.Resource, observed.DesiredVersion, observed.State)
+	fmt.Fprintf(w, "observed: %s\n", observedSummary(observed))
 	fmt.Fprintf(w, "last reconcile: %s\n", observed.LastReconcileTime)
 	if observed.LastError != "" {
 		fmt.Fprintf(w, "last error: %s\n", observed.LastError)
@@ -308,6 +405,13 @@ func printObserved(w io.Writer, observed control.ObservedStatus) {
 	if observed.NextAction != "" {
 		fmt.Fprintf(w, "next action: %s\n", observed.NextAction)
 	}
+}
+
+func observedSummary(observed control.ObservedStatus) string {
+	if observed.DesiredVersion == "" {
+		return fmt.Sprintf("%s %s", observed.Resource, observed.State)
+	}
+	return fmt.Sprintf("%s %s %s", observed.Resource, observed.DesiredVersion, observed.State)
 }
 
 func defaultStore() (*control.FileStore, error) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prvious/pv/internal/control"
 	"github.com/prvious/pv/internal/host"
 	"github.com/prvious/pv/internal/project"
+	"github.com/prvious/pv/internal/status"
 )
 
 const Version = "dev"
@@ -50,7 +51,7 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) error {
 	case "s3":
 		return runCheckedHelper(args[1:], stderr, project.S3)
 	case "status":
-		return runStatus(stderr)
+		return runStatus(args[1:], stderr)
 	case "version", "--version":
 		fmt.Fprintf(stdout, "pv %s\n", Version)
 		return nil
@@ -220,7 +221,15 @@ func loadCurrentContract() (project.Contract, error) {
 	return project.LoadContract(cwd)
 }
 
-func runStatus(stderr io.Writer) error {
+func runStatus(args []string, stderr io.Writer) error {
+	if len(args) > 1 {
+		fmt.Fprintln(stderr, "usage: pv status [project|runtime|resource|gateway]")
+		return fmt.Errorf("%w: invalid status command", ErrUsage)
+	}
+	if len(args) == 1 {
+		return runTargetedStatus(status.View(args[0]), stderr)
+	}
+
 	store, err := defaultStore()
 	if err != nil {
 		return err
@@ -254,6 +263,15 @@ func runStatus(stderr io.Writer) error {
 	if !anyDesired {
 		fmt.Fprintln(stderr, "desired: none")
 	}
+	return nil
+}
+
+func runTargetedStatus(view status.View, stderr io.Writer) error {
+	rendered, err := status.Render(nil, view)
+	if err != nil {
+		return err
+	}
+	fmt.Fprint(stderr, rendered)
 	return nil
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -366,6 +366,23 @@ func TestRunStatusReportsPHPAndComposer(t *testing.T) {
 	}
 }
 
+func TestRunStatusSupportsTargetedViews(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"status", "resource"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run targeted status returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run targeted status wrote stdout: %q", stdout.String())
+	}
+	if got := stderr.String(); got != "status: none\n" {
+		t.Fatalf("targeted status = %q, want status none", got)
+	}
+}
+
 func fixedClock(value string) func() time.Time {
 	parsed, err := time.Parse(time.RFC3339, value)
 	if err != nil {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -367,6 +367,8 @@ func TestRunStatusReportsPHPAndComposer(t *testing.T) {
 }
 
 func TestRunStatusSupportsTargetedViews(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
@@ -380,6 +382,57 @@ func TestRunStatusSupportsTargetedViews(t *testing.T) {
 	}
 	if got := stderr.String(); got != "status: none\n" {
 		t.Fatalf("targeted status = %q, want status none", got)
+	}
+}
+
+func TestRunStatusResourceViewLoadsStoreEntries(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	ctx := t.Context()
+	store := control.NewFileStore(filepath.Join(home, ".pv", "state", "pv.db"))
+	if err := store.PutDesired(ctx, control.DesiredResource{
+		Resource:       control.ResourceComposer,
+		Version:        "2.8.0",
+		RuntimeVersion: "8.4",
+	}); err != nil {
+		t.Fatalf("PutDesired Composer returned error: %v", err)
+	}
+	if err := store.PutObserved(ctx, control.ObservedStatus{
+		Resource:          control.ResourceComposer,
+		DesiredVersion:    "2.8.0",
+		RuntimeVersion:    "8.4",
+		State:             control.StateBlocked,
+		LastReconcileTime: "2026-05-15T19:10:00Z",
+		LastError:         "PHP runtime 8.4 is not installed",
+		NextAction:        "run pv php:install 8.4",
+	}); err != nil {
+		t.Fatalf("PutObserved Composer returned error: %v", err)
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"status", "resource"}, &stdout, &stderr)
+
+	if err != nil {
+		t.Fatalf("Run targeted status returned error: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("Run targeted status wrote stdout: %q", stdout.String())
+	}
+	output := stderr.String()
+	for _, want := range []string{
+		"resource composer: blocked",
+		"desired: composer 2.8.0 install with php 8.4",
+		"observed: composer 2.8.0 blocked",
+		"last error: PHP runtime 8.4 is not installed",
+		"next action: run pv php:install 8.4",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("targeted status output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "status: none") {
+		t.Fatalf("targeted status ignored store entries:\n%s", output)
 	}
 }
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -1,0 +1,131 @@
+package status
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type State string
+
+const (
+	StateHealthy        State = "healthy"
+	StateStopped        State = "stopped"
+	StateMissingInstall State = "missing_install"
+	StateBlocked        State = "blocked"
+	StateCrashed        State = "crashed"
+	StateFailed         State = "failed"
+	StatePartial        State = "partial"
+	StateUnknown        State = "unknown"
+)
+
+type View string
+
+const (
+	ViewProject  View = "project"
+	ViewRuntime  View = "runtime"
+	ViewResource View = "resource"
+	ViewGateway  View = "gateway"
+)
+
+type Entry struct {
+	View       View
+	Name       string
+	Desired    string
+	Observed   string
+	State      State
+	LogPath    string
+	LastError  string
+	NextAction string
+	Values     map[string]string
+}
+
+func Render(entries []Entry, view View) (string, error) {
+	if view != "" {
+		if err := ValidateView(view); err != nil {
+			return "", err
+		}
+	}
+	filtered := make([]Entry, 0, len(entries))
+	for _, entry := range entries {
+		if view == "" || entry.View == view {
+			entry.Values = Redact(entry.Values)
+			filtered = append(filtered, entry)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		if filtered[i].View == filtered[j].View {
+			return filtered[i].Name < filtered[j].Name
+		}
+		return filtered[i].View < filtered[j].View
+	})
+	var b strings.Builder
+	for _, entry := range filtered {
+		fmt.Fprintf(&b, "%s %s: %s\n", entry.View, entry.Name, entry.State)
+		if entry.Desired != "" {
+			fmt.Fprintf(&b, "desired: %s\n", entry.Desired)
+		}
+		if entry.Observed != "" {
+			fmt.Fprintf(&b, "observed: %s\n", entry.Observed)
+		}
+		if entry.LogPath != "" {
+			fmt.Fprintf(&b, "log: %s\n", entry.LogPath)
+		}
+		if entry.LastError != "" {
+			fmt.Fprintf(&b, "last error: %s\n", entry.LastError)
+		}
+		if entry.NextAction != "" {
+			fmt.Fprintf(&b, "next action: %s\n", entry.NextAction)
+		}
+		for _, key := range sortedKeys(entry.Values) {
+			fmt.Fprintf(&b, "%s=%s\n", key, entry.Values[key])
+		}
+	}
+	if b.Len() == 0 {
+		return "status: none\n", nil
+	}
+	return b.String(), nil
+}
+
+func ValidateView(view View) error {
+	switch view {
+	case ViewProject, ViewRuntime, ViewResource, ViewGateway:
+		return nil
+	default:
+		return fmt.Errorf("unknown status view %q", view)
+	}
+}
+
+func Redact(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	redacted := make(map[string]string, len(values))
+	for key, value := range values {
+		if isSecretKey(key) {
+			redacted[key] = "<redacted>"
+			continue
+		}
+		redacted[key] = value
+	}
+	return redacted
+}
+
+func isSecretKey(key string) bool {
+	upper := strings.ToUpper(key)
+	for _, marker := range []string{"SECRET", "PASSWORD", "TOKEN", "ACCESS_KEY"} {
+		if strings.Contains(upper, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1,0 +1,68 @@
+package status
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderFiltersTargetedViewsAndRedactsSecrets(t *testing.T) {
+	output, err := Render([]Entry{
+		{
+			View:       ViewResource,
+			Name:       "rustfs",
+			Desired:    "1.0.0",
+			Observed:   "running",
+			State:      StateHealthy,
+			LogPath:    "/tmp/rustfs.log",
+			NextAction: "none",
+			Values: map[string]string{
+				"AWS_SECRET_ACCESS_KEY": "secret",
+				"AWS_ENDPOINT_URL":      "http://127.0.0.1:9000",
+			},
+		},
+		{View: ViewProject, Name: "app", State: StatePartial},
+	}, ViewResource)
+
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+	for _, want := range []string{
+		"resource rustfs: healthy",
+		"desired: 1.0.0",
+		"AWS_SECRET_ACCESS_KEY=<redacted>",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "project app") || strings.Contains(output, "secret\n") {
+		t.Fatalf("output included wrong view or secret:\n%s", output)
+	}
+}
+
+func TestValidateViewRejectsUnknownView(t *testing.T) {
+	if err := ValidateView("daemon"); err == nil {
+		t.Fatal("ValidateView returned nil error")
+	}
+}
+
+func TestRenderSupportsAllNormalizedStates(t *testing.T) {
+	for _, state := range []State{
+		StateHealthy,
+		StateStopped,
+		StateMissingInstall,
+		StateBlocked,
+		StateCrashed,
+		StateFailed,
+		StatePartial,
+		StateUnknown,
+	} {
+		output, err := Render([]Entry{{View: ViewGateway, Name: string(state), State: state}}, "")
+		if err != nil {
+			t.Fatalf("Render(%s) returned error: %v", state, err)
+		}
+		if !strings.Contains(output, string(state)) {
+			t.Fatalf("output missing %s:\n%s", state, output)
+		}
+	}
+}


### PR DESCRIPTION
Stack position: Epic 5 of 5
Base branch: rewrite/epic-4-laravel-project-experience
Targets main directly: no
Depends on: #209 / rewrite/epic-4-laravel-project-experience
Verification: `gofmt -w . && go vet ./... && go build ./... && go test ./...`; `cd legacy/prototype && gofmt -w . && go vet ./... && go build ./... && go test ./...`

## Summary
- Adds aggregate status rendering with normalized states, scoped views, next actions, logs, last errors, and secret redaction.
- Adds final QA evidence for the rewrite stack.

## Linked Issues
Resolves #193, resolves #194, resolves #195, resolves #196, resolves #197, resolves #198, resolves #199, resolves #200, resolves #201, resolves #202, resolves #203, resolves #204, resolves #205.
