### PR TITLE
Add state foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +97,38 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+
+[[package]]
+name = "camino-tempfile"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64308c4c82a5c38679945ddf88738dc1483dcc563bbb5780755ae9f8497d2b20"
+dependencies = [
+ "camino",
+ "tempfile",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -177,6 +218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,16 +255,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "getrandom"
@@ -235,7 +309,16 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -245,10 +328,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "id-arena"
@@ -276,6 +377,7 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
+ "regex",
  "similar",
  "tempfile",
 ]
@@ -293,6 +395,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +416,17 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -330,6 +454,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +470,18 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -413,16 +555,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resources"
 version = "0.1.0"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -437,6 +627,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "semver"
@@ -487,16 +683,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd578e94101503d97e2b286bbf8db2135035ca24b2ce4cbf3f9e2fb2bbf1eee"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "state"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "camino",
+ "camino-tempfile",
+ "home",
+ "insta",
+ "rusqlite",
+ "rustix",
  "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -556,6 +784,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +831,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wait-timeout"
@@ -598,6 +863,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.122"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,15 @@ publish = false
 
 [workspace.dependencies]
 anyhow = "1"
+camino = "1"
+camino-tempfile = "1"
 clap = { version = "4", features = ["derive"] }
+home = "0"
+insta = { version = "1", features = ["filters"] }
+rusqlite = { version = "0", features = ["bundled"] }
+rustix = { version = "1", features = ["process"] }
 thiserror = "2"
+time = { version = "0", features = ["formatting", "macros"] }
 
 [workspace.lints.clippy]
 dbg_macro = "deny"

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -8,4 +8,14 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+camino = { workspace = true }
+home = { workspace = true }
+rusqlite = { workspace = true }
+rustix = { workspace = true }
 thiserror = { workspace = true }
+time = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+camino-tempfile = { workspace = true }
+insta = { workspace = true }

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -1,0 +1,293 @@
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use rusqlite::{Connection, Transaction, params};
+
+use crate::{PvPaths, StateError, fs};
+
+const BUSY_TIMEOUT: Duration = Duration::from_millis(250);
+
+const CORE_SCHEMA_SQL: &str = r#"
+CREATE TABLE projects (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL UNIQUE,
+    primary_hostname TEXT NOT NULL UNIQUE,
+    config_path TEXT,
+    desired_php_track TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE project_hostnames (
+    hostname TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    is_primary INTEGER NOT NULL CHECK (is_primary IN (0, 1)),
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE managed_resource_tracks (
+    resource_name TEXT NOT NULL,
+    track TEXT NOT NULL,
+    desired_state TEXT NOT NULL,
+    installed_version TEXT,
+    current_artifact_path TEXT,
+    usage_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (resource_name, track)
+);
+
+CREATE TABLE resource_allocations (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    resource_name TEXT NOT NULL,
+    track TEXT NOT NULL,
+    allocation_name TEXT NOT NULL,
+    generated_name TEXT NOT NULL,
+    env_json TEXT NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (project_id, resource_name, allocation_name)
+);
+
+CREATE TABLE ports (
+    name TEXT PRIMARY KEY,
+    port INTEGER NOT NULL UNIQUE,
+    owner_kind TEXT NOT NULL,
+    resource_name TEXT,
+    track TEXT,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE observed_states (
+    subject_kind TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    message TEXT,
+    observed_at TEXT NOT NULL,
+    PRIMARY KEY (subject_kind, subject_id)
+);
+
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    summary TEXT,
+    error TEXT
+);
+"#;
+
+const DEFAULT_MIGRATIONS: &[Migration] = &[Migration::new(1, "core_state_schema", CORE_SCHEMA_SQL)];
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Migration {
+    version: i64,
+    name: &'static str,
+    sql: &'static str,
+}
+
+impl Migration {
+    pub const fn new(version: i64, name: &'static str, sql: &'static str) -> Self {
+        Self { version, name, sql }
+    }
+}
+
+#[derive(Debug)]
+pub struct Database {
+    connection: Connection,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatabaseInspection {
+    pub busy_timeout_ms: i64,
+    pub foreign_keys_enabled: bool,
+    pub journal_mode: String,
+    pub migrations: Vec<String>,
+    pub tables: Vec<String>,
+}
+
+impl Database {
+    pub fn open(paths: &PvPaths) -> Result<Self, StateError> {
+        Self::open_with_migrations(paths, DEFAULT_MIGRATIONS)
+    }
+
+    pub fn open_with_migrations(
+        paths: &PvPaths,
+        migrations: &[Migration],
+    ) -> Result<Self, StateError> {
+        fs::ensure_layout(paths)?;
+
+        let database_existed = fs::database_exists(paths);
+        let mut connection = Connection::open(paths.db())?;
+        fs::secure_database_files(paths)?;
+        configure_connection(&connection)?;
+        run_migrations(paths, &mut connection, migrations, database_existed)?;
+        fs::secure_database_files(paths)?;
+
+        Ok(Self { connection })
+    }
+
+    pub fn inspect(&self) -> Result<DatabaseInspection, StateError> {
+        Ok(DatabaseInspection {
+            busy_timeout_ms: self.pragma_i64("busy_timeout")?,
+            foreign_keys_enabled: self.pragma_bool("foreign_keys")?,
+            journal_mode: self.pragma_string("journal_mode")?,
+            migrations: self.applied_migration_names()?,
+            tables: self.table_names()?,
+        })
+    }
+
+    pub fn transaction<T>(
+        &mut self,
+        operation: impl FnOnce(&Transaction<'_>) -> rusqlite::Result<T>,
+    ) -> Result<T, StateError> {
+        let transaction = self.connection.transaction()?;
+        let output = operation(&transaction)?;
+        transaction.commit()?;
+
+        Ok(output)
+    }
+
+    pub fn query_i64(&self, sql: &str) -> Result<i64, StateError> {
+        Ok(self.connection.query_row(sql, [], |row| row.get(0))?)
+    }
+
+    fn pragma_bool(&self, pragma: &str) -> Result<bool, StateError> {
+        Ok(self.pragma_i64(pragma)? == 1)
+    }
+
+    fn pragma_i64(&self, pragma: &str) -> Result<i64, StateError> {
+        Ok(self
+            .connection
+            .pragma_query_value(None, pragma, |row| row.get(0))?)
+    }
+
+    fn pragma_string(&self, pragma: &str) -> Result<String, StateError> {
+        Ok(self
+            .connection
+            .pragma_query_value(None, pragma, |row| row.get(0))?)
+    }
+
+    fn applied_migration_names(&self) -> Result<Vec<String>, StateError> {
+        let mut statement = self.connection.prepare(
+            "SELECT printf('%03d:%s', version, name) FROM pv_migrations ORDER BY version",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        let mut migrations = Vec::new();
+
+        for row in rows {
+            migrations.push(row?);
+        }
+
+        Ok(migrations)
+    }
+
+    fn table_names(&self) -> Result<Vec<String>, StateError> {
+        let mut statement = self.connection.prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+        )?;
+        let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+        let mut tables = Vec::new();
+
+        for row in rows {
+            tables.push(row?);
+        }
+
+        Ok(tables)
+    }
+}
+
+fn configure_connection(connection: &Connection) -> Result<(), StateError> {
+    connection.busy_timeout(BUSY_TIMEOUT)?;
+    connection.pragma_update(None, "foreign_keys", "ON")?;
+    connection.pragma_update(None, "journal_mode", "WAL")?;
+
+    Ok(())
+}
+
+fn run_migrations(
+    paths: &PvPaths,
+    connection: &mut Connection,
+    migrations: &[Migration],
+    database_existed: bool,
+) -> Result<(), StateError> {
+    let applied_versions = applied_versions(connection)?;
+    let pending = migrations
+        .iter()
+        .filter(|migration| !applied_versions.contains(&migration.version))
+        .copied()
+        .collect::<Vec<_>>();
+
+    if pending.is_empty() {
+        ensure_migration_table(connection)?;
+        return Ok(());
+    }
+
+    if database_existed {
+        backup_database(paths, connection)?;
+    }
+
+    ensure_migration_table(connection)?;
+
+    for migration in pending {
+        let transaction = connection.transaction()?;
+        transaction.execute_batch(migration.sql)?;
+        transaction.execute(
+            "INSERT INTO pv_migrations (version, name, applied_at) VALUES (?1, ?2, datetime('now'))",
+            params![migration.version, migration.name],
+        )?;
+        transaction.commit()?;
+    }
+
+    Ok(())
+}
+
+fn backup_database(paths: &PvPaths, connection: &Connection) -> Result<(), StateError> {
+    fs::backup_database(paths, |backup_path| {
+        connection.execute("VACUUM main INTO ?1", params![backup_path.as_str()])?;
+        Ok(())
+    })
+}
+
+fn ensure_migration_table(connection: &Connection) -> Result<(), StateError> {
+    connection.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS pv_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            applied_at TEXT NOT NULL
+        );
+        "#,
+    )?;
+
+    Ok(())
+}
+
+fn applied_versions(connection: &Connection) -> Result<BTreeSet<i64>, StateError> {
+    if !table_exists(connection, "pv_migrations")? {
+        return Ok(BTreeSet::new());
+    }
+
+    let mut statement = connection.prepare("SELECT version FROM pv_migrations")?;
+    let rows = statement.query_map([], |row| row.get::<_, i64>(0))?;
+    let mut versions = BTreeSet::new();
+
+    for row in rows {
+        versions.insert(row?);
+    }
+
+    Ok(versions)
+}
+
+fn table_exists(connection: &Connection, table: &str) -> Result<bool, StateError> {
+    let count = connection.query_row(
+        "SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = ?1",
+        params![table],
+        |row| row.get::<_, i64>(0),
+    )?;
+
+    Ok(count > 0)
+}

--- a/crates/state/src/error.rs
+++ b/crates/state/src/error.rs
@@ -1,0 +1,50 @@
+use camino::Utf8PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StateError {
+    #[error("home directory could not be determined")]
+    MissingHome,
+
+    #[error("home directory is not valid UTF-8: {path:?}")]
+    NonUtf8Home { path: std::path::PathBuf },
+
+    #[error("filesystem error at {path}: {source}")]
+    Filesystem {
+        path: Utf8PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("unsafe permissions for {path}: expected {expected:o}, found {actual:o}")]
+    UnsafePermissions {
+        path: Utf8PathBuf,
+        expected: u32,
+        actual: u32,
+    },
+
+    #[error("unexpected owner for {path}: expected uid {expected}, found uid {actual}")]
+    UnexpectedOwner {
+        path: Utf8PathBuf,
+        expected: u32,
+        actual: u32,
+    },
+
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("time formatting failed: {0}")]
+    TimeFormat(#[from] time::error::Format),
+
+    #[error("could not allocate a unique migration backup name under {path}")]
+    BackupNameExhausted { path: Utf8PathBuf },
+}
+
+impl StateError {
+    pub(crate) fn filesystem(path: impl Into<Utf8PathBuf>, source: std::io::Error) -> Self {
+        Self::Filesystem {
+            path: path.into(),
+            source,
+        }
+    }
+}

--- a/crates/state/src/fs.rs
+++ b/crates/state/src/fs.rs
@@ -1,0 +1,300 @@
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::{PvPaths, StateError};
+
+const USER_ONLY_DIR_MODE: u32 = 0o700;
+const SENSITIVE_FILE_MODE: u32 = 0o600;
+const MIGRATION_BACKUP_RETENTION: usize = 5;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LayoutInspection {
+    pub name: &'static str,
+    pub path: String,
+    pub mode: String,
+    pub owned_by_current_user: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DatabaseFileInspection {
+    pub name: &'static str,
+    pub path: String,
+    pub mode: String,
+    pub owned_by_current_user: bool,
+}
+
+pub fn ensure_layout(paths: &PvPaths) -> Result<(), StateError> {
+    for (_, directory) in paths.layout_directories() {
+        ensure_user_dir(directory)?;
+    }
+
+    Ok(())
+}
+
+pub fn inspect_layout(paths: &PvPaths) -> Result<Vec<LayoutInspection>, StateError> {
+    let mut entries = Vec::new();
+
+    for (name, directory) in paths.layout_directories() {
+        let mode = mode(directory)?;
+        entries.push(LayoutInspection {
+            name,
+            path: display_path(paths, directory),
+            mode: format!("{mode:o}"),
+            owned_by_current_user: is_owned_by_current_user(directory)?,
+        });
+    }
+
+    Ok(entries)
+}
+
+pub fn migration_backups(paths: &PvPaths) -> Result<Vec<String>, StateError> {
+    migration_backup_names(paths)
+}
+
+pub fn inspect_database_files(paths: &PvPaths) -> Result<Vec<DatabaseFileInspection>, StateError> {
+    let mut entries = Vec::new();
+
+    for (name, path) in database_files(paths) {
+        if !path_exists(&path) {
+            continue;
+        }
+
+        let mode = mode(&path)?;
+        entries.push(DatabaseFileInspection {
+            name,
+            path: display_path(paths, &path),
+            mode: format!("{mode:o}"),
+            owned_by_current_user: is_owned_by_current_user(&path)?,
+        });
+    }
+
+    Ok(entries)
+}
+
+pub(crate) fn backup_database(
+    paths: &PvPaths,
+    create_backup: impl FnOnce(&Utf8Path) -> Result<(), StateError>,
+) -> Result<(), StateError> {
+    let backup_path = unique_backup_path(paths)?;
+
+    create_backup(&backup_path)?;
+    set_file_mode(&backup_path, SENSITIVE_FILE_MODE)?;
+    validate_mode(&backup_path, SENSITIVE_FILE_MODE)?;
+    validate_owner(&backup_path)?;
+    prune_migration_backups(paths)?;
+
+    Ok(())
+}
+
+fn unique_backup_path(paths: &PvPaths) -> Result<camino::Utf8PathBuf, StateError> {
+    let timestamp = backup_timestamp()?;
+    let base = paths.root().join(format!("pv.db.{timestamp}.bak"));
+
+    if !path_exists(&base) {
+        return Ok(base);
+    }
+
+    for suffix in 1..=999 {
+        let candidate = paths.root().join(format!("pv.db.{timestamp}-{suffix}.bak"));
+
+        if !path_exists(&candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    Err(StateError::BackupNameExhausted {
+        path: paths.root().to_path_buf(),
+    })
+}
+
+pub(crate) fn database_exists(paths: &PvPaths) -> bool {
+    path_exists(paths.db())
+}
+
+pub(crate) fn secure_database_files(paths: &PvPaths) -> Result<(), StateError> {
+    for (_, path) in database_files(paths) {
+        if !path_exists(&path) {
+            continue;
+        }
+
+        set_file_mode(&path, SENSITIVE_FILE_MODE)?;
+        validate_mode(&path, SENSITIVE_FILE_MODE)?;
+        validate_owner(&path)?;
+    }
+
+    Ok(())
+}
+
+fn database_files(paths: &PvPaths) -> [(&'static str, Utf8PathBuf); 3] {
+    [
+        ("database", paths.db().to_path_buf()),
+        ("wal", paths.root().join("pv.db-wal")),
+        ("shared_memory", paths.root().join("pv.db-shm")),
+    ]
+}
+
+fn ensure_user_dir(path: &Utf8Path) -> Result<(), StateError> {
+    create_dir_all(path)?;
+    set_dir_mode(path, USER_ONLY_DIR_MODE)?;
+    validate_mode(path, USER_ONLY_DIR_MODE)?;
+    validate_owner(path)
+}
+
+fn prune_migration_backups(paths: &PvPaths) -> Result<(), StateError> {
+    let backups = migration_backup_names(paths)?;
+    let prune_count = backups.len().saturating_sub(MIGRATION_BACKUP_RETENTION);
+
+    for backup in backups.iter().take(prune_count) {
+        remove_file(&paths.root().join(backup))?;
+    }
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+fn create_dir_all(path: &Utf8Path) -> Result<(), StateError> {
+    std::fs::create_dir_all(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+fn remove_file(path: &Utf8Path) -> Result<(), StateError> {
+    std::fs::remove_file(path).map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+fn set_dir_mode(path: &Utf8Path, mode: u32) -> Result<(), StateError> {
+    let permissions = std::fs::Permissions::from_mode(mode);
+    std::fs::set_permissions(path, permissions)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+fn set_file_mode(path: &Utf8Path, mode: u32) -> Result<(), StateError> {
+    let permissions = std::fs::Permissions::from_mode(mode);
+    std::fs::set_permissions(path, permissions)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}
+
+fn validate_mode(path: &Utf8Path, expected: u32) -> Result<(), StateError> {
+    let actual = mode(path)?;
+
+    if actual == expected {
+        return Ok(());
+    }
+
+    Err(StateError::UnsafePermissions {
+        path: path.to_path_buf(),
+        expected,
+        actual,
+    })
+}
+
+fn validate_owner(path: &Utf8Path) -> Result<(), StateError> {
+    let expected = current_uid();
+    let actual = owner_uid(path)?;
+
+    if actual == expected {
+        return Ok(());
+    }
+
+    Err(StateError::UnexpectedOwner {
+        path: path.to_path_buf(),
+        expected,
+        actual,
+    })
+}
+
+fn is_owned_by_current_user(path: &Utf8Path) -> Result<bool, StateError> {
+    Ok(owner_uid(path)? == current_uid())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+fn mode(path: &Utf8Path) -> Result<u32, StateError> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))?;
+
+    Ok(metadata.permissions().mode() & 0o777)
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+fn owner_uid(path: &Utf8Path) -> Result<u32, StateError> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))?;
+
+    Ok(metadata.uid())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+fn migration_backup_names(paths: &PvPaths) -> Result<Vec<String>, StateError> {
+    let mut backups = Vec::new();
+    let entries = std::fs::read_dir(paths.root())
+        .map_err(|source| StateError::filesystem(paths.root().to_path_buf(), source))?;
+
+    for entry in entries {
+        let entry =
+            entry.map_err(|source| StateError::filesystem(paths.root().to_path_buf(), source))?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+
+        if file_name.starts_with("pv.db.") && file_name.ends_with(".bak") {
+            backups.push(file_name.into_owned());
+        }
+    }
+
+    backups.sort();
+
+    Ok(backups)
+}
+
+fn path_exists(path: &Utf8Path) -> bool {
+    path.exists()
+}
+
+fn display_path(paths: &PvPaths, path: &Utf8Path) -> String {
+    if path == paths.root() {
+        return "~/.pv".to_string();
+    }
+
+    match path.strip_prefix(paths.root()) {
+        Ok(relative) => relative.to_string(),
+        Err(_) => path.to_string(),
+    }
+}
+
+fn backup_timestamp() -> Result<String, StateError> {
+    let format = time::macros::format_description!("[year][month][day]-[hour][minute][second]");
+
+    Ok(time::OffsetDateTime::now_utc().format(format)?)
+}
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    rustix::process::getuid().as_raw()
+}
+
+#[cfg(not(unix))]
+compile_error!("PV v1 targets macOS and requires Unix filesystem permissions");

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -1,5 +1,8 @@
-use thiserror::Error;
+mod database;
+mod error;
+pub mod fs;
+mod paths;
 
-#[derive(Debug, Error)]
-#[error("state error")]
-pub struct StateError;
+pub use database::{Database, DatabaseInspection, Migration};
+pub use error::StateError;
+pub use paths::{PathSummaryEntry, PvPaths};

--- a/crates/state/src/paths.rs
+++ b/crates/state/src/paths.rs
@@ -1,0 +1,160 @@
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::StateError;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PvPaths {
+    home: Utf8PathBuf,
+    root: Utf8PathBuf,
+    db: Utf8PathBuf,
+    bin: Utf8PathBuf,
+    run: Utf8PathBuf,
+    logs: Utf8PathBuf,
+    downloads: Utf8PathBuf,
+    config: Utf8PathBuf,
+    certificates: Utf8PathBuf,
+    composer: Utf8PathBuf,
+    resources: Utf8PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PathSummaryEntry {
+    pub name: &'static str,
+    pub path: String,
+}
+
+impl PvPaths {
+    pub fn for_home(home: impl AsRef<Utf8Path>) -> Self {
+        let home = home.as_ref().to_path_buf();
+        let root = home.join(".pv");
+
+        Self {
+            home,
+            db: root.join("pv.db"),
+            bin: root.join("bin"),
+            run: root.join("run"),
+            logs: root.join("logs"),
+            downloads: root.join("downloads"),
+            config: root.join("config"),
+            certificates: root.join("certificates"),
+            composer: root.join("composer"),
+            resources: root.join("resources"),
+            root,
+        }
+    }
+
+    pub fn default_home() -> Result<Self, StateError> {
+        let home = home::home_dir().ok_or(StateError::MissingHome)?;
+        let home =
+            Utf8PathBuf::from_path_buf(home).map_err(|path| StateError::NonUtf8Home { path })?;
+
+        Ok(Self::for_home(home))
+    }
+
+    pub fn home(&self) -> &Utf8Path {
+        &self.home
+    }
+
+    pub fn root(&self) -> &Utf8Path {
+        &self.root
+    }
+
+    pub fn db(&self) -> &Utf8Path {
+        &self.db
+    }
+
+    pub fn bin(&self) -> &Utf8Path {
+        &self.bin
+    }
+
+    pub fn run(&self) -> &Utf8Path {
+        &self.run
+    }
+
+    pub fn logs(&self) -> &Utf8Path {
+        &self.logs
+    }
+
+    pub fn downloads(&self) -> &Utf8Path {
+        &self.downloads
+    }
+
+    pub fn config(&self) -> &Utf8Path {
+        &self.config
+    }
+
+    pub fn certificates(&self) -> &Utf8Path {
+        &self.certificates
+    }
+
+    pub fn composer(&self) -> &Utf8Path {
+        &self.composer
+    }
+
+    pub fn resources(&self) -> &Utf8Path {
+        &self.resources
+    }
+
+    pub fn layout_directories(&self) -> Vec<(&'static str, &Utf8Path)> {
+        vec![
+            ("root", self.root()),
+            ("bin", self.bin()),
+            ("run", self.run()),
+            ("logs", self.logs()),
+            ("downloads", self.downloads()),
+            ("config", self.config()),
+            ("certificates", self.certificates()),
+            ("composer", self.composer()),
+            ("resources", self.resources()),
+        ]
+    }
+
+    pub fn summary(&self) -> Vec<PathSummaryEntry> {
+        vec![
+            PathSummaryEntry {
+                name: "home",
+                path: self.home().to_string(),
+            },
+            PathSummaryEntry {
+                name: "root",
+                path: self.root().to_string(),
+            },
+            PathSummaryEntry {
+                name: "db",
+                path: self.db().to_string(),
+            },
+            PathSummaryEntry {
+                name: "bin",
+                path: self.bin().to_string(),
+            },
+            PathSummaryEntry {
+                name: "run",
+                path: self.run().to_string(),
+            },
+            PathSummaryEntry {
+                name: "logs",
+                path: self.logs().to_string(),
+            },
+            PathSummaryEntry {
+                name: "downloads",
+                path: self.downloads().to_string(),
+            },
+            PathSummaryEntry {
+                name: "config",
+                path: self.config().to_string(),
+            },
+            PathSummaryEntry {
+                name: "certificates",
+                path: self.certificates().to_string(),
+            },
+            PathSummaryEntry {
+                name: "composer",
+                path: self.composer().to_string(),
+            },
+            PathSummaryEntry {
+                name: "resources",
+                path: self.resources().to_string(),
+            },
+        ]
+    }
+}

--- a/crates/state/tests/snapshots/state_foundation__after_first_open.snap
+++ b/crates/state/tests/snapshots/state_foundation__after_first_open.snap
@@ -1,0 +1,5 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: "state::fs::migration_backups(&paths)?"
+---
+[]

--- a/crates/state/tests/snapshots/state_foundation__after_second_open.snap
+++ b/crates/state/tests/snapshots/state_foundation__after_second_open.snap
@@ -1,0 +1,7 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: "state::fs::migration_backups(&paths)?"
+---
+[
+    "pv.db.<timestamp>.bak",
+]

--- a/crates/state/tests/snapshots/state_foundation__database_files_are_restricted_to_the_current_user.snap
+++ b/crates/state/tests/snapshots/state_foundation__database_files_are_restricted_to_the_current_user.snap
@@ -1,0 +1,24 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: "state::fs::inspect_database_files(&paths)?"
+---
+[
+    DatabaseFileInspection {
+        name: "database",
+        path: "pv.db",
+        mode: "600",
+        owned_by_current_user: true,
+    },
+    DatabaseFileInspection {
+        name: "wal",
+        path: "pv.db-wal",
+        mode: "600",
+        owned_by_current_user: true,
+    },
+    DatabaseFileInspection {
+        name: "shared_memory",
+        path: "pv.db-shm",
+        mode: "600",
+        owned_by_current_user: true,
+    },
+]

--- a/crates/state/tests/snapshots/state_foundation__database_runs_migrations_and_exposes_core_schema.snap
+++ b/crates/state/tests/snapshots/state_foundation__database_runs_migrations_and_exposes_core_schema.snap
@@ -1,0 +1,22 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: database.inspect()?
+---
+DatabaseInspection {
+    busy_timeout_ms: 250,
+    foreign_keys_enabled: true,
+    journal_mode: "wal",
+    migrations: [
+        "001:core_state_schema",
+    ],
+    tables: [
+        "jobs",
+        "managed_resource_tracks",
+        "observed_states",
+        "ports",
+        "project_hostnames",
+        "projects",
+        "pv_migrations",
+        "resource_allocations",
+    ],
+}

--- a/crates/state/tests/snapshots/state_foundation__layout_creates_expected_directories_with_user_only_modes.snap
+++ b/crates/state/tests/snapshots/state_foundation__layout_creates_expected_directories_with_user_only_modes.snap
@@ -1,0 +1,60 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: "state::fs::inspect_layout(&paths)?"
+---
+[
+    LayoutInspection {
+        name: "root",
+        path: "~/.pv",
+        mode: "700",
+        owned_by_current_user: true,
+    },
+    LayoutInspection {
+        name: "bin",
+        path: "bin",
+        mode: "700",
+        owned_by_current_user: true,
+    },
+    LayoutInspection {
+        name: "run",
+        path: "run",
+        mode: "700",
+        owned_by_current_user: true,
+    },
+    LayoutInspection {
+        name: "logs",
+        path: "logs",
+        mode: "700",
+        owned_by_current_user: true,
+    },
+    LayoutInspection {
+        name: "downloads",
+        path: "downloads",
+        mode: "700",
+        owned_by_current_user: true,
+    },
+    LayoutInspection {
+        name: "config",
+        path: "config",
+        mode: "700",
+        owned_by_current_user: true,
+    },
+    LayoutInspection {
+        name: "certificates",
+        path: "certificates",
+        mode: "700",
+        owned_by_current_user: true,
+    },
+    LayoutInspection {
+        name: "composer",
+        path: "composer",
+        mode: "700",
+        owned_by_current_user: true,
+    },
+    LayoutInspection {
+        name: "resources",
+        path: "resources",
+        mode: "700",
+        owned_by_current_user: true,
+    },
+]

--- a/crates/state/tests/snapshots/state_foundation__migration_backup_includes_committed_wal_pages.snap
+++ b/crates/state/tests/snapshots/state_foundation__migration_backup_includes_committed_wal_pages.snap
@@ -1,0 +1,5 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: backed_up_rows
+---
+1

--- a/crates/state/tests/snapshots/state_foundation__migration_backup_retention_keeps_the_latest_five_backups.snap
+++ b/crates/state/tests/snapshots/state_foundation__migration_backup_retention_keeps_the_latest_five_backups.snap
@@ -1,0 +1,5 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: "state::fs::migration_backups(&paths)?.len()"
+---
+5

--- a/crates/state/tests/snapshots/state_foundation__paths_are_derived_from_an_injected_home.snap
+++ b/crates/state/tests/snapshots/state_foundation__paths_are_derived_from_an_injected_home.snap
@@ -1,0 +1,50 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: paths.summary()
+---
+[
+    PathSummaryEntry {
+        name: "home",
+        path: "/tmp/pv-test-home",
+    },
+    PathSummaryEntry {
+        name: "root",
+        path: "/tmp/pv-test-home/.pv",
+    },
+    PathSummaryEntry {
+        name: "db",
+        path: "/tmp/pv-test-home/.pv/pv.db",
+    },
+    PathSummaryEntry {
+        name: "bin",
+        path: "/tmp/pv-test-home/.pv/bin",
+    },
+    PathSummaryEntry {
+        name: "run",
+        path: "/tmp/pv-test-home/.pv/run",
+    },
+    PathSummaryEntry {
+        name: "logs",
+        path: "/tmp/pv-test-home/.pv/logs",
+    },
+    PathSummaryEntry {
+        name: "downloads",
+        path: "/tmp/pv-test-home/.pv/downloads",
+    },
+    PathSummaryEntry {
+        name: "config",
+        path: "/tmp/pv-test-home/.pv/config",
+    },
+    PathSummaryEntry {
+        name: "certificates",
+        path: "/tmp/pv-test-home/.pv/certificates",
+    },
+    PathSummaryEntry {
+        name: "composer",
+        path: "/tmp/pv-test-home/.pv/composer",
+    },
+    PathSummaryEntry {
+        name: "resources",
+        path: "/tmp/pv-test-home/.pv/resources",
+    },
+]

--- a/crates/state/tests/snapshots/state_foundation__transactions_roll_back_when_the_operation_fails.snap
+++ b/crates/state/tests/snapshots/state_foundation__transactions_roll_back_when_the_operation_fails.snap
@@ -1,0 +1,5 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: "database.query_i64(\"SELECT COUNT(*) FROM jobs\")?"
+---
+0

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -1,0 +1,203 @@
+use anyhow::{Result, anyhow};
+use camino::Utf8Path;
+use camino_tempfile::tempdir;
+use insta::{Settings, assert_debug_snapshot};
+use rusqlite::{Connection, params};
+use state::{Database, Migration, PvPaths};
+
+#[test]
+fn paths_are_derived_from_an_injected_home() -> Result<()> {
+    let paths = PvPaths::for_home(Utf8Path::new("/tmp/pv-test-home"));
+
+    assert_debug_snapshot!(paths.summary());
+
+    Ok(())
+}
+
+#[test]
+fn layout_creates_expected_directories_with_user_only_modes() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+
+    state::fs::ensure_layout(&paths)?;
+
+    assert_debug_snapshot!(state::fs::inspect_layout(&paths)?);
+
+    Ok(())
+}
+
+#[test]
+fn database_runs_migrations_and_exposes_core_schema() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+
+    let database = Database::open(&paths)?;
+
+    assert_debug_snapshot!(database.inspect()?);
+
+    Ok(())
+}
+
+#[test]
+fn database_files_are_restricted_to_the_current_user() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+
+    let _database = Database::open(&paths)?;
+
+    assert_debug_snapshot!(state::fs::inspect_database_files(&paths)?);
+
+    Ok(())
+}
+
+#[test]
+fn migration_backups_are_created_only_when_pending_migrations_exist() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+
+    let first_migration = [Migration::new(
+        1,
+        "first",
+        "CREATE TABLE first_table (id TEXT PRIMARY KEY);",
+    )];
+    Database::open_with_migrations(&paths, &first_migration)?;
+    with_normalized_backup_names(|| {
+        assert_debug_snapshot!("after_first_open", state::fs::migration_backups(&paths)?);
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    let second_migration = [
+        Migration::new(
+            1,
+            "first",
+            "CREATE TABLE first_table (id TEXT PRIMARY KEY);",
+        ),
+        Migration::new(
+            2,
+            "second",
+            "CREATE TABLE second_table (id TEXT PRIMARY KEY);",
+        ),
+    ];
+    Database::open_with_migrations(&paths, &second_migration)?;
+
+    with_normalized_backup_names(|| {
+        assert_debug_snapshot!("after_second_open", state::fs::migration_backups(&paths)?);
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn migration_backup_includes_committed_wal_pages() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+    let first_migration = [Migration::new(
+        1,
+        "first",
+        "CREATE TABLE first_table (id TEXT PRIMARY KEY, value TEXT NOT NULL);",
+    )];
+    let mut database = Database::open_with_migrations(&paths, &first_migration)?;
+    database.transaction(|transaction| {
+        transaction.execute(
+            "INSERT INTO first_table (id, value) VALUES (?1, ?2)",
+            params!["row_1", "from_wal"],
+        )?;
+
+        Ok(())
+    })?;
+
+    let second_migration = [
+        Migration::new(
+            1,
+            "first",
+            "CREATE TABLE first_table (id TEXT PRIMARY KEY, value TEXT NOT NULL);",
+        ),
+        Migration::new(
+            2,
+            "second",
+            "CREATE TABLE second_table (id TEXT PRIMARY KEY);",
+        ),
+    ];
+    Database::open_with_migrations(&paths, &second_migration)?;
+
+    let backup_names = state::fs::migration_backups(&paths)?;
+    let backup_name = backup_names
+        .first()
+        .ok_or_else(|| anyhow!("missing migration backup"))?;
+    let backup_connection = Connection::open(paths.root().join(backup_name))?;
+    let backed_up_rows = backup_connection.query_row(
+        "SELECT COUNT(*) FROM first_table WHERE value = ?1",
+        params!["from_wal"],
+        |row| row.get::<_, i64>(0),
+    )?;
+
+    assert_debug_snapshot!(backed_up_rows);
+
+    Ok(())
+}
+
+#[test]
+fn migration_backup_retention_keeps_the_latest_five_backups() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+    let migrations = [
+        Migration::new(1, "m1", "CREATE TABLE m1 (id TEXT PRIMARY KEY);"),
+        Migration::new(2, "m2", "CREATE TABLE m2 (id TEXT PRIMARY KEY);"),
+        Migration::new(3, "m3", "CREATE TABLE m3 (id TEXT PRIMARY KEY);"),
+        Migration::new(4, "m4", "CREATE TABLE m4 (id TEXT PRIMARY KEY);"),
+        Migration::new(5, "m5", "CREATE TABLE m5 (id TEXT PRIMARY KEY);"),
+        Migration::new(6, "m6", "CREATE TABLE m6 (id TEXT PRIMARY KEY);"),
+        Migration::new(7, "m7", "CREATE TABLE m7 (id TEXT PRIMARY KEY);"),
+        Migration::new(8, "m8", "CREATE TABLE m8 (id TEXT PRIMARY KEY);"),
+    ];
+
+    for migration_count in 1..=migrations.len() {
+        Database::open_with_migrations(&paths, &migrations[..migration_count])?;
+    }
+
+    assert_debug_snapshot!(state::fs::migration_backups(&paths)?.len());
+
+    Ok(())
+}
+
+fn with_normalized_backup_names(assertion: impl FnOnce() -> Result<()>) -> Result<()> {
+    let mut settings = Settings::clone_current();
+    settings.add_filter(
+        r"pv\.db\.\d{8}-\d{6}(?:-\d+)?\.bak",
+        "pv.db.<timestamp>.bak",
+    );
+
+    settings.bind(assertion)
+}
+
+#[test]
+fn transactions_roll_back_when_the_operation_fails() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+
+    let mut database = Database::open(&paths)?;
+    let result = database.transaction(|transaction| {
+        transaction.execute(
+            "INSERT INTO jobs (id, kind, scope, status, started_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params!["job_1", "test", "system", "running", "2026-05-23T00:00:00Z"],
+        )?;
+        transaction.execute(
+            "INSERT INTO missing_table (id) VALUES (?1)",
+            params!["boom"],
+        )?;
+
+        Ok(())
+    });
+
+    assert!(result.is_err());
+    assert_debug_snapshot!(database.query_i64("SELECT COUNT(*) FROM jobs")?);
+
+    Ok(())
+}


### PR DESCRIPTION

## Summary
- Implements PV-010 through PV-015.
- Adds PV path derivation, filesystem layout validation, SQLite state, migrations, transactions, and migration backup retention.
- Adds integration coverage and insta snapshots for the state foundation.

## Stack
- Depends on #234.

## Verification
- cargo fmt --all --check
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
