### PR TITLE
Refactor CLI command modules

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -1,0 +1,49 @@
+use clap::{Parser, Subcommand};
+
+use crate::shell::Shell;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "pv",
+    version,
+    about = "Laravel-first local desired-state control plane",
+    arg_required_else_help = true,
+    disable_help_subcommand = true
+)]
+pub(crate) struct Cli {
+    #[arg(long, global = true, help = "Disable colored output")]
+    pub(crate) no_color: bool,
+
+    #[command(subcommand)]
+    pub(crate) command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum Command {
+    #[command(name = "env", about = "Print shell integration code")]
+    Env(EnvArgs),
+
+    #[command(name = "completions", about = "Generate shell completions")]
+    Completions(CompletionsArgs),
+
+    #[command(name = "php:install", about = "Install a PHP track")]
+    PhpInstall(PhpInstallArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct EnvArgs {
+    #[arg(long, value_enum, help = "Shell syntax to generate")]
+    pub(crate) shell: Option<Shell>,
+}
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct CompletionsArgs {
+    #[arg(value_enum, help = "Shell to generate completions for")]
+    pub(crate) shell: Shell,
+}
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct PhpInstallArgs {
+    #[arg(value_name = "version", help = "PHP track to install")]
+    pub(crate) track: Option<String>,
+}

--- a/crates/cli/src/commands/completions.rs
+++ b/crates/cli/src/commands/completions.rs
@@ -1,0 +1,14 @@
+use std::io::Write;
+use std::process::ExitCode;
+
+use clap::CommandFactory;
+use clap_complete::generate;
+
+use crate::args::{Cli, CompletionsArgs};
+
+pub(crate) fn run(args: CompletionsArgs, stdout: &mut impl Write) -> ExitCode {
+    let mut command = Cli::command();
+    generate(args.shell.completion_shell(), &mut command, "pv", stdout);
+
+    ExitCode::SUCCESS
+}

--- a/crates/cli/src/commands/env.rs
+++ b/crates/cli/src/commands/env.rs
@@ -1,0 +1,31 @@
+use std::io::Write;
+use std::process::ExitCode;
+
+use crate::args::EnvArgs;
+use crate::environment::Environment;
+use crate::error::{CliError, ExecuteError};
+use crate::output::{Output, OutputMode};
+use crate::shell::Shell;
+
+pub(crate) fn run(
+    args: EnvArgs,
+    no_color: bool,
+    environment: &impl Environment,
+    stdout: &mut impl Write,
+) -> Result<ExitCode, ExecuteError> {
+    let shell = match args.shell {
+        Some(shell) => shell,
+        None => detect_shell(environment)?,
+    };
+    let mut output = Output::new(stdout, OutputMode::from_no_color(no_color));
+    output.line(shell.env_script())?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+fn detect_shell(environment: &impl Environment) -> Result<Shell, CliError> {
+    let shell_path = environment.var_os("SHELL").ok_or(CliError::MissingShell)?;
+    Shell::detect(&shell_path).ok_or_else(|| CliError::UnsupportedDetectedShell {
+        shell: shell_path.to_string_lossy().into_owned(),
+    })
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,0 +1,22 @@
+use std::io::Write;
+use std::process::ExitCode;
+
+use crate::args::{Cli, Command};
+use crate::environment::Environment;
+use crate::error::ExecuteError;
+
+mod completions;
+mod env;
+mod php;
+
+pub(crate) fn execute(
+    cli: Cli,
+    environment: &impl Environment,
+    stdout: &mut impl Write,
+) -> Result<ExitCode, ExecuteError> {
+    match cli.command {
+        Command::Env(args) => env::run(args, cli.no_color, environment, stdout),
+        Command::Completions(args) => Ok(completions::run(args, stdout)),
+        Command::PhpInstall(args) => php::install(args),
+    }
+}

--- a/crates/cli/src/commands/php.rs
+++ b/crates/cli/src/commands/php.rs
@@ -1,0 +1,13 @@
+use std::process::ExitCode;
+
+use crate::args::PhpInstallArgs;
+use crate::error::{CliError, ExecuteError};
+
+pub(crate) fn install(args: PhpInstallArgs) -> Result<ExitCode, ExecuteError> {
+    let _track = args.track;
+
+    Err(CliError::DeferredCommand {
+        command: "php:install",
+    }
+    .into())
+}

--- a/crates/cli/src/environment.rs
+++ b/crates/cli/src/environment.rs
@@ -1,0 +1,22 @@
+use std::ffi::OsString;
+
+pub trait Environment {
+    fn var_os(&self, key: &str) -> Option<OsString>;
+}
+
+#[derive(Debug, Default)]
+pub struct ProcessEnvironment;
+
+impl Environment for ProcessEnvironment {
+    fn var_os(&self, key: &str) -> Option<OsString> {
+        process_var_os(key)
+    }
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV environment helper owns direct process environment reads"
+)]
+fn process_var_os(key: &str) -> Option<OsString> {
+    std::env::var_os(key)
+}

--- a/crates/cli/src/error.rs
+++ b/crates/cli/src/error.rs
@@ -1,0 +1,26 @@
+use std::io;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error("could not detect the current shell; pass --shell zsh, --shell bash, or --shell fish")]
+    MissingShell,
+
+    #[error(
+        "detected unsupported shell `{shell}`; pass --shell zsh, --shell bash, or --shell fish"
+    )]
+    UnsupportedDetectedShell { shell: String },
+
+    #[error("{command} is routed, but Managed Resource installs start after PV-023")]
+    DeferredCommand { command: &'static str },
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum ExecuteError {
+    #[error(transparent)]
+    User(#[from] CliError),
+
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,207 +1,22 @@
-use std::ffi::{OsStr, OsString};
-use std::io::{self, Write};
-use std::path::Path;
+mod args;
+mod commands;
+mod environment;
+mod error;
+mod output;
+mod shell;
+
+use std::ffi::OsString;
+use std::io::Write;
 use std::process::ExitCode;
 
 use anyhow::Result;
+use args::Cli;
 use clap::error::ErrorKind;
-use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
-use clap_complete::generate;
-use thiserror::Error;
-
-#[derive(Debug, Parser)]
-#[command(
-    name = "pv",
-    version,
-    about = "Laravel-first local desired-state control plane",
-    arg_required_else_help = true,
-    disable_help_subcommand = true
-)]
-struct Cli {
-    #[arg(long, global = true, help = "Disable colored output")]
-    no_color: bool,
-
-    #[command(subcommand)]
-    command: Command,
-}
-
-#[derive(Debug, Subcommand)]
-enum Command {
-    #[command(name = "env", about = "Print shell integration code")]
-    Env(EnvArgs),
-
-    #[command(name = "completions", about = "Generate shell completions")]
-    Completions(CompletionsArgs),
-
-    #[command(name = "php:install", about = "Install a PHP track")]
-    PhpInstall(PhpInstallArgs),
-}
-
-#[derive(Debug, clap::Args)]
-struct EnvArgs {
-    #[arg(long, value_enum, help = "Shell syntax to generate")]
-    shell: Option<Shell>,
-}
-
-#[derive(Debug, clap::Args)]
-struct CompletionsArgs {
-    #[arg(value_enum, help = "Shell to generate completions for")]
-    shell: Shell,
-}
-
-#[derive(Debug, clap::Args)]
-struct PhpInstallArgs {
-    #[arg(value_name = "version", help = "PHP track to install")]
-    track: Option<String>,
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
-enum Shell {
-    Bash,
-    Fish,
-    Zsh,
-}
-
-impl Shell {
-    fn detect(shell_path: &OsStr) -> Option<Self> {
-        let file_name = Path::new(shell_path).file_name()?;
-        let shell_name = file_name.to_string_lossy();
-
-        match shell_name.as_ref() {
-            "bash" => Some(Self::Bash),
-            "fish" => Some(Self::Fish),
-            "zsh" => Some(Self::Zsh),
-            _ => None,
-        }
-    }
-
-    fn env_script(self) -> &'static str {
-        match self {
-            Self::Bash | Self::Zsh => POSIX_ENV_SCRIPT,
-            Self::Fish => FISH_ENV_SCRIPT,
-        }
-    }
-
-    fn completion_shell(self) -> clap_complete::Shell {
-        match self {
-            Self::Bash => clap_complete::Shell::Bash,
-            Self::Fish => clap_complete::Shell::Fish,
-            Self::Zsh => clap_complete::Shell::Zsh,
-        }
-    }
-}
-
-const POSIX_ENV_SCRIPT: &str = r#"pv_prepend_path() {
-  case ":$PATH:" in
-    *":$1:"*) ;;
-    *) PATH="$1${PATH:+:$PATH}" ;;
-  esac
-}
-
-export COMPOSER_HOME="$HOME/.pv/composer"
-export COMPOSER_CACHE_DIR="$HOME/.pv/composer/cache"
-pv_prepend_path "$HOME/.pv/composer/vendor/bin"
-pv_prepend_path "$HOME/.pv/bin"
-export PATH
-unset -f pv_prepend_path
-"#;
-
-const FISH_ENV_SCRIPT: &str = r#"set -gx COMPOSER_HOME "$HOME/.pv/composer"
-set -gx COMPOSER_CACHE_DIR "$HOME/.pv/composer/cache"
-contains -- "$HOME/.pv/composer/vendor/bin" $PATH; or set -gx PATH "$HOME/.pv/composer/vendor/bin" $PATH
-contains -- "$HOME/.pv/bin" $PATH; or set -gx PATH "$HOME/.pv/bin" $PATH
-"#;
-
-#[derive(Debug, Error)]
-pub enum CliError {
-    #[error("could not detect the current shell; pass --shell zsh, --shell bash, or --shell fish")]
-    MissingShell,
-
-    #[error(
-        "detected unsupported shell `{shell}`; pass --shell zsh, --shell bash, or --shell fish"
-    )]
-    UnsupportedDetectedShell { shell: String },
-
-    #[error("{command} is routed, but Managed Resource installs start after PV-023")]
-    DeferredCommand { command: &'static str },
-}
-
-#[derive(Debug, Error)]
-enum ExecuteError {
-    #[error(transparent)]
-    User(#[from] CliError),
-
-    #[error(transparent)]
-    Io(#[from] io::Error),
-}
-
-pub trait Environment {
-    fn var_os(&self, key: &str) -> Option<OsString>;
-}
-
-#[derive(Debug, Default)]
-pub struct ProcessEnvironment;
-
-impl Environment for ProcessEnvironment {
-    fn var_os(&self, key: &str) -> Option<OsString> {
-        process_var_os(key)
-    }
-}
-
-#[expect(
-    clippy::disallowed_methods,
-    reason = "PV environment helper owns direct process environment reads"
-)]
-fn process_var_os(key: &str) -> Option<OsString> {
-    std::env::var_os(key)
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct OutputMode {
-    no_color: bool,
-}
-
-impl OutputMode {
-    pub fn plain() -> Self {
-        Self { no_color: true }
-    }
-
-    pub fn no_color(self) -> bool {
-        self.no_color
-    }
-
-    fn from_inputs(args: &[OsString], environment: &impl Environment) -> Self {
-        Self {
-            no_color: args_have_no_color(args) || environment.var_os("NO_COLOR").is_some(),
-        }
-    }
-
-    fn error_label(self) -> &'static str {
-        "error"
-    }
-}
-
-pub struct Output<'writer, Writer> {
-    writer: &'writer mut Writer,
-    mode: OutputMode,
-}
-
-impl<'writer, Writer> Output<'writer, Writer>
-where
-    Writer: Write,
-{
-    pub fn new(writer: &'writer mut Writer, mode: OutputMode) -> Self {
-        Self { writer, mode }
-    }
-
-    pub fn line(&mut self, line: &str) -> std::io::Result<()> {
-        writeln!(self.writer, "{line}")
-    }
-
-    pub fn error(&mut self, message: &str) -> std::io::Result<()> {
-        writeln!(self.writer, "{}: {message}", self.mode.error_label())
-    }
-}
+use clap::{CommandFactory, FromArgMatches};
+pub use environment::{Environment, ProcessEnvironment};
+pub use error::CliError;
+use error::ExecuteError;
+pub use output::{Output, OutputMode};
 
 pub fn run<I, Argument>(
     args: I,
@@ -245,7 +60,7 @@ where
         }
     };
 
-    match execute(cli, environment, stdout) {
+    match commands::execute(cli, environment, stdout) {
         Ok(exit_code) => Ok(exit_code),
         Err(ExecuteError::User(error)) => {
             let mut output = Output::new(stderr, output_mode);
@@ -257,61 +72,12 @@ where
     }
 }
 
-fn execute(
-    cli: Cli,
-    environment: &impl Environment,
-    stdout: &mut impl Write,
-) -> Result<ExitCode, ExecuteError> {
-    match cli.command {
-        Command::Env(args) => {
-            let shell = match args.shell {
-                Some(shell) => shell,
-                None => detect_shell(environment)?,
-            };
-            let mut output = Output::new(
-                stdout,
-                OutputMode {
-                    no_color: cli.no_color,
-                },
-            );
-            output.line(shell.env_script())?;
-
-            Ok(ExitCode::SUCCESS)
-        }
-        Command::Completions(args) => {
-            let mut command = Cli::command();
-            generate(args.shell.completion_shell(), &mut command, "pv", stdout);
-
-            Ok(ExitCode::SUCCESS)
-        }
-        Command::PhpInstall(args) => {
-            let _track = args.track;
-
-            Err(CliError::DeferredCommand {
-                command: "php:install",
-            }
-            .into())
-        }
-    }
-}
-
-fn detect_shell(environment: &impl Environment) -> Result<Shell, CliError> {
-    let shell_path = environment.var_os("SHELL").ok_or(CliError::MissingShell)?;
-    Shell::detect(&shell_path).ok_or_else(|| CliError::UnsupportedDetectedShell {
-        shell: shell_path.to_string_lossy().into_owned(),
-    })
-}
-
 fn clap_color(output_mode: OutputMode) -> clap::ColorChoice {
-    if output_mode.no_color {
+    if output_mode.no_color() {
         clap::ColorChoice::Never
     } else {
         clap::ColorChoice::Auto
     }
-}
-
-fn args_have_no_color(args: &[OsString]) -> bool {
-    args.iter().any(|argument| argument == "--no-color")
 }
 
 fn exit_code(code: i32) -> ExitCode {

--- a/crates/cli/src/output.rs
+++ b/crates/cli/src/output.rs
@@ -1,0 +1,59 @@
+use std::ffi::OsString;
+use std::io::Write;
+
+use crate::environment::Environment;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct OutputMode {
+    no_color: bool,
+}
+
+impl OutputMode {
+    pub fn plain() -> Self {
+        Self { no_color: true }
+    }
+
+    pub fn no_color(self) -> bool {
+        self.no_color
+    }
+
+    pub(crate) fn from_inputs(args: &[OsString], environment: &impl Environment) -> Self {
+        Self {
+            no_color: args_have_no_color(args) || environment.var_os("NO_COLOR").is_some(),
+        }
+    }
+
+    pub(crate) fn from_no_color(no_color: bool) -> Self {
+        Self { no_color }
+    }
+
+    fn error_label(self) -> &'static str {
+        "error"
+    }
+}
+
+pub struct Output<'writer, Writer> {
+    writer: &'writer mut Writer,
+    mode: OutputMode,
+}
+
+impl<'writer, Writer> Output<'writer, Writer>
+where
+    Writer: Write,
+{
+    pub fn new(writer: &'writer mut Writer, mode: OutputMode) -> Self {
+        Self { writer, mode }
+    }
+
+    pub fn line(&mut self, line: &str) -> std::io::Result<()> {
+        writeln!(self.writer, "{line}")
+    }
+
+    pub fn error(&mut self, message: &str) -> std::io::Result<()> {
+        writeln!(self.writer, "{}: {message}", self.mode.error_label())
+    }
+}
+
+fn args_have_no_color(args: &[OsString]) -> bool {
+    args.iter().any(|argument| argument == "--no-color")
+}

--- a/crates/cli/src/shell.rs
+++ b/crates/cli/src/shell.rs
@@ -1,0 +1,61 @@
+use std::ffi::OsStr;
+use std::path::Path;
+
+use clap::ValueEnum;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum Shell {
+    Bash,
+    Fish,
+    Zsh,
+}
+
+impl Shell {
+    pub(crate) fn detect(shell_path: &OsStr) -> Option<Self> {
+        let file_name = Path::new(shell_path).file_name()?;
+        let shell_name = file_name.to_string_lossy();
+
+        match shell_name.as_ref() {
+            "bash" => Some(Self::Bash),
+            "fish" => Some(Self::Fish),
+            "zsh" => Some(Self::Zsh),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn env_script(self) -> &'static str {
+        match self {
+            Self::Bash | Self::Zsh => POSIX_ENV_SCRIPT,
+            Self::Fish => FISH_ENV_SCRIPT,
+        }
+    }
+
+    pub(crate) fn completion_shell(self) -> clap_complete::Shell {
+        match self {
+            Self::Bash => clap_complete::Shell::Bash,
+            Self::Fish => clap_complete::Shell::Fish,
+            Self::Zsh => clap_complete::Shell::Zsh,
+        }
+    }
+}
+
+const POSIX_ENV_SCRIPT: &str = r#"pv_prepend_path() {
+  case ":$PATH:" in
+    *":$1:"*) ;;
+    *) PATH="$1${PATH:+:$PATH}" ;;
+  esac
+}
+
+export COMPOSER_HOME="$HOME/.pv/composer"
+export COMPOSER_CACHE_DIR="$HOME/.pv/composer/cache"
+pv_prepend_path "$HOME/.pv/composer/vendor/bin"
+pv_prepend_path "$HOME/.pv/bin"
+export PATH
+unset -f pv_prepend_path
+"#;
+
+const FISH_ENV_SCRIPT: &str = r#"set -gx COMPOSER_HOME "$HOME/.pv/composer"
+set -gx COMPOSER_CACHE_DIR "$HOME/.pv/composer/cache"
+contains -- "$HOME/.pv/composer/vendor/bin" $PATH; or set -gx PATH "$HOME/.pv/composer/vendor/bin" $PATH
+contains -- "$HOME/.pv/bin" $PATH; or set -gx PATH "$HOME/.pv/bin" $PATH
+"#;

--- a/it/cli.rs
+++ b/it/cli.rs
@@ -32,6 +32,23 @@ fn run_pv_with_env(args: &[&str], env: &[(&str, &str)]) -> Result<CommandOutput>
     })
 }
 
+fn run_pv_without_env(args: &[&str], env: &[&str]) -> Result<CommandOutput> {
+    let mut command = Command::cargo_bin("pv")?;
+    command.env_remove("NO_COLOR");
+
+    for key in env {
+        command.env_remove(key);
+    }
+
+    let output = command.args(args).output()?;
+
+    Ok(CommandOutput {
+        code: status_code(output.status),
+        stdout: String::from_utf8(output.stdout)?,
+        stderr: String::from_utf8(output.stderr)?,
+    })
+}
+
 fn status_code(status: ExitStatus) -> Option<i32> {
     status.code()
 }
@@ -102,6 +119,24 @@ fn env_fish_output_is_idempotent() -> Result<()> {
 #[test]
 fn env_detects_shell_from_environment() -> Result<()> {
     let output = run_pv_with_env(&["env"], &[("SHELL", "/bin/zsh")])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn env_reports_missing_detected_shell() -> Result<()> {
+    let output = run_pv_without_env(&["env"], &["SHELL"])?;
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+
+#[test]
+fn env_reports_unsupported_detected_shell() -> Result<()> {
+    let output = run_pv_with_env(&["env"], &[("SHELL", "/bin/tcsh")])?;
 
     assert_debug_snapshot!(output);
 

--- a/it/snapshots/cli__env_reports_missing_detected_shell.snap
+++ b/it/snapshots/cli__env_reports_missing_detected_shell.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        1,
+    ),
+    stdout: "",
+    stderr: "error: could not detect the current shell; pass --shell zsh, --shell bash, or --shell fish\n",
+}

--- a/it/snapshots/cli__env_reports_unsupported_detected_shell.snap
+++ b/it/snapshots/cli__env_reports_unsupported_detected_shell.snap
@@ -1,0 +1,11 @@
+---
+source: it/cli.rs
+expression: output
+---
+CommandOutput {
+    code: Some(
+        1,
+    ),
+    stdout: "",
+    stderr: "error: detected unsupported shell `/bin/tcsh`; pass --shell zsh, --shell bash, or --shell fish\n",
+}


### PR DESCRIPTION
## Summary
- Split the CLI crate internals into focused modules for args, command handlers, shell integration, environment, output, and errors.
- Keep `lib.rs` focused on the public `run` boundary and clap error handling.
- Preserve the existing public command behavior and colon-style command surface.

## Test Plan
- `cargo fmt --all --check`
- `cargo nextest run --workspace -E 'binary(cli)'`\n- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`