### PR TITLE
Refactor state migrations and backups

### DIFF
--- a/crates/state/src/backup.rs
+++ b/crates/state/src/backup.rs
@@ -120,19 +120,39 @@ fn migration_backup_parts(name: &str) -> Option<(&str, usize)> {
     let stem = name
         .strip_prefix("pv.db.")
         .and_then(|name| name.strip_suffix(".bak"))?;
+    let timestamp = stem.get(..TIMESTAMP_LENGTH)?;
 
-    if stem.len() == TIMESTAMP_LENGTH {
-        return Some((stem, 0));
+    if !valid_backup_timestamp(timestamp) {
+        return None;
     }
 
-    if stem.len() > TIMESTAMP_LENGTH
-        && stem.as_bytes().get(TIMESTAMP_LENGTH) == Some(&b'-')
-        && let Ok(suffix) = stem[TIMESTAMP_LENGTH + 1..].parse::<usize>()
+    if stem.len() == TIMESTAMP_LENGTH {
+        return Some((timestamp, 0));
+    }
+
+    let suffix = stem.get(TIMESTAMP_LENGTH..)?.strip_prefix('-')?;
+
+    if let Ok(parsed_suffix) = suffix.parse::<usize>()
+        && parsed_suffix > 0
+        && parsed_suffix.to_string() == suffix
     {
-        return Some((&stem[..TIMESTAMP_LENGTH], suffix));
+        return Some((timestamp, parsed_suffix));
     }
 
     None
+}
+
+fn valid_backup_timestamp(timestamp: &str) -> bool {
+    const DATE_LENGTH: usize = "20260522".len();
+
+    timestamp.len() == "20260522-143012".len()
+        && timestamp.as_bytes().get(DATE_LENGTH) == Some(&b'-')
+        && timestamp[..DATE_LENGTH]
+            .bytes()
+            .all(|byte| byte.is_ascii_digit())
+        && timestamp[DATE_LENGTH + 1..]
+            .bytes()
+            .all(|byte| byte.is_ascii_digit())
 }
 
 fn backup_timestamp() -> Result<String, StateError> {

--- a/crates/state/src/backup.rs
+++ b/crates/state/src/backup.rs
@@ -1,0 +1,169 @@
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::{PvPaths, StateError, fs};
+
+const MIGRATION_BACKUP_RETENTION: usize = 5;
+
+pub(crate) fn database(
+    paths: &PvPaths,
+    create_backup: impl FnOnce(&Utf8Path) -> Result<(), StateError>,
+) -> Result<(), StateError> {
+    let backup_path = unique_backup_path(paths)?;
+
+    create_backup(&backup_path)?;
+    fs::secure_sensitive_file(&backup_path)?;
+    prune_migration_backups(paths)?;
+
+    Ok(())
+}
+
+fn unique_backup_path(paths: &PvPaths) -> Result<Utf8PathBuf, StateError> {
+    let timestamp = backup_timestamp()?;
+    let next_suffix = next_backup_suffix(paths, &timestamp)?;
+
+    for suffix in next_suffix..=999 {
+        let candidate = backup_path(paths, &timestamp, suffix);
+
+        if !fs::path_exists(&candidate) {
+            return Ok(candidate);
+        }
+    }
+
+    Err(StateError::BackupNameExhausted {
+        path: paths.root().to_path_buf(),
+    })
+}
+
+fn next_backup_suffix(paths: &PvPaths, timestamp: &str) -> Result<usize, StateError> {
+    let mut next_suffix = 0;
+
+    for backup in migration_backups(paths)? {
+        if let Some((backup_timestamp, suffix)) = migration_backup_parts(&backup)
+            && backup_timestamp == timestamp
+        {
+            next_suffix = next_suffix.max(suffix.saturating_add(1));
+        }
+    }
+
+    Ok(next_suffix)
+}
+
+fn backup_path(paths: &PvPaths, timestamp: &str, suffix: usize) -> Utf8PathBuf {
+    if suffix == 0 {
+        return paths.root().join(format!("pv.db.{timestamp}.bak"));
+    }
+
+    paths.root().join(format!("pv.db.{timestamp}-{suffix}.bak"))
+}
+
+pub(crate) fn migration_backups(paths: &PvPaths) -> Result<Vec<String>, StateError> {
+    let mut backups = Vec::new();
+    let entries = read_backup_directory(paths)?;
+
+    for entry in entries {
+        let entry =
+            entry.map_err(|source| StateError::filesystem(paths.root().to_path_buf(), source))?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+
+        if migration_backup_parts(&file_name).is_some() {
+            backups.push(file_name.into_owned());
+        }
+    }
+
+    sort_migration_backup_names(&mut backups);
+
+    Ok(backups)
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "PV backup helper owns migration backup directory traversal"
+)]
+type ReadDir = std::fs::ReadDir;
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV backup helper owns migration backup directory traversal"
+)]
+fn read_backup_directory(paths: &PvPaths) -> Result<ReadDir, StateError> {
+    std::fs::read_dir(paths.root())
+        .map_err(|source| StateError::filesystem(paths.root().to_path_buf(), source))
+}
+
+fn prune_migration_backups(paths: &PvPaths) -> Result<(), StateError> {
+    let backups = migration_backups(paths)?;
+    let prune_count = backups.len().saturating_sub(MIGRATION_BACKUP_RETENTION);
+
+    for backup in backups.iter().take(prune_count) {
+        fs::remove_file(&paths.root().join(backup))?;
+    }
+
+    Ok(())
+}
+
+fn sort_migration_backup_names(backups: &mut [String]) {
+    backups.sort_by(|left, right| {
+        migration_backup_sort_key(left).cmp(&migration_backup_sort_key(right))
+    });
+}
+
+fn migration_backup_sort_key(name: &str) -> (&str, usize) {
+    match migration_backup_parts(name) {
+        Some((timestamp, suffix)) => (timestamp, suffix),
+        None => (name, usize::MAX),
+    }
+}
+
+fn migration_backup_parts(name: &str) -> Option<(&str, usize)> {
+    const TIMESTAMP_LENGTH: usize = "20260522-143012".len();
+    let stem = name
+        .strip_prefix("pv.db.")
+        .and_then(|name| name.strip_suffix(".bak"))?;
+
+    if stem.len() == TIMESTAMP_LENGTH {
+        return Some((stem, 0));
+    }
+
+    if stem.len() > TIMESTAMP_LENGTH
+        && stem.as_bytes().get(TIMESTAMP_LENGTH) == Some(&b'-')
+        && let Ok(suffix) = stem[TIMESTAMP_LENGTH + 1..].parse::<usize>()
+    {
+        return Some((&stem[..TIMESTAMP_LENGTH], suffix));
+    }
+
+    None
+}
+
+fn backup_timestamp() -> Result<String, StateError> {
+    let format = time::macros::format_description!("[year][month][day]-[hour][minute][second]");
+
+    Ok(time::OffsetDateTime::now_utc().format(format)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sort_migration_backup_names;
+
+    #[test]
+    fn suffixed_backup_names_sort_after_the_unsuffixed_backup_from_the_same_second() {
+        let mut backups = vec![
+            "pv.db.20260523-120000-3.bak".to_string(),
+            "pv.db.20260523-120000.bak".to_string(),
+            "pv.db.20260523-120000-1.bak".to_string(),
+            "pv.db.20260523-120000-2.bak".to_string(),
+        ];
+
+        sort_migration_backup_names(&mut backups);
+
+        assert_eq!(
+            backups,
+            vec![
+                "pv.db.20260523-120000.bak".to_string(),
+                "pv.db.20260523-120000-1.bak".to_string(),
+                "pv.db.20260523-120000-2.bak".to_string(),
+                "pv.db.20260523-120000-3.bak".to_string(),
+            ]
+        );
+    }
+}

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -1,159 +1,10 @@
-use std::collections::BTreeSet;
 use std::time::Duration;
 
-use rusqlite::{Connection, Transaction, params};
+use rusqlite::{Connection, Transaction};
 
-use crate::{PvPaths, StateError, fs};
+use crate::{PvPaths, StateError, fs, migrations};
 
 const BUSY_TIMEOUT: Duration = Duration::from_millis(250);
-
-const CORE_SCHEMA_SQL: &str = r#"
-CREATE TABLE projects (
-    id TEXT PRIMARY KEY,
-    path TEXT NOT NULL UNIQUE,
-    primary_hostname TEXT NOT NULL UNIQUE,
-    config_path TEXT,
-    desired_php_track TEXT,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL
-);
-
-CREATE TABLE project_hostnames (
-    hostname TEXT PRIMARY KEY,
-    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    is_primary INTEGER NOT NULL CHECK (is_primary IN (0, 1)),
-    created_at TEXT NOT NULL
-);
-
-CREATE UNIQUE INDEX project_hostnames_one_primary_per_project
-ON project_hostnames(project_id)
-WHERE is_primary = 1;
-
-CREATE TRIGGER project_hostnames_primary_matches_project_insert
-BEFORE INSERT ON project_hostnames
-WHEN NEW.is_primary = 1
-AND (
-    SELECT primary_hostname
-    FROM projects
-    WHERE id = NEW.project_id
-) != NEW.hostname
-BEGIN
-    SELECT RAISE(ABORT, 'primary hostname must match project primary_hostname');
-END;
-
-CREATE TRIGGER project_hostnames_primary_matches_project_update
-BEFORE UPDATE OF hostname, project_id, is_primary ON project_hostnames
-WHEN NEW.is_primary = 1
-AND (
-    SELECT primary_hostname
-    FROM projects
-    WHERE id = NEW.project_id
-) != NEW.hostname
-BEGIN
-    SELECT RAISE(ABORT, 'primary hostname must match project primary_hostname');
-END;
-
-CREATE TRIGGER projects_primary_hostname_matches_hostname_update
-BEFORE UPDATE OF primary_hostname ON projects
-WHEN EXISTS (
-    SELECT 1
-    FROM project_hostnames
-    WHERE project_id = OLD.id
-    AND is_primary = 1
-)
-AND NOT EXISTS (
-    SELECT 1
-    FROM project_hostnames
-    WHERE project_id = OLD.id
-    AND is_primary = 1
-    AND hostname = NEW.primary_hostname
-)
-BEGIN
-    SELECT RAISE(ABORT, 'project primary_hostname must match primary project_hostname row');
-END;
-
-CREATE TRIGGER project_hostnames_primary_delete_requires_project_delete
-BEFORE DELETE ON project_hostnames
-WHEN OLD.is_primary = 1
-AND EXISTS (
-    SELECT 1
-    FROM projects
-    WHERE id = OLD.project_id
-)
-BEGIN
-    SELECT RAISE(ABORT, 'primary project_hostname rows are removed with their project');
-END;
-
-CREATE TABLE managed_resource_tracks (
-    resource_name TEXT NOT NULL,
-    track TEXT NOT NULL,
-    desired_state TEXT NOT NULL,
-    installed_version TEXT,
-    current_artifact_path TEXT,
-    usage_count INTEGER NOT NULL DEFAULT 0,
-    updated_at TEXT NOT NULL,
-    PRIMARY KEY (resource_name, track)
-);
-
-CREATE TABLE resource_allocations (
-    id TEXT PRIMARY KEY,
-    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    resource_name TEXT NOT NULL,
-    track TEXT NOT NULL,
-    allocation_name TEXT NOT NULL,
-    generated_name TEXT NOT NULL,
-    env_json TEXT NOT NULL DEFAULT '{}',
-    status TEXT NOT NULL,
-    created_at TEXT NOT NULL,
-    updated_at TEXT NOT NULL,
-    UNIQUE (project_id, resource_name, allocation_name),
-    UNIQUE (resource_name, track, generated_name)
-);
-
-CREATE TABLE ports (
-    name TEXT PRIMARY KEY,
-    port INTEGER NOT NULL UNIQUE,
-    owner_kind TEXT NOT NULL,
-    resource_name TEXT,
-    track TEXT,
-    updated_at TEXT NOT NULL
-);
-
-CREATE TABLE observed_states (
-    subject_kind TEXT NOT NULL,
-    subject_id TEXT NOT NULL,
-    status TEXT NOT NULL,
-    message TEXT,
-    observed_at TEXT NOT NULL,
-    PRIMARY KEY (subject_kind, subject_id)
-);
-
-CREATE TABLE jobs (
-    id TEXT PRIMARY KEY,
-    kind TEXT NOT NULL,
-    scope TEXT NOT NULL,
-    status TEXT NOT NULL,
-    started_at TEXT NOT NULL,
-    finished_at TEXT,
-    summary TEXT,
-    error TEXT
-);
-"#;
-
-const DEFAULT_MIGRATIONS: &[Migration] = &[Migration::new(1, "core_state_schema", CORE_SCHEMA_SQL)];
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Migration {
-    version: i64,
-    name: &'static str,
-    sql: &'static str,
-}
-
-impl Migration {
-    pub const fn new(version: i64, name: &'static str, sql: &'static str) -> Self {
-        Self { version, name, sql }
-    }
-}
 
 #[derive(Debug)]
 pub struct Database {
@@ -171,12 +22,12 @@ pub struct DatabaseInspection {
 
 impl Database {
     pub fn open(paths: &PvPaths) -> Result<Self, StateError> {
-        Self::open_with_migrations(paths, DEFAULT_MIGRATIONS)
+        Self::open_with_migrations(paths, migrations::DEFAULT_MIGRATIONS)
     }
 
     pub(crate) fn open_with_migrations(
         paths: &PvPaths,
-        migrations: &[Migration],
+        migrations: &[migrations::Migration],
     ) -> Result<Self, StateError> {
         fs::ensure_layout(paths)?;
 
@@ -184,7 +35,7 @@ impl Database {
         let mut connection = Connection::open(paths.db())?;
         fs::secure_database_files(paths)?;
         configure_connection(&connection)?;
-        run_migrations(paths, &mut connection, migrations, database_existed)?;
+        migrations::run(paths, &mut connection, migrations, database_existed)?;
         fs::secure_database_files(paths)?;
 
         Ok(Self { connection })
@@ -266,107 +117,4 @@ fn configure_connection(connection: &Connection) -> Result<(), StateError> {
     connection.pragma_update(None, "journal_mode", "WAL")?;
 
     Ok(())
-}
-
-fn run_migrations(
-    paths: &PvPaths,
-    connection: &mut Connection,
-    migrations: &[Migration],
-    database_existed: bool,
-) -> Result<(), StateError> {
-    let applied_versions = applied_versions(connection)?;
-    let pending = migrations
-        .iter()
-        .filter(|migration| !applied_versions.contains(&migration.version))
-        .copied()
-        .collect::<Vec<_>>();
-
-    if pending.is_empty() {
-        ensure_migration_table(connection)?;
-        return Ok(());
-    }
-
-    if database_existed {
-        backup_database(paths, connection)?;
-    }
-
-    let transaction = connection.transaction()?;
-    transaction.execute_batch(MIGRATION_TABLE_SQL)?;
-
-    for migration in pending {
-        apply_migration(&transaction, migration)?;
-    }
-
-    transaction.commit()?;
-
-    Ok(())
-}
-
-fn backup_database(paths: &PvPaths, connection: &Connection) -> Result<(), StateError> {
-    fs::backup_database(paths, |backup_path| {
-        connection.execute("VACUUM main INTO ?1", params![backup_path.as_str()])?;
-        Ok(())
-    })
-}
-
-fn ensure_migration_table(connection: &Connection) -> Result<(), StateError> {
-    connection.execute_batch(MIGRATION_TABLE_SQL)?;
-
-    Ok(())
-}
-
-const MIGRATION_TABLE_SQL: &str = r#"
-CREATE TABLE IF NOT EXISTS pv_migrations (
-    version INTEGER PRIMARY KEY,
-    name TEXT NOT NULL,
-    applied_at TEXT NOT NULL
-);
-"#;
-
-fn apply_migration(transaction: &Transaction<'_>, migration: Migration) -> Result<(), StateError> {
-    transaction
-        .execute_batch(migration.sql)
-        .map_err(|source| StateError::MigrationFailed {
-            version: migration.version,
-            name: migration.name,
-            source,
-        })?;
-    transaction
-        .execute(
-            "INSERT INTO pv_migrations (version, name, applied_at) VALUES (?1, ?2, datetime('now'))",
-            params![migration.version, migration.name],
-        )
-        .map_err(|source| StateError::MigrationFailed {
-            version: migration.version,
-            name: migration.name,
-            source,
-        })?;
-
-    Ok(())
-}
-
-fn applied_versions(connection: &Connection) -> Result<BTreeSet<i64>, StateError> {
-    if !table_exists(connection, "pv_migrations")? {
-        return Ok(BTreeSet::new());
-    }
-
-    let mut statement = connection.prepare("SELECT version FROM pv_migrations")?;
-    let rows = statement.query_map([], |row| row.get::<_, i64>(0))?;
-    let mut versions = BTreeSet::new();
-
-    for row in rows {
-        versions.insert(row?);
-    }
-
-    Ok(versions)
-}
-
-fn table_exists(connection: &Connection, table: &str) -> Result<bool, StateError> {
-    let count = connection.query_row(
-        "SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = ?1",
-        params![table],
-        |row| row.get::<_, i64>(0),
-    )?;
-
-    Ok(count > 0)
 }

--- a/crates/state/src/error.rs
+++ b/crates/state/src/error.rs
@@ -41,6 +41,13 @@ pub enum StateError {
         source: rusqlite::Error,
     },
 
+    #[error("migration {version} name mismatch: expected {expected}, found {actual}")]
+    MigrationNameMismatch {
+        version: i64,
+        expected: &'static str,
+        actual: String,
+    },
+
     #[error("time formatting failed: {0}")]
     TimeFormat(#[from] time::error::Format),
 

--- a/crates/state/src/fs.rs
+++ b/crates/state/src/fs.rs
@@ -1,10 +1,9 @@
 use camino::{Utf8Path, Utf8PathBuf};
 
-use crate::{PvPaths, StateError};
+use crate::{PvPaths, StateError, backup};
 
 const USER_ONLY_DIR_MODE: u32 = 0o700;
 const SENSITIVE_FILE_MODE: u32 = 0o600;
-const MIGRATION_BACKUP_RETENTION: usize = 5;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LayoutInspection {
@@ -47,7 +46,7 @@ pub fn inspect_layout(paths: &PvPaths) -> Result<Vec<LayoutInspection>, StateErr
 }
 
 pub fn migration_backups(paths: &PvPaths) -> Result<Vec<String>, StateError> {
-    migration_backup_names(paths)
+    backup::migration_backups(paths)
 }
 
 pub fn inspect_database_files(paths: &PvPaths) -> Result<Vec<DatabaseFileInspection>, StateError> {
@@ -70,60 +69,6 @@ pub fn inspect_database_files(paths: &PvPaths) -> Result<Vec<DatabaseFileInspect
     Ok(entries)
 }
 
-pub(crate) fn backup_database(
-    paths: &PvPaths,
-    create_backup: impl FnOnce(&Utf8Path) -> Result<(), StateError>,
-) -> Result<(), StateError> {
-    let backup_path = unique_backup_path(paths)?;
-
-    create_backup(&backup_path)?;
-    set_file_mode(&backup_path, SENSITIVE_FILE_MODE)?;
-    validate_mode(&backup_path, SENSITIVE_FILE_MODE)?;
-    validate_owner(&backup_path)?;
-    prune_migration_backups(paths)?;
-
-    Ok(())
-}
-
-fn unique_backup_path(paths: &PvPaths) -> Result<camino::Utf8PathBuf, StateError> {
-    let timestamp = backup_timestamp()?;
-    let next_suffix = next_backup_suffix(paths, &timestamp)?;
-
-    for suffix in next_suffix..=999 {
-        let candidate = backup_path(paths, &timestamp, suffix);
-
-        if !path_exists(&candidate) {
-            return Ok(candidate);
-        }
-    }
-
-    Err(StateError::BackupNameExhausted {
-        path: paths.root().to_path_buf(),
-    })
-}
-
-fn next_backup_suffix(paths: &PvPaths, timestamp: &str) -> Result<usize, StateError> {
-    let mut next_suffix = 0;
-
-    for backup in migration_backup_names(paths)? {
-        if let Some((backup_timestamp, suffix)) = migration_backup_parts(&backup)
-            && backup_timestamp == timestamp
-        {
-            next_suffix = next_suffix.max(suffix.saturating_add(1));
-        }
-    }
-
-    Ok(next_suffix)
-}
-
-fn backup_path(paths: &PvPaths, timestamp: &str, suffix: usize) -> Utf8PathBuf {
-    if suffix == 0 {
-        return paths.root().join(format!("pv.db.{timestamp}.bak"));
-    }
-
-    paths.root().join(format!("pv.db.{timestamp}-{suffix}.bak"))
-}
-
 pub(crate) fn database_exists(paths: &PvPaths) -> bool {
     path_exists(paths.db())
 }
@@ -134,12 +79,16 @@ pub(crate) fn secure_database_files(paths: &PvPaths) -> Result<(), StateError> {
             continue;
         }
 
-        set_file_mode(&path, SENSITIVE_FILE_MODE)?;
-        validate_mode(&path, SENSITIVE_FILE_MODE)?;
-        validate_owner(&path)?;
+        secure_sensitive_file(&path)?;
     }
 
     Ok(())
+}
+
+pub(crate) fn secure_sensitive_file(path: &Utf8Path) -> Result<(), StateError> {
+    set_file_mode(path, SENSITIVE_FILE_MODE)?;
+    validate_mode(path, SENSITIVE_FILE_MODE)?;
+    validate_owner(path)
 }
 
 fn database_files(paths: &PvPaths) -> [(&'static str, Utf8PathBuf); 3] {
@@ -157,17 +106,6 @@ fn ensure_user_dir(path: &Utf8Path) -> Result<(), StateError> {
     validate_owner(path)
 }
 
-fn prune_migration_backups(paths: &PvPaths) -> Result<(), StateError> {
-    let backups = migration_backup_names(paths)?;
-    let prune_count = backups.len().saturating_sub(MIGRATION_BACKUP_RETENTION);
-
-    for backup in backups.iter().take(prune_count) {
-        remove_file(&paths.root().join(backup))?;
-    }
-
-    Ok(())
-}
-
 #[expect(
     clippy::disallowed_methods,
     reason = "PV filesystem helper owns direct filesystem access"
@@ -181,7 +119,7 @@ fn create_dir_all(path: &Utf8Path) -> Result<(), StateError> {
     clippy::disallowed_methods,
     reason = "PV filesystem helper owns direct filesystem access"
 )]
-fn remove_file(path: &Utf8Path) -> Result<(), StateError> {
+pub(crate) fn remove_file(path: &Utf8Path) -> Result<(), StateError> {
     std::fs::remove_file(path).map_err(|source| StateError::filesystem(path.to_path_buf(), source))
 }
 
@@ -260,65 +198,7 @@ fn owner_uid(path: &Utf8Path) -> Result<u32, StateError> {
     Ok(metadata.uid())
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "PV filesystem helper owns direct filesystem access"
-)]
-fn migration_backup_names(paths: &PvPaths) -> Result<Vec<String>, StateError> {
-    let mut backups = Vec::new();
-    let entries = std::fs::read_dir(paths.root())
-        .map_err(|source| StateError::filesystem(paths.root().to_path_buf(), source))?;
-
-    for entry in entries {
-        let entry =
-            entry.map_err(|source| StateError::filesystem(paths.root().to_path_buf(), source))?;
-        let file_name = entry.file_name();
-        let file_name = file_name.to_string_lossy();
-
-        if file_name.starts_with("pv.db.") && file_name.ends_with(".bak") {
-            backups.push(file_name.into_owned());
-        }
-    }
-
-    sort_migration_backup_names(&mut backups);
-
-    Ok(backups)
-}
-
-fn sort_migration_backup_names(backups: &mut [String]) {
-    backups.sort_by(|left, right| {
-        migration_backup_sort_key(left).cmp(&migration_backup_sort_key(right))
-    });
-}
-
-fn migration_backup_sort_key(name: &str) -> (&str, usize) {
-    match migration_backup_parts(name) {
-        Some((timestamp, suffix)) => (timestamp, suffix),
-        None => (name, usize::MAX),
-    }
-}
-
-fn migration_backup_parts(name: &str) -> Option<(&str, usize)> {
-    const TIMESTAMP_LENGTH: usize = "20260522-143012".len();
-    let stem = name
-        .strip_prefix("pv.db.")
-        .and_then(|name| name.strip_suffix(".bak"))?;
-
-    if stem.len() == TIMESTAMP_LENGTH {
-        return Some((stem, 0));
-    }
-
-    if stem.len() > TIMESTAMP_LENGTH
-        && stem.as_bytes().get(TIMESTAMP_LENGTH) == Some(&b'-')
-        && let Ok(suffix) = stem[TIMESTAMP_LENGTH + 1..].parse::<usize>()
-    {
-        return Some((&stem[..TIMESTAMP_LENGTH], suffix));
-    }
-
-    None
-}
-
-fn path_exists(path: &Utf8Path) -> bool {
+pub(crate) fn path_exists(path: &Utf8Path) -> bool {
     path.exists()
 }
 
@@ -333,12 +213,6 @@ fn display_path(paths: &PvPaths, path: &Utf8Path) -> String {
     }
 }
 
-fn backup_timestamp() -> Result<String, StateError> {
-    let format = time::macros::format_description!("[year][month][day]-[hour][minute][second]");
-
-    Ok(time::OffsetDateTime::now_utc().format(format)?)
-}
-
 #[cfg(unix)]
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
@@ -349,30 +223,3 @@ fn current_uid() -> u32 {
 
 #[cfg(not(unix))]
 compile_error!("PV v1 targets macOS and requires Unix filesystem permissions");
-
-#[cfg(test)]
-mod tests {
-    use super::sort_migration_backup_names;
-
-    #[test]
-    fn suffixed_backup_names_sort_after_the_unsuffixed_backup_from_the_same_second() {
-        let mut backups = vec![
-            "pv.db.20260523-120000-3.bak".to_string(),
-            "pv.db.20260523-120000.bak".to_string(),
-            "pv.db.20260523-120000-1.bak".to_string(),
-            "pv.db.20260523-120000-2.bak".to_string(),
-        ];
-
-        sort_migration_backup_names(&mut backups);
-
-        assert_eq!(
-            backups,
-            vec![
-                "pv.db.20260523-120000.bak".to_string(),
-                "pv.db.20260523-120000-1.bak".to_string(),
-                "pv.db.20260523-120000-2.bak".to_string(),
-                "pv.db.20260523-120000-3.bak".to_string(),
-            ]
-        );
-    }
-}

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -1,6 +1,8 @@
+mod backup;
 mod database;
 mod error;
 pub mod fs;
+mod migrations;
 mod paths;
 
 pub use database::{Database, DatabaseInspection};
@@ -11,7 +13,7 @@ pub use paths::{PathSummaryEntry, PvPaths};
 pub mod testing {
     use rusqlite::Transaction;
 
-    pub use crate::database::Migration;
+    pub use crate::migrations::Migration;
     use crate::{Database, PvPaths, StateError};
 
     pub fn open_with_migrations(

--- a/crates/state/src/migrations.rs
+++ b/crates/state/src/migrations.rs
@@ -1,0 +1,122 @@
+use std::collections::BTreeSet;
+
+use rusqlite::{Connection, Transaction, params};
+
+use crate::{PvPaths, StateError, backup};
+
+const CORE_SCHEMA_SQL: &str = include_str!("sql/001_core_state_schema.sql");
+
+pub(crate) const DEFAULT_MIGRATIONS: &[Migration] =
+    &[Migration::new(1, "core_state_schema", CORE_SCHEMA_SQL)];
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Migration {
+    version: i64,
+    name: &'static str,
+    sql: &'static str,
+}
+
+impl Migration {
+    pub const fn new(version: i64, name: &'static str, sql: &'static str) -> Self {
+        Self { version, name, sql }
+    }
+}
+
+pub(crate) fn run(
+    paths: &PvPaths,
+    connection: &mut Connection,
+    migrations: &[Migration],
+    database_existed: bool,
+) -> Result<(), StateError> {
+    let applied_versions = applied_versions(connection)?;
+    let pending = migrations
+        .iter()
+        .filter(|migration| !applied_versions.contains(&migration.version))
+        .copied()
+        .collect::<Vec<_>>();
+
+    if pending.is_empty() {
+        ensure_migration_table(connection)?;
+        return Ok(());
+    }
+
+    if database_existed {
+        backup::database(paths, |backup_path| {
+            connection.execute("VACUUM main INTO ?1", params![backup_path.as_str()])?;
+            Ok(())
+        })?;
+    }
+
+    let transaction = connection.transaction()?;
+    transaction.execute_batch(MIGRATION_TABLE_SQL)?;
+
+    for migration in pending {
+        apply_migration(&transaction, migration)?;
+    }
+
+    transaction.commit()?;
+
+    Ok(())
+}
+
+fn ensure_migration_table(connection: &Connection) -> Result<(), StateError> {
+    connection.execute_batch(MIGRATION_TABLE_SQL)?;
+
+    Ok(())
+}
+
+const MIGRATION_TABLE_SQL: &str = r#"
+CREATE TABLE IF NOT EXISTS pv_migrations (
+    version INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    applied_at TEXT NOT NULL
+);
+"#;
+
+fn apply_migration(transaction: &Transaction<'_>, migration: Migration) -> Result<(), StateError> {
+    transaction
+        .execute_batch(migration.sql)
+        .map_err(|source| StateError::MigrationFailed {
+            version: migration.version,
+            name: migration.name,
+            source,
+        })?;
+    transaction
+        .execute(
+            "INSERT INTO pv_migrations (version, name, applied_at) VALUES (?1, ?2, datetime('now'))",
+            params![migration.version, migration.name],
+        )
+        .map_err(|source| StateError::MigrationFailed {
+            version: migration.version,
+            name: migration.name,
+            source,
+        })?;
+
+    Ok(())
+}
+
+fn applied_versions(connection: &Connection) -> Result<BTreeSet<i64>, StateError> {
+    if !table_exists(connection, "pv_migrations")? {
+        return Ok(BTreeSet::new());
+    }
+
+    let mut statement = connection.prepare("SELECT version FROM pv_migrations")?;
+    let rows = statement.query_map([], |row| row.get::<_, i64>(0))?;
+    let mut versions = BTreeSet::new();
+
+    for row in rows {
+        versions.insert(row?);
+    }
+
+    Ok(versions)
+}
+
+fn table_exists(connection: &Connection, table: &str) -> Result<bool, StateError> {
+    let count = connection.query_row(
+        "SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = ?1",
+        params![table],
+        |row| row.get::<_, i64>(0),
+    )?;
+
+    Ok(count > 0)
+}

--- a/crates/state/src/migrations.rs
+++ b/crates/state/src/migrations.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 use rusqlite::{Connection, Transaction, params};
 
@@ -28,10 +28,11 @@ pub(crate) fn run(
     migrations: &[Migration],
     database_existed: bool,
 ) -> Result<(), StateError> {
-    let applied_versions = applied_versions(connection)?;
+    let applied_migrations = applied_migrations(connection)?;
+    validate_applied_migration_names(&applied_migrations, migrations)?;
     let pending = migrations
         .iter()
-        .filter(|migration| !applied_versions.contains(&migration.version))
+        .filter(|migration| !applied_migrations.contains_key(&migration.version))
         .copied()
         .collect::<Vec<_>>();
 
@@ -55,6 +56,25 @@ pub(crate) fn run(
     }
 
     transaction.commit()?;
+
+    Ok(())
+}
+
+fn validate_applied_migration_names(
+    applied_migrations: &BTreeMap<i64, String>,
+    migrations: &[Migration],
+) -> Result<(), StateError> {
+    for migration in migrations {
+        if let Some(actual) = applied_migrations.get(&migration.version)
+            && actual.as_str() != migration.name
+        {
+            return Err(StateError::MigrationNameMismatch {
+                version: migration.version,
+                expected: migration.name,
+                actual: actual.clone(),
+            });
+        }
+    }
 
     Ok(())
 }
@@ -95,20 +115,23 @@ fn apply_migration(transaction: &Transaction<'_>, migration: Migration) -> Resul
     Ok(())
 }
 
-fn applied_versions(connection: &Connection) -> Result<BTreeSet<i64>, StateError> {
+fn applied_migrations(connection: &Connection) -> Result<BTreeMap<i64, String>, StateError> {
     if !table_exists(connection, "pv_migrations")? {
-        return Ok(BTreeSet::new());
+        return Ok(BTreeMap::new());
     }
 
-    let mut statement = connection.prepare("SELECT version FROM pv_migrations")?;
-    let rows = statement.query_map([], |row| row.get::<_, i64>(0))?;
-    let mut versions = BTreeSet::new();
+    let mut statement = connection.prepare("SELECT version, name FROM pv_migrations")?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+    })?;
+    let mut migrations = BTreeMap::new();
 
     for row in rows {
-        versions.insert(row?);
+        let (version, name) = row?;
+        migrations.insert(version, name);
     }
 
-    Ok(versions)
+    Ok(migrations)
 }
 
 fn table_exists(connection: &Connection, table: &str) -> Result<bool, StateError> {

--- a/crates/state/src/paths.rs
+++ b/crates/state/src/paths.rs
@@ -23,6 +23,13 @@ pub struct PathSummaryEntry {
     pub path: String,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+struct PathEntry<'path> {
+    name: &'static str,
+    path: &'path Utf8Path,
+    layout_directory: bool,
+}
+
 impl PvPaths {
     pub fn for_home(home: impl AsRef<Utf8Path>) -> Self {
         let home = home.as_ref().to_path_buf();
@@ -96,64 +103,79 @@ impl PvPaths {
     }
 
     pub fn layout_directories(&self) -> Vec<(&'static str, &Utf8Path)> {
-        vec![
-            ("root", self.root()),
-            ("bin", self.bin()),
-            ("run", self.run()),
-            ("logs", self.logs()),
-            ("downloads", self.downloads()),
-            ("config", self.config()),
-            ("certificates", self.certificates()),
-            ("composer", self.composer()),
-            ("resources", self.resources()),
-        ]
+        self.path_entries()
+            .into_iter()
+            .filter(|entry| entry.layout_directory)
+            .map(|entry| (entry.name, entry.path))
+            .collect()
     }
 
     pub fn summary(&self) -> Vec<PathSummaryEntry> {
-        vec![
-            PathSummaryEntry {
+        self.path_entries()
+            .into_iter()
+            .map(|entry| PathSummaryEntry {
+                name: entry.name,
+                path: entry.path.to_string(),
+            })
+            .collect()
+    }
+
+    fn path_entries(&self) -> [PathEntry<'_>; 11] {
+        [
+            PathEntry {
                 name: "home",
-                path: self.home().to_string(),
+                path: self.home(),
+                layout_directory: false,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "root",
-                path: self.root().to_string(),
+                path: self.root(),
+                layout_directory: true,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "db",
-                path: self.db().to_string(),
+                path: self.db(),
+                layout_directory: false,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "bin",
-                path: self.bin().to_string(),
+                path: self.bin(),
+                layout_directory: true,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "run",
-                path: self.run().to_string(),
+                path: self.run(),
+                layout_directory: true,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "logs",
-                path: self.logs().to_string(),
+                path: self.logs(),
+                layout_directory: true,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "downloads",
-                path: self.downloads().to_string(),
+                path: self.downloads(),
+                layout_directory: true,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "config",
-                path: self.config().to_string(),
+                path: self.config(),
+                layout_directory: true,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "certificates",
-                path: self.certificates().to_string(),
+                path: self.certificates(),
+                layout_directory: true,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "composer",
-                path: self.composer().to_string(),
+                path: self.composer(),
+                layout_directory: true,
             },
-            PathSummaryEntry {
+            PathEntry {
                 name: "resources",
-                path: self.resources().to_string(),
+                path: self.resources(),
+                layout_directory: true,
             },
         ]
     }

--- a/crates/state/src/sql/001_core_state_schema.sql
+++ b/crates/state/src/sql/001_core_state_schema.sql
@@ -1,0 +1,130 @@
+CREATE TABLE projects (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL UNIQUE,
+    primary_hostname TEXT NOT NULL UNIQUE,
+    config_path TEXT,
+    desired_php_track TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE project_hostnames (
+    hostname TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    is_primary INTEGER NOT NULL CHECK (is_primary IN (0, 1)),
+    created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX project_hostnames_one_primary_per_project
+ON project_hostnames(project_id)
+WHERE is_primary = 1;
+
+CREATE TRIGGER project_hostnames_primary_matches_project_insert
+BEFORE INSERT ON project_hostnames
+WHEN NEW.is_primary = 1
+AND (
+    SELECT primary_hostname
+    FROM projects
+    WHERE id = NEW.project_id
+) != NEW.hostname
+BEGIN
+    SELECT RAISE(ABORT, 'primary hostname must match project primary_hostname');
+END;
+
+CREATE TRIGGER project_hostnames_primary_matches_project_update
+BEFORE UPDATE OF hostname, project_id, is_primary ON project_hostnames
+WHEN NEW.is_primary = 1
+AND (
+    SELECT primary_hostname
+    FROM projects
+    WHERE id = NEW.project_id
+) != NEW.hostname
+BEGIN
+    SELECT RAISE(ABORT, 'primary hostname must match project primary_hostname');
+END;
+
+CREATE TRIGGER projects_primary_hostname_matches_hostname_update
+BEFORE UPDATE OF primary_hostname ON projects
+WHEN EXISTS (
+    SELECT 1
+    FROM project_hostnames
+    WHERE project_id = OLD.id
+    AND is_primary = 1
+)
+AND NOT EXISTS (
+    SELECT 1
+    FROM project_hostnames
+    WHERE project_id = OLD.id
+    AND is_primary = 1
+    AND hostname = NEW.primary_hostname
+)
+BEGIN
+    SELECT RAISE(ABORT, 'project primary_hostname must match primary project_hostname row');
+END;
+
+CREATE TRIGGER project_hostnames_primary_delete_requires_project_delete
+BEFORE DELETE ON project_hostnames
+WHEN OLD.is_primary = 1
+AND EXISTS (
+    SELECT 1
+    FROM projects
+    WHERE id = OLD.project_id
+)
+BEGIN
+    SELECT RAISE(ABORT, 'primary project_hostname rows are removed with their project');
+END;
+
+CREATE TABLE managed_resource_tracks (
+    resource_name TEXT NOT NULL,
+    track TEXT NOT NULL,
+    desired_state TEXT NOT NULL,
+    installed_version TEXT,
+    current_artifact_path TEXT,
+    usage_count INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (resource_name, track)
+);
+
+CREATE TABLE resource_allocations (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    resource_name TEXT NOT NULL,
+    track TEXT NOT NULL,
+    allocation_name TEXT NOT NULL,
+    generated_name TEXT NOT NULL,
+    env_json TEXT NOT NULL DEFAULT '{}',
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (project_id, resource_name, allocation_name),
+    UNIQUE (resource_name, track, generated_name)
+);
+
+CREATE TABLE ports (
+    name TEXT PRIMARY KEY,
+    port INTEGER NOT NULL UNIQUE,
+    owner_kind TEXT NOT NULL,
+    resource_name TEXT,
+    track TEXT,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE observed_states (
+    subject_kind TEXT NOT NULL,
+    subject_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    message TEXT,
+    observed_at TEXT NOT NULL,
+    PRIMARY KEY (subject_kind, subject_id)
+);
+
+CREATE TABLE jobs (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    status TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    summary TEXT,
+    error TEXT
+);

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -147,6 +147,12 @@ fn migration_backup_retention_keeps_the_latest_five_backups() -> Result<()> {
     let tempdir = tempdir()?;
     let paths = PvPaths::for_home(tempdir.path().join("home"));
     state::fs::ensure_layout(&paths)?;
+    let manual_backup_path = paths.root().join("pv.db.00000000-manual.bak");
+
+    {
+        let _manual_backup = Connection::open(&manual_backup_path)?;
+    }
+
     let migrations = [
         Migration::new(1, "m1", "CREATE TABLE m1 (id TEXT PRIMARY KEY);"),
         Migration::new(2, "m2", "CREATE TABLE m2 (id TEXT PRIMARY KEY);"),
@@ -164,6 +170,7 @@ fn migration_backup_retention_keeps_the_latest_five_backups() -> Result<()> {
 
     let backup_table_counts = migration_backup_table_counts(&paths)?;
 
+    assert!(manual_backup_path.exists());
     assert_debug_snapshot!(backup_table_counts);
 
     Ok(())
@@ -174,16 +181,22 @@ fn migration_backups_ignore_non_pv_backup_files() -> Result<()> {
     let tempdir = tempdir()?;
     let paths = PvPaths::for_home(tempdir.path().join("home"));
     state::fs::ensure_layout(&paths)?;
-    let manual_backup_name = "pv.db.manual.bak";
-    let manual_backup_path = paths.root().join(manual_backup_name);
+    let manual_backup_names = [
+        "pv.db.manual.bak",
+        "pv.db.00000000-manual.bak",
+        "pv.db.not-a-timestamp.bak",
+    ];
 
-    {
+    for manual_backup_name in manual_backup_names {
+        let manual_backup_path = paths.root().join(manual_backup_name);
         let _manual_backup = Connection::open(&manual_backup_path)?;
     }
 
     let backups = state::fs::migration_backups(&paths)?;
 
-    assert!(!backups.contains(&manual_backup_name.to_string()));
+    for manual_backup_name in manual_backup_names {
+        assert!(!backups.contains(&manual_backup_name.to_string()));
+    }
 
     Ok(())
 }
@@ -238,6 +251,37 @@ fn pending_migrations_roll_back_as_one_batch_when_later_migration_fails() -> Res
     assert_debug_snapshot!((
         table_exists(&connection, "second_table")?,
         applied_migration_count(&connection)?
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn applied_migration_name_mismatches_are_reported() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+    let first_migration = [Migration::new(
+        1,
+        "first",
+        "CREATE TABLE first_table (id TEXT PRIMARY KEY);",
+    )];
+    state::testing::open_with_migrations(&paths, &first_migration)?;
+
+    let renamed_migration = [Migration::new(
+        1,
+        "renamed",
+        "CREATE TABLE first_table (id TEXT PRIMARY KEY);",
+    )];
+    let result = state::testing::open_with_migrations(&paths, &renamed_migration);
+
+    assert!(matches!(
+        result,
+        Err(StateError::MigrationNameMismatch {
+            version: 1,
+            expected: "renamed",
+            actual,
+        }) if actual == "first"
     ));
 
     Ok(())

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -169,6 +169,25 @@ fn migration_backup_retention_keeps_the_latest_five_backups() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn migration_backups_ignore_non_pv_backup_files() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+    let manual_backup_name = "pv.db.manual.bak";
+    let manual_backup_path = paths.root().join(manual_backup_name);
+
+    {
+        let _manual_backup = Connection::open(&manual_backup_path)?;
+    }
+
+    let backups = state::fs::migration_backups(&paths)?;
+
+    assert!(!backups.contains(&manual_backup_name.to_string()));
+
+    Ok(())
+}
+
 fn with_normalized_backup_names(assertion: impl FnOnce() -> Result<()>) -> Result<()> {
     let mut settings = Settings::clone_current();
     settings.add_filter(


### PR DESCRIPTION
## Summary
- Move the core state schema into an embedded SQL migration file.
- Extract migration execution and migration backup retention into focused state modules.
- Ignore non-PV backup files when listing/pruning migration backups.

## Test Plan
- `cargo fmt --all --check`
- `cargo nextest run --workspace -E 'binary(state)'`\n- `cargo nextest run --workspace -E 'binary(state_foundation)'`\n- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`