### PR TITLE
Add CLI foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +192,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ publish = false
 
 [workspace.dependencies]
 anyhow = "1"
+assert_cmd = "2"
 camino = "1"
 camino-tempfile = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 home = "0"
 insta = { version = "1", features = ["filters"] }
 rusqlite = { version = "0", features = ["bundled"] }
@@ -54,8 +56,8 @@ cli = { path = "crates/cli" }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-assert_cmd = "2"
-insta = "1"
+assert_cmd = { workspace = true }
+insta = { workspace = true }
 
 [[test]]
 name = "cli"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,4 +10,5 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,9 +1,12 @@
-use std::ffi::OsString;
-use std::io::Write;
+use std::ffi::{OsStr, OsString};
+use std::io::{self, Write};
+use std::path::Path;
 use std::process::ExitCode;
 
 use anyhow::Result;
-use clap::{CommandFactory, FromArgMatches, Parser};
+use clap::error::ErrorKind;
+use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
+use clap_complete::generate;
 use thiserror::Error;
 
 #[derive(Debug, Parser)]
@@ -17,10 +20,120 @@ use thiserror::Error;
 struct Cli {
     #[arg(long, global = true, help = "Disable colored output")]
     no_color: bool,
+
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    #[command(name = "env", about = "Print shell integration code")]
+    Env(EnvArgs),
+
+    #[command(name = "completions", about = "Generate shell completions")]
+    Completions(CompletionsArgs),
+
+    #[command(name = "php:install", about = "Install a PHP track")]
+    PhpInstall(PhpInstallArgs),
+}
+
+#[derive(Debug, clap::Args)]
+struct EnvArgs {
+    #[arg(long, value_enum, help = "Shell syntax to generate")]
+    shell: Option<Shell>,
+}
+
+#[derive(Debug, clap::Args)]
+struct CompletionsArgs {
+    #[arg(value_enum, help = "Shell to generate completions for")]
+    shell: Shell,
+}
+
+#[derive(Debug, clap::Args)]
+struct PhpInstallArgs {
+    #[arg(help = "PHP track to install")]
+    track: String,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+enum Shell {
+    Bash,
+    Fish,
+    Zsh,
+}
+
+impl Shell {
+    fn detect(shell_path: &OsStr) -> Option<Self> {
+        let file_name = Path::new(shell_path).file_name()?;
+        let shell_name = file_name.to_string_lossy();
+
+        match shell_name.as_ref() {
+            "bash" => Some(Self::Bash),
+            "fish" => Some(Self::Fish),
+            "zsh" => Some(Self::Zsh),
+            _ => None,
+        }
+    }
+
+    fn env_script(self) -> &'static str {
+        match self {
+            Self::Bash | Self::Zsh => POSIX_ENV_SCRIPT,
+            Self::Fish => FISH_ENV_SCRIPT,
+        }
+    }
+
+    fn completion_shell(self) -> clap_complete::Shell {
+        match self {
+            Self::Bash => clap_complete::Shell::Bash,
+            Self::Fish => clap_complete::Shell::Fish,
+            Self::Zsh => clap_complete::Shell::Zsh,
+        }
+    }
+}
+
+const POSIX_ENV_SCRIPT: &str = r#"pv_prepend_path() {
+  case ":$PATH:" in
+    *":$1:"*) ;;
+    *) PATH="$1${PATH:+:$PATH}" ;;
+  esac
+}
+
+export COMPOSER_HOME="$HOME/.pv/composer"
+export COMPOSER_CACHE_DIR="$HOME/.pv/composer/cache"
+pv_prepend_path "$HOME/.pv/composer/vendor/bin"
+pv_prepend_path "$HOME/.pv/bin"
+export PATH
+unset -f pv_prepend_path
+"#;
+
+const FISH_ENV_SCRIPT: &str = r#"set -gx COMPOSER_HOME "$HOME/.pv/composer"
+set -gx COMPOSER_CACHE_DIR "$HOME/.pv/composer/cache"
+contains -- "$HOME/.pv/composer/vendor/bin" $PATH; or set -gx PATH "$HOME/.pv/composer/vendor/bin" $PATH
+contains -- "$HOME/.pv/bin" $PATH; or set -gx PATH "$HOME/.pv/bin" $PATH
+"#;
+
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error("could not detect the current shell; pass --shell zsh, --shell bash, or --shell fish")]
+    MissingShell,
+
+    #[error(
+        "detected unsupported shell `{shell}`; pass --shell zsh, --shell bash, or --shell fish"
+    )]
+    UnsupportedDetectedShell { shell: String },
+
+    #[error("{command} is routed, but Managed Resource installs start after PV-023")]
+    DeferredCommand { command: &'static str },
 }
 
 #[derive(Debug, Error)]
-pub enum CliError {}
+enum ExecuteError {
+    #[error(transparent)]
+    User(#[from] CliError),
+
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
 
 pub trait Environment {
     fn var_os(&self, key: &str) -> Option<OsString>;
@@ -123,7 +236,7 @@ where
             return Ok(exit_code(status_code));
         }
     };
-    let _cli = match Cli::from_arg_matches(&matches) {
+    let cli = match Cli::from_arg_matches(&matches) {
         Ok(cli) => cli,
         Err(error) => {
             let status_code = error.exit_code();
@@ -132,7 +245,61 @@ where
         }
     };
 
-    Ok(ExitCode::SUCCESS)
+    match execute(cli, environment, stdout) {
+        Ok(exit_code) => Ok(exit_code),
+        Err(ExecuteError::User(error)) => {
+            let mut output = Output::new(stderr, output_mode);
+            output.error(&error.to_string())?;
+
+            Ok(ExitCode::FAILURE)
+        }
+        Err(ExecuteError::Io(error)) => Err(error.into()),
+    }
+}
+
+fn execute(
+    cli: Cli,
+    environment: &impl Environment,
+    stdout: &mut impl Write,
+) -> Result<ExitCode, ExecuteError> {
+    match cli.command {
+        Command::Env(args) => {
+            let shell = match args.shell {
+                Some(shell) => shell,
+                None => detect_shell(environment)?,
+            };
+            let mut output = Output::new(
+                stdout,
+                OutputMode {
+                    no_color: cli.no_color,
+                },
+            );
+            output.line(shell.env_script())?;
+
+            Ok(ExitCode::SUCCESS)
+        }
+        Command::Completions(args) => {
+            let mut command = Cli::command();
+            generate(args.shell.completion_shell(), &mut command, "pv", stdout);
+
+            Ok(ExitCode::SUCCESS)
+        }
+        Command::PhpInstall(args) => {
+            let _track = args.track;
+
+            Err(CliError::DeferredCommand {
+                command: "php:install",
+            }
+            .into())
+        }
+    }
+}
+
+fn detect_shell(environment: &impl Environment) -> Result<Shell, CliError> {
+    let shell_path = environment.var_os("SHELL").ok_or(CliError::MissingShell)?;
+    Shell::detect(&shell_path).ok_or_else(|| CliError::UnsupportedDetectedShell {
+        shell: shell_path.to_string_lossy().into_owned(),
+    })
 }
 
 fn clap_color(output_mode: OutputMode) -> clap::ColorChoice {
@@ -165,7 +332,7 @@ fn write_clap_error(
 ) -> std::io::Result<()> {
     if matches!(
         error.kind(),
-        clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion
+        ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
     ) {
         write!(stdout, "{error}")
     } else {

--- a/it/cli.rs
+++ b/it/cli.rs
@@ -2,7 +2,7 @@ use std::process::ExitStatus;
 
 use anyhow::Result;
 use assert_cmd::Command;
-use insta::assert_debug_snapshot;
+use insta::{assert_debug_snapshot, assert_snapshot};
 
 #[derive(Debug)]
 struct CommandOutput {
@@ -12,7 +12,18 @@ struct CommandOutput {
 }
 
 fn run_pv(args: &[&str]) -> Result<CommandOutput> {
-    let output = Command::cargo_bin("pv")?.args(args).output()?;
+    run_pv_with_env(args, &[])
+}
+
+fn run_pv_with_env(args: &[&str], env: &[(&str, &str)]) -> Result<CommandOutput> {
+    let mut command = Command::cargo_bin("pv")?;
+    command.env_remove("NO_COLOR");
+
+    for (key, value) in env {
+        command.env(key, value);
+    }
+
+    let output = command.args(args).output()?;
 
     Ok(CommandOutput {
         code: status_code(output.status),
@@ -28,17 +39,128 @@ fn status_code(status: ExitStatus) -> Option<i32> {
 #[test]
 fn version_builds_and_runs_from_source() -> Result<()> {
     let output = run_pv(&["--version"])?;
-    let CommandOutput {
-        code,
-        stdout,
-        stderr,
-    } = output;
 
-    assert_debug_snapshot!(CommandOutput {
-        code,
-        stdout,
-        stderr,
-    });
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn rejects_space_separated_namespace_commands() -> Result<()> {
+    let output = run_pv(&["php", "install", "8.4"])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn routes_literal_colon_commands_without_space_aliases() -> Result<()> {
+    let output = run_pv(&["php:install", "8.4"])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn env_zsh_output_is_shell_startup_safe() -> Result<()> {
+    let output = run_pv(&["env", "--shell", "zsh"])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn env_bash_output_matches_posix_shells() -> Result<()> {
+    let output = run_pv(&["env", "--shell", "bash"])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn env_fish_output_is_idempotent() -> Result<()> {
+    let output = run_pv(&["env", "--shell", "fish"])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn env_detects_shell_from_environment() -> Result<()> {
+    let output = run_pv_with_env(&["env"], &[("SHELL", "/bin/zsh")])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn no_color_global_flag_is_accepted() -> Result<()> {
+    let output = run_pv(&["--no-color", "env", "--shell", "zsh"])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn no_color_environment_keeps_errors_plain() -> Result<()> {
+    let output = run_pv_with_env(&["php", "install", "8.4"], &[("NO_COLOR", "1")])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn env_rejects_unsupported_shells() -> Result<()> {
+    let output = run_pv(&["env", "--shell", "tcsh"])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn completions_generate_zsh_script() -> Result<()> {
+    let output = run_pv(&["completions", "zsh"])?;
+
+    assert_snapshot!(output.stdout);
+    assert_debug_snapshot!((output.code, output.stderr));
+
+    Ok(())
+}
+
+#[test]
+fn completions_generate_bash_script() -> Result<()> {
+    let output = run_pv(&["completions", "bash"])?;
+
+    assert_snapshot!(output.stdout);
+    assert_debug_snapshot!((output.code, output.stderr));
+
+    Ok(())
+}
+
+#[test]
+fn completions_generate_fish_script() -> Result<()> {
+    let output = run_pv(&["completions", "fish"])?;
+
+    assert_snapshot!(output.stdout);
+    assert_debug_snapshot!((output.code, output.stderr));
+
+    Ok(())
+}
+
+#[test]
+fn completions_reject_unsupported_shells() -> Result<()> {
+    let output = run_pv(&["completions", "tcsh"])?;
+
+    assert_debug_snapshot!(output);
 
     Ok(())
 }

--- a/it/snapshots/cli__completions_generate_bash_script-2.snap
+++ b/it/snapshots/cli__completions_generate_bash_script-2.snap
@@ -1,0 +1,10 @@
+---
+source: it/cli.rs
+expression: "(output.code, output.stderr)"
+---
+(
+    Some(
+        0,
+    ),
+    "",
+)

--- a/it/snapshots/cli__completions_generate_bash_script.snap
+++ b/it/snapshots/cli__completions_generate_bash_script.snap
@@ -1,0 +1,105 @@
+---
+source: it/cli.rs
+expression: output.stdout
+---
+_pv() {
+    local i cur prev opts cmd
+    COMPREPLY=()
+    if [[ "${BASH_VERSINFO[0]}" -ge 4 ]]; then
+        cur="$2"
+    else
+        cur="${COMP_WORDS[COMP_CWORD]}"
+    fi
+    prev="$3"
+    cmd=""
+    opts=""
+
+    for i in "${COMP_WORDS[@]:0:COMP_CWORD}"
+    do
+        case "${cmd},${i}" in
+            ",$1")
+                cmd="pv"
+                ;;
+            pv,completions)
+                cmd="pv__subcmd__completions"
+                ;;
+            pv,env)
+                cmd="pv__subcmd__env"
+                ;;
+            pv,php:install)
+                cmd="pv__subcmd__php:install"
+                ;;
+            *)
+                ;;
+        esac
+    done
+
+    case "${cmd}" in
+        pv)
+            opts="-h -V --no-color --help --version env completions php:install"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        pv__subcmd__completions)
+            opts="-h --no-color --help bash fish zsh"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        pv__subcmd__env)
+            opts="-h --shell --no-color --help"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                --shell)
+                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
+                    return 0
+                    ;;
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        pv__subcmd__php:install)
+            opts="-h --no-color --help <TRACK>"
+            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
+                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+                return 0
+            fi
+            case "${prev}" in
+                *)
+                    COMPREPLY=()
+                    ;;
+            esac
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+    esac
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -F _pv -o nosort -o bashdefault -o default pv
+else
+    complete -F _pv -o bashdefault -o default pv
+fi

--- a/it/snapshots/cli__completions_generate_fish_script-2.snap
+++ b/it/snapshots/cli__completions_generate_fish_script-2.snap
@@ -1,0 +1,10 @@
+---
+source: it/cli.rs
+expression: "(output.code, output.stderr)"
+---
+(
+    Some(
+        0,
+    ),
+    "",
+)

--- a/it/snapshots/cli__completions_generate_fish_script.snap
+++ b/it/snapshots/cli__completions_generate_fish_script.snap
@@ -1,0 +1,45 @@
+---
+source: it/cli.rs
+expression: output.stdout
+---
+# Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
+function __fish_pv_global_optspecs
+	string join \n no-color h/help V/version
+end
+
+function __fish_pv_needs_command
+	# Figure out if the current invocation already has a command.
+	set -l cmd (commandline -opc)
+	set -e cmd[1]
+	argparse -s (__fish_pv_global_optspecs) -- $cmd 2>/dev/null
+	or return
+	if set -q argv[1]
+		# Also print the command, so this can be used to figure out what it is.
+		echo $argv[1]
+		return 1
+	end
+	return 0
+end
+
+function __fish_pv_using_subcommand
+	set -l cmd (__fish_pv_needs_command)
+	test -z "$cmd"
+	and return 1
+	contains -- $cmd[1] $argv
+end
+
+complete -c pv -n "__fish_pv_needs_command" -l no-color -d 'Disable colored output'
+complete -c pv -n "__fish_pv_needs_command" -s h -l help -d 'Print help'
+complete -c pv -n "__fish_pv_needs_command" -s V -l version -d 'Print version'
+complete -c pv -n "__fish_pv_needs_command" -f -a "env" -d 'Print shell integration code'
+complete -c pv -n "__fish_pv_needs_command" -f -a "completions" -d 'Generate shell completions'
+complete -c pv -n "__fish_pv_needs_command" -f -a "php:install" -d 'Install a PHP track'
+complete -c pv -n "__fish_pv_using_subcommand env" -l shell -d 'Shell syntax to generate' -r -f -a "bash\t''
+fish\t''
+zsh\t''"
+complete -c pv -n "__fish_pv_using_subcommand env" -l no-color -d 'Disable colored output'
+complete -c pv -n "__fish_pv_using_subcommand env" -s h -l help -d 'Print help'
+complete -c pv -n "__fish_pv_using_subcommand completions" -l no-color -d 'Disable colored output'
+complete -c pv -n "__fish_pv_using_subcommand completions" -s h -l help -d 'Print help'
+complete -c pv -n "__fish_pv_using_subcommand php:install" -l no-color -d 'Disable colored output'
+complete -c pv -n "__fish_pv_using_subcommand php:install" -s h -l help -d 'Print help'

--- a/it/snapshots/cli__completions_generate_zsh_script-2.snap
+++ b/it/snapshots/cli__completions_generate_zsh_script-2.snap
@@ -1,0 +1,10 @@
+---
+source: it/cli.rs
+expression: "(output.code, output.stderr)"
+---
+(
+    Some(
+        0,
+    ),
+    "",
+)

--- a/it/snapshots/cli__completions_generate_zsh_script.snap
+++ b/it/snapshots/cli__completions_generate_zsh_script.snap
@@ -1,0 +1,94 @@
+---
+source: it/cli.rs
+expression: output.stdout
+---
+#compdef pv
+
+autoload -U is-at-least
+
+_pv() {
+    typeset -A opt_args
+    typeset -a _arguments_options
+    local ret=1
+
+    if is-at-least 5.2; then
+        _arguments_options=(-s -S -C)
+    else
+        _arguments_options=(-s -C)
+    fi
+
+    local context curcontext="$curcontext" state line
+    _arguments "${_arguments_options[@]}" : \
+'--no-color[Disable colored output]' \
+'-h[Print help]' \
+'--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
+":: :_pv_commands" \
+"*::: :->pv" \
+&& ret=0
+    case $state in
+    (pv)
+        words=($line[1] "${words[@]}")
+        (( CURRENT += 1 ))
+        curcontext="${curcontext%:*:*}:pv-command-$line[1]:"
+        case $line[1] in
+            (env)
+_arguments "${_arguments_options[@]}" : \
+'--shell=[Shell syntax to generate]:SHELL:(bash fish zsh)' \
+'--no-color[Disable colored output]' \
+'-h[Print help]' \
+'--help[Print help]' \
+&& ret=0
+;;
+(completions)
+_arguments "${_arguments_options[@]}" : \
+'--no-color[Disable colored output]' \
+'-h[Print help]' \
+'--help[Print help]' \
+':shell -- Shell to generate completions for:(bash fish zsh)' \
+&& ret=0
+;;
+(php:install)
+_arguments "${_arguments_options[@]}" : \
+'--no-color[Disable colored output]' \
+'-h[Print help]' \
+'--help[Print help]' \
+':track -- PHP track to install:_default' \
+&& ret=0
+;;
+        esac
+    ;;
+esac
+}
+
+(( $+functions[_pv_commands] )) ||
+_pv_commands() {
+    local commands; commands=(
+'env:Print shell integration code' \
+'completions:Generate shell completions' \
+'php:install:Install a PHP track' \
+    )
+    _describe -t commands 'pv commands' commands "$@"
+}
+(( $+functions[_pv__subcmd__completions_commands] )) ||
+_pv__subcmd__completions_commands() {
+    local commands; commands=()
+    _describe -t commands 'pv completions commands' commands "$@"
+}
+(( $+functions[_pv__subcmd__env_commands] )) ||
+_pv__subcmd__env_commands() {
+    local commands; commands=()
+    _describe -t commands 'pv env commands' commands "$@"
+}
+(( $+functions[_pv__subcmd__php:install_commands] )) ||
+_pv__subcmd__php:install_commands() {
+    local commands; commands=()
+    _describe -t commands 'pv php:install commands' commands "$@"
+}
+
+if [ "$funcstack[1]" = "_pv" ]; then
+    _pv "$@"
+else
+    compdef _pv pv
+fi

--- a/it/snapshots/cli__completions_reject_unsupported_shells.snap
+++ b/it/snapshots/cli__completions_reject_unsupported_shells.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        2,
+    ),
+    stdout: "",
+    stderr: "error: invalid value 'tcsh' for '<SHELL>'\n  [possible values: bash, fish, zsh]\n\n  tip: a similar value exists: 'zsh'\n\nFor more information, try '--help'.\n",
+}

--- a/it/snapshots/cli__env_bash_output_matches_posix_shells.snap
+++ b/it/snapshots/cli__env_bash_output_matches_posix_shells.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        0,
+    ),
+    stdout: "pv_prepend_path() {\n  case \":$PATH:\" in\n    *\":$1:\"*) ;;\n    *) PATH=\"$1${PATH:+:$PATH}\" ;;\n  esac\n}\n\nexport COMPOSER_HOME=\"$HOME/.pv/composer\"\nexport COMPOSER_CACHE_DIR=\"$HOME/.pv/composer/cache\"\npv_prepend_path \"$HOME/.pv/composer/vendor/bin\"\npv_prepend_path \"$HOME/.pv/bin\"\nexport PATH\nunset -f pv_prepend_path\n\n",
+    stderr: "",
+}

--- a/it/snapshots/cli__env_detects_shell_from_environment.snap
+++ b/it/snapshots/cli__env_detects_shell_from_environment.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        0,
+    ),
+    stdout: "pv_prepend_path() {\n  case \":$PATH:\" in\n    *\":$1:\"*) ;;\n    *) PATH=\"$1${PATH:+:$PATH}\" ;;\n  esac\n}\n\nexport COMPOSER_HOME=\"$HOME/.pv/composer\"\nexport COMPOSER_CACHE_DIR=\"$HOME/.pv/composer/cache\"\npv_prepend_path \"$HOME/.pv/composer/vendor/bin\"\npv_prepend_path \"$HOME/.pv/bin\"\nexport PATH\nunset -f pv_prepend_path\n\n",
+    stderr: "",
+}

--- a/it/snapshots/cli__env_fish_output_is_idempotent.snap
+++ b/it/snapshots/cli__env_fish_output_is_idempotent.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        0,
+    ),
+    stdout: "set -gx COMPOSER_HOME \"$HOME/.pv/composer\"\nset -gx COMPOSER_CACHE_DIR \"$HOME/.pv/composer/cache\"\ncontains -- \"$HOME/.pv/composer/vendor/bin\" $PATH; or set -gx PATH \"$HOME/.pv/composer/vendor/bin\" $PATH\ncontains -- \"$HOME/.pv/bin\" $PATH; or set -gx PATH \"$HOME/.pv/bin\" $PATH\n\n",
+    stderr: "",
+}

--- a/it/snapshots/cli__env_rejects_unsupported_shells.snap
+++ b/it/snapshots/cli__env_rejects_unsupported_shells.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        2,
+    ),
+    stdout: "",
+    stderr: "error: invalid value 'tcsh' for '--shell <SHELL>'\n  [possible values: bash, fish, zsh]\n\n  tip: a similar value exists: 'zsh'\n\nFor more information, try '--help'.\n",
+}

--- a/it/snapshots/cli__env_zsh_output_is_shell_startup_safe.snap
+++ b/it/snapshots/cli__env_zsh_output_is_shell_startup_safe.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        0,
+    ),
+    stdout: "pv_prepend_path() {\n  case \":$PATH:\" in\n    *\":$1:\"*) ;;\n    *) PATH=\"$1${PATH:+:$PATH}\" ;;\n  esac\n}\n\nexport COMPOSER_HOME=\"$HOME/.pv/composer\"\nexport COMPOSER_CACHE_DIR=\"$HOME/.pv/composer/cache\"\npv_prepend_path \"$HOME/.pv/composer/vendor/bin\"\npv_prepend_path \"$HOME/.pv/bin\"\nexport PATH\nunset -f pv_prepend_path\n\n",
+    stderr: "",
+}

--- a/it/snapshots/cli__no_color_environment_keeps_errors_plain.snap
+++ b/it/snapshots/cli__no_color_environment_keeps_errors_plain.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        2,
+    ),
+    stdout: "",
+    stderr: "error: unrecognized subcommand 'php'\n\n  tip: a similar subcommand exists: 'php:install'\n\nUsage: pv [OPTIONS] <COMMAND>\n\nFor more information, try '--help'.\n",
+}

--- a/it/snapshots/cli__no_color_global_flag_is_accepted.snap
+++ b/it/snapshots/cli__no_color_global_flag_is_accepted.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        0,
+    ),
+    stdout: "pv_prepend_path() {\n  case \":$PATH:\" in\n    *\":$1:\"*) ;;\n    *) PATH=\"$1${PATH:+:$PATH}\" ;;\n  esac\n}\n\nexport COMPOSER_HOME=\"$HOME/.pv/composer\"\nexport COMPOSER_CACHE_DIR=\"$HOME/.pv/composer/cache\"\npv_prepend_path \"$HOME/.pv/composer/vendor/bin\"\npv_prepend_path \"$HOME/.pv/bin\"\nexport PATH\nunset -f pv_prepend_path\n\n",
+    stderr: "",
+}

--- a/it/snapshots/cli__rejects_space_separated_namespace_commands.snap
+++ b/it/snapshots/cli__rejects_space_separated_namespace_commands.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        2,
+    ),
+    stdout: "",
+    stderr: "error: unrecognized subcommand 'php'\n\n  tip: a similar subcommand exists: 'php:install'\n\nUsage: pv [OPTIONS] <COMMAND>\n\nFor more information, try '--help'.\n",
+}

--- a/it/snapshots/cli__routes_literal_colon_commands_without_space_aliases.snap
+++ b/it/snapshots/cli__routes_literal_colon_commands_without_space_aliases.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        1,
+    ),
+    stdout: "",
+    stderr: "error: php:install is routed, but Managed Resource installs start after PV-023\n",
+}


### PR DESCRIPTION

## Summary
- Implements PV-020 through PV-023.
- Adds literal colon command routing, global no-color handling, pv env, and shell completions.
- Adds integration coverage and insta snapshots for the CLI surface.

## Stack
- Depends on #235.

## Verification
- cargo fmt --all --check
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
