### PR TITLE
feat: add reconciliation supervisor foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "camino-tempfile",
  "futures-util",
  "insta",
+ "rusqlite",
  "rustix",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,13 +233,16 @@ name = "daemon"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "camino",
  "camino-tempfile",
  "futures-util",
  "insta",
+ "rustix",
  "serde",
  "serde_json",
  "state",
  "thiserror",
+ "time",
  "tokio",
  "tokio-util",
 ]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -24,5 +24,6 @@ anyhow = { workspace = true }
 camino = { workspace = true }
 camino-tempfile = { workspace = true }
 insta = { workspace = true }
+rusqlite = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -8,16 +8,20 @@ publish.workspace = true
 workspace = true
 
 [dependencies]
+camino = { workspace = true }
 futures-util = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+rustix = { workspace = true }
 state = { path = "../state" }
 thiserror = { workspace = true }
+time = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+camino = { workspace = true }
 camino-tempfile = { workspace = true }
 insta = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -25,4 +25,13 @@ pub enum DaemonError {
 
     #[error("daemon task failed: {0}")]
     Task(#[from] JoinError),
+
+    #[error("process `{name}` started without an observable pid")]
+    MissingProcessId { name: String },
+
+    #[error("readiness check `{check}` timed out after {timeout_ms}ms")]
+    ReadinessTimedOut { check: String, timeout_ms: u128 },
+
+    #[error("time formatting failed: {0}")]
+    TimeFormat(#[from] time::error::Format),
 }

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -29,8 +29,12 @@ pub enum DaemonError {
     #[error("process `{name}` started without an observable pid")]
     MissingProcessId { name: String },
 
-    #[error("readiness check `{check}` timed out after {timeout_ms}ms")]
-    ReadinessTimedOut { check: String, timeout_ms: u128 },
+    #[error("readiness check `{check}` timed out after {timeout_ms}ms; last error: {last_error:?}")]
+    ReadinessTimedOut {
+        check: String,
+        timeout_ms: u128,
+        last_error: Option<String>,
+    },
 
     #[error("time formatting failed: {0}")]
     TimeFormat(#[from] time::error::Format),

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -9,7 +9,7 @@ use state::{Database, PvPaths};
 pub(crate) async fn run_job(
     paths: PvPaths,
     queue: ReconciliationQueue,
-    mut transport: DaemonTransport<LocalStream>,
+    transport: DaemonTransport<LocalStream>,
     kind: &str,
     scope: &str,
 ) -> Result<(), DaemonError> {
@@ -17,29 +17,159 @@ pub(crate) async fn run_job(
     if kind == "reconcile"
         && let Ok(parsed_scope) = parsed_scope
     {
-        let EnqueueResult::Queued(queued) = queue.enqueue(parsed_scope).await else {
-            return write_line(
+        return run_reconciliation_job(paths, queue, transport, parsed_scope).await;
+    }
+
+    run_started_job(paths, transport, kind, scope).await
+}
+
+pub(crate) async fn run_background_reconciliation_job(
+    paths: PvPaths,
+    queue: ReconciliationQueue,
+    scope: ReconciliationScope,
+) -> Result<(), DaemonError> {
+    let scope_text = scope.to_string();
+    let result = queue.enqueue(scope, || start_reconciliation_job(&paths, &scope_text))?;
+    let EnqueueResult::Queued(queued) = result else {
+        return Ok(());
+    };
+    let running = queued.wait_for_turn().await;
+    let job_id = running.job_id().to_string();
+    let result = complete_stub_reconciliation(&paths, &job_id);
+
+    running.finish();
+
+    result.map(|_summary| ())
+}
+
+async fn run_reconciliation_job(
+    paths: PvPaths,
+    queue: ReconciliationQueue,
+    mut transport: DaemonTransport<LocalStream>,
+    scope: ReconciliationScope,
+) -> Result<(), DaemonError> {
+    let scope_text = scope.to_string();
+    let result = queue.enqueue(scope, || start_reconciliation_job(&paths, &scope_text))?;
+
+    match result {
+        EnqueueResult::Queued(queued) => {
+            let job_id = queued.job_id().to_string();
+            let stream_is_open = write_line(
+                &mut transport,
+                &DaemonResponse {
+                    line_type: "response",
+                    protocol_version: PROTOCOL_VERSION,
+                    status: ResponseStatus::Accepted,
+                    message: "job accepted",
+                    job_id: Some(&job_id),
+                },
+            )
+            .await
+            .is_ok();
+            let running = queued.wait_for_turn().await;
+            let result = stream_started_reconciliation_job(
+                paths,
+                transport,
+                stream_is_open,
+                running.job_id(),
+                &scope_text,
+            )
+            .await;
+
+            running.finish();
+
+            result
+        }
+        EnqueueResult::Coalesced(job) => {
+            write_line(
                 &mut transport,
                 &DaemonResponse {
                     line_type: "response",
                     protocol_version: PROTOCOL_VERSION,
                     status: ResponseStatus::Accepted,
                     message: "reconciliation already queued or running",
-                    job_id: None,
+                    job_id: Some(job.job_id()),
                 },
             )
-            .await;
-        };
-        let running = queued.wait_for_turn().await;
-        let active_scope = running.scope().to_string();
-        let result = run_started_job(paths, transport, kind, &active_scope).await;
+            .await
+        }
+    }
+}
 
-        running.finish().await;
+async fn stream_started_reconciliation_job(
+    paths: PvPaths,
+    mut transport: DaemonTransport<LocalStream>,
+    stream_is_open: bool,
+    job_id: &str,
+    scope: &str,
+) -> Result<(), DaemonError> {
+    let stream_is_open = stream_is_open
+        && async {
+            write_line(
+                &mut transport,
+                &DaemonEvent::JobStarted {
+                    job_id,
+                    kind: "reconcile",
+                    scope,
+                },
+            )
+            .await?;
+            write_line(
+                &mut transport,
+                &DaemonEvent::Log {
+                    job_id,
+                    message: "stub job started",
+                },
+            )
+            .await?;
 
-        return result;
+            Ok::<(), DaemonError>(())
+        }
+        .await
+        .is_ok();
+
+    let summary = complete_stub_reconciliation(&paths, job_id)?;
+    if !stream_is_open {
+        return Ok(());
     }
 
-    run_started_job(paths, transport, kind, scope).await
+    async {
+        write_line(
+            &mut transport,
+            &DaemonEvent::Progress {
+                job_id,
+                message: "stub job completed without reconciliation work",
+            },
+        )
+        .await?;
+        write_line(
+            &mut transport,
+            &DaemonEvent::JobCompleted { job_id, summary },
+        )
+        .await?;
+
+        Ok::<(), DaemonError>(())
+    }
+    .await
+}
+
+fn start_reconciliation_job(paths: &PvPaths, scope: &str) -> Result<String, DaemonError> {
+    let mut database = Database::open(paths)?;
+    let job = database.start_job("reconcile", scope)?;
+
+    Ok(job.id)
+}
+
+fn complete_stub_reconciliation(
+    paths: &PvPaths,
+    job_id: &str,
+) -> Result<&'static str, DaemonError> {
+    let mut database = Database::open(paths)?;
+    let summary = "stub job completed";
+
+    database.complete_job(job_id, summary)?;
+
+    Ok(summary)
 }
 
 async fn run_started_job(

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -4,7 +4,7 @@ use crate::protocol::{
     DaemonEvent, DaemonResponse, DaemonTransport, PROTOCOL_VERSION, ResponseStatus, write_line,
 };
 use crate::reconciliation::{EnqueueResult, ReconciliationQueue, ReconciliationScope};
-use state::{Database, PvPaths};
+use state::{Database, JobStatus, PvPaths};
 use tokio::io::AsyncWrite;
 
 pub(crate) async fn run_job(
@@ -32,8 +32,7 @@ pub(crate) async fn run_background_reconciliation_job(
     queue: ReconciliationQueue,
     scope: ReconciliationScope,
 ) -> Result<(), DaemonError> {
-    let scope_text = scope.to_string();
-    let result = queue.enqueue(scope, || start_reconciliation_job(&paths, &scope_text))?;
+    let result = enqueue_reconciliation_job(&paths, &queue, scope)?;
     let EnqueueResult::Queued(queued) = result else {
         return Ok(());
     };
@@ -55,7 +54,7 @@ async fn run_reconciliation_job(
     scope: ReconciliationScope,
 ) -> Result<(), DaemonError> {
     let scope_text = scope.to_string();
-    let result = queue.enqueue(scope, || start_reconciliation_job(&paths, &scope_text))?;
+    let result = enqueue_reconciliation_job(&paths, &queue, scope)?;
 
     match result {
         EnqueueResult::Queued(queued) => {
@@ -84,9 +83,7 @@ async fn run_reconciliation_job(
 
             running.finish();
 
-            accepted_result?;
-
-            result
+            foreground_reconciliation_result(accepted_result, result)
         }
         EnqueueResult::Coalesced(job) => {
             write_line(
@@ -102,6 +99,31 @@ async fn run_reconciliation_job(
             .await
         }
     }
+}
+
+fn enqueue_reconciliation_job(
+    paths: &PvPaths,
+    queue: &ReconciliationQueue,
+    scope: ReconciliationScope,
+) -> Result<EnqueueResult, DaemonError> {
+    let scope_text = scope.to_string();
+    let abandon_paths = paths.clone();
+
+    queue.enqueue_with_abandon(
+        scope,
+        || start_reconciliation_job(paths, &scope_text),
+        move |job_id| {
+            let _result = abandon_reconciliation_job(&abandon_paths, job_id);
+        },
+    )
+}
+
+fn foreground_reconciliation_result(
+    accepted_result: Result<(), DaemonError>,
+    reconciliation_result: Result<(), DaemonError>,
+) -> Result<(), DaemonError> {
+    reconciliation_result?;
+    accepted_result
 }
 
 async fn stream_started_reconciliation_job<Stream>(
@@ -175,6 +197,13 @@ fn start_reconciliation_job(paths: &PvPaths, scope: &str) -> Result<String, Daem
     Ok(job.id)
 }
 
+fn abandon_reconciliation_job(paths: &PvPaths, job_id: &str) -> Result<(), DaemonError> {
+    let mut database = Database::open(paths)?;
+    database.fail_job(job_id, "reconciliation was abandoned before completion")?;
+
+    Ok(())
+}
+
 fn complete_stub_reconciliation(
     paths: &PvPaths,
     job_id: &str,
@@ -202,6 +231,30 @@ fn complete_or_fail_background_reconciliation(
             Err(error)
         }
     }
+}
+
+pub(crate) fn record_background_reconciliation_error(
+    paths: &PvPaths,
+    scope: &str,
+    error: &DaemonError,
+) -> Result<(), DaemonError> {
+    let error_message = error.to_string();
+    let mut database = Database::open(paths)?;
+    let already_recorded = database.recent_jobs()?.into_iter().any(|job| {
+        job.kind == "reconcile"
+            && job.scope == scope
+            && job.status == JobStatus::Failed
+            && job.error.as_deref() == Some(error_message.as_str())
+    });
+
+    if already_recorded {
+        return Ok(());
+    }
+
+    let job = database.start_job("reconcile", scope)?;
+    database.fail_job(&job.id, &error_message)?;
+
+    Ok(())
 }
 
 async fn run_invalid_reconciliation_scope_job(
@@ -356,13 +409,15 @@ mod tests {
     use std::io;
 
     use camino_tempfile::tempdir;
-    use state::{Database, JobStatus, PvPaths};
+    use state::{Database, JobStatus, PvPaths, StateError};
     use tokio::io::duplex;
 
     use super::{
-        complete_or_fail_background_reconciliation, start_reconciliation_job,
-        stream_started_reconciliation_job,
+        complete_or_fail_background_reconciliation, enqueue_reconciliation_job,
+        foreground_reconciliation_result, record_background_reconciliation_error,
+        start_reconciliation_job, stream_started_reconciliation_job,
     };
+    use crate::reconciliation::{EnqueueResult, ReconciliationQueue, ReconciliationScope};
 
     #[tokio::test]
     async fn stream_write_error_is_returned_after_job_completion_is_persisted() -> anyhow::Result<()>
@@ -415,5 +470,105 @@ mod tests {
         assert_eq!(job.error.as_deref(), Some("I/O error: reconcile failed"));
 
         Ok(())
+    }
+
+    #[test]
+    fn background_reconciliation_error_records_failed_job() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let error = crate::DaemonError::Io(io::Error::other("background task failed"));
+
+        record_background_reconciliation_error(&paths, "project:project_1", &error)?;
+
+        let database = Database::open(&paths)?;
+        let job = database
+            .recent_jobs()?
+            .into_iter()
+            .find(|job| job.scope == "project:project_1")
+            .ok_or_else(|| anyhow::anyhow!("missing background failure job"))?;
+        assert_eq!(job.status, JobStatus::Failed);
+        assert_eq!(
+            job.error.as_deref(),
+            Some("I/O error: background task failed")
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn foreground_reconciliation_result_takes_precedence_over_accepted_write_error() {
+        let result = foreground_reconciliation_result(
+            Err(crate::DaemonError::Io(io::Error::other(
+                "accepted write failed",
+            ))),
+            Err(crate::DaemonError::State(StateError::JobNotFound {
+                id: "reconcile_1".to_string(),
+            })),
+        );
+
+        assert!(matches!(
+            result,
+            Err(crate::DaemonError::State(StateError::JobNotFound { id }))
+                if id == "reconcile_1"
+        ));
+    }
+
+    #[test]
+    fn foreground_reconciliation_returns_accepted_write_error_after_successful_reconciliation() {
+        let result = foreground_reconciliation_result(
+            Err(crate::DaemonError::Io(io::Error::other(
+                "accepted write failed",
+            ))),
+            Ok(()),
+        );
+
+        assert!(matches!(
+            result,
+            Err(crate::DaemonError::Io(error)) if error.to_string() == "accepted write failed"
+        ));
+    }
+
+    #[tokio::test]
+    async fn dropping_queued_reconciliation_marks_persisted_job_failed() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let queue = ReconciliationQueue::new();
+        let first = queued(enqueue_reconciliation_job(
+            &paths,
+            &queue,
+            ReconciliationScope::System,
+        )?)?;
+        let running = first.wait_for_turn().await;
+        let queued_scope = ReconciliationScope::project("project_1")?;
+        let queued = queued(enqueue_reconciliation_job(&paths, &queue, queued_scope)?)?;
+        let queued_job_id = queued.job_id().to_string();
+
+        drop(queued);
+
+        let database = Database::open(&paths)?;
+        let job = database
+            .recent_jobs()?
+            .into_iter()
+            .find(|job| job.id == queued_job_id)
+            .ok_or_else(|| anyhow::anyhow!("missing abandoned job {queued_job_id}"))?;
+        assert_eq!(job.status, JobStatus::Failed);
+        assert_eq!(
+            job.error.as_deref(),
+            Some("reconciliation was abandoned before completion")
+        );
+
+        running.finish();
+
+        Ok(())
+    }
+
+    fn queued(result: EnqueueResult) -> anyhow::Result<crate::QueuedReconciliation> {
+        match result {
+            EnqueueResult::Queued(queued) => Ok(queued),
+            EnqueueResult::Coalesced(job) => Err(anyhow::anyhow!(
+                "scope unexpectedly coalesced into {}",
+                job.job_id()
+            )),
+        }
     }
 }

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -3,9 +3,46 @@ use crate::ipc::LocalStream;
 use crate::protocol::{
     DaemonEvent, DaemonResponse, DaemonTransport, PROTOCOL_VERSION, ResponseStatus, write_line,
 };
+use crate::reconciliation::{EnqueueResult, ReconciliationQueue, ReconciliationScope};
 use state::{Database, PvPaths};
 
 pub(crate) async fn run_job(
+    paths: PvPaths,
+    queue: ReconciliationQueue,
+    mut transport: DaemonTransport<LocalStream>,
+    kind: &str,
+    scope: &str,
+) -> Result<(), DaemonError> {
+    let parsed_scope = scope.parse::<ReconciliationScope>();
+    if kind == "reconcile"
+        && let Ok(parsed_scope) = parsed_scope
+    {
+        let EnqueueResult::Queued(queued) = queue.enqueue(parsed_scope).await else {
+            return write_line(
+                &mut transport,
+                &DaemonResponse {
+                    line_type: "response",
+                    protocol_version: PROTOCOL_VERSION,
+                    status: ResponseStatus::Accepted,
+                    message: "reconciliation already queued or running",
+                    job_id: None,
+                },
+            )
+            .await;
+        };
+        let running = queued.wait_for_turn().await;
+        let active_scope = running.scope().to_string();
+        let result = run_started_job(paths, transport, kind, &active_scope).await;
+
+        running.finish().await;
+
+        return result;
+    }
+
+    run_started_job(paths, transport, kind, scope).await
+}
+
+async fn run_started_job(
     paths: PvPaths,
     mut transport: DaemonTransport<LocalStream>,
     kind: &str,
@@ -50,7 +87,7 @@ pub(crate) async fn run_job(
     .await
     .is_ok();
 
-    if kind != "reconcile" || scope != "system" {
+    if kind != "reconcile" || scope.parse::<ReconciliationScope>().is_err() {
         let error = format!("unsupported daemon job `{kind}` with scope `{scope}`");
         database.fail_job(&job.id, &error)?;
 

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -5,6 +5,7 @@ use crate::protocol::{
 };
 use crate::reconciliation::{EnqueueResult, ReconciliationQueue, ReconciliationScope};
 use state::{Database, PvPaths};
+use tokio::io::AsyncWrite;
 
 pub(crate) async fn run_job(
     paths: PvPaths,
@@ -14,10 +15,13 @@ pub(crate) async fn run_job(
     scope: &str,
 ) -> Result<(), DaemonError> {
     let parsed_scope = scope.parse::<ReconciliationScope>();
-    if kind == "reconcile"
-        && let Ok(parsed_scope) = parsed_scope
-    {
-        return run_reconciliation_job(paths, queue, transport, parsed_scope).await;
+    if kind == "reconcile" {
+        return match parsed_scope {
+            Ok(parsed_scope) => run_reconciliation_job(paths, queue, transport, parsed_scope).await,
+            Err(error) => {
+                run_invalid_reconciliation_scope_job(paths, transport, scope, error).await
+            }
+        };
     }
 
     run_started_job(paths, transport, kind, scope).await
@@ -35,11 +39,13 @@ pub(crate) async fn run_background_reconciliation_job(
     };
     let running = queued.wait_for_turn().await;
     let job_id = running.job_id().to_string();
-    let result = complete_stub_reconciliation(&paths, &job_id);
+    let result = complete_or_fail_background_reconciliation(&paths, &job_id, || {
+        complete_stub_reconciliation(&paths, &job_id).map(|_summary| ())
+    });
 
     running.finish();
 
-    result.map(|_summary| ())
+    result
 }
 
 async fn run_reconciliation_job(
@@ -54,7 +60,7 @@ async fn run_reconciliation_job(
     match result {
         EnqueueResult::Queued(queued) => {
             let job_id = queued.job_id().to_string();
-            let stream_is_open = write_line(
+            let accepted_result = write_line(
                 &mut transport,
                 &DaemonResponse {
                     line_type: "response",
@@ -64,8 +70,8 @@ async fn run_reconciliation_job(
                     job_id: Some(&job_id),
                 },
             )
-            .await
-            .is_ok();
+            .await;
+            let stream_is_open = accepted_result.is_ok();
             let running = queued.wait_for_turn().await;
             let result = stream_started_reconciliation_job(
                 paths,
@@ -77,6 +83,8 @@ async fn run_reconciliation_job(
             .await;
 
             running.finish();
+
+            accepted_result?;
 
             result
         }
@@ -96,15 +104,18 @@ async fn run_reconciliation_job(
     }
 }
 
-async fn stream_started_reconciliation_job(
+async fn stream_started_reconciliation_job<Stream>(
     paths: PvPaths,
-    mut transport: DaemonTransport<LocalStream>,
+    mut transport: DaemonTransport<Stream>,
     stream_is_open: bool,
     job_id: &str,
     scope: &str,
-) -> Result<(), DaemonError> {
-    let stream_is_open = stream_is_open
-        && async {
+) -> Result<(), DaemonError>
+where
+    Stream: AsyncWrite + Unpin,
+{
+    let started_stream_result = if stream_is_open {
+        async {
             write_line(
                 &mut transport,
                 &DaemonEvent::JobStarted {
@@ -126,9 +137,13 @@ async fn stream_started_reconciliation_job(
             Ok::<(), DaemonError>(())
         }
         .await
-        .is_ok();
+    } else {
+        Ok(())
+    };
 
     let summary = complete_stub_reconciliation(&paths, job_id)?;
+    started_stream_result?;
+
     if !stream_is_open {
         return Ok(());
     }
@@ -170,6 +185,76 @@ fn complete_stub_reconciliation(
     database.complete_job(job_id, summary)?;
 
     Ok(summary)
+}
+
+fn complete_or_fail_background_reconciliation(
+    paths: &PvPaths,
+    job_id: &str,
+    operation: impl FnOnce() -> Result<(), DaemonError>,
+) -> Result<(), DaemonError> {
+    match operation() {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let error_message = error.to_string();
+            let mut database = Database::open(paths)?;
+            database.fail_job(job_id, &error_message)?;
+
+            Err(error)
+        }
+    }
+}
+
+async fn run_invalid_reconciliation_scope_job(
+    paths: PvPaths,
+    mut transport: DaemonTransport<LocalStream>,
+    scope: &str,
+    parse_error: crate::reconciliation::ReconciliationScopeParseError,
+) -> Result<(), DaemonError> {
+    let mut database = Database::open(&paths)?;
+    let job = database.start_job("reconcile", scope)?;
+    let error = format!("invalid reconciliation scope `{scope}`: {parse_error}");
+
+    let stream_is_open = async {
+        write_line(
+            &mut transport,
+            &DaemonResponse {
+                line_type: "response",
+                protocol_version: PROTOCOL_VERSION,
+                status: ResponseStatus::Accepted,
+                message: "job accepted",
+                job_id: Some(&job.id),
+            },
+        )
+        .await?;
+        write_line(
+            &mut transport,
+            &DaemonEvent::JobStarted {
+                job_id: &job.id,
+                kind: "reconcile",
+                scope,
+            },
+        )
+        .await?;
+
+        Ok::<(), DaemonError>(())
+    }
+    .await
+    .is_ok();
+
+    database.fail_job(&job.id, &error)?;
+
+    if stream_is_open {
+        write_line(
+            &mut transport,
+            &DaemonEvent::JobFailed {
+                job_id: &job.id,
+                error: &error,
+            },
+        )
+        .await?;
+    }
+
+    Ok(())
 }
 
 async fn run_started_job(
@@ -264,4 +349,71 @@ async fn run_started_job(
         },
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use camino_tempfile::tempdir;
+    use state::{Database, JobStatus, PvPaths};
+    use tokio::io::duplex;
+
+    use super::{
+        complete_or_fail_background_reconciliation, start_reconciliation_job,
+        stream_started_reconciliation_job,
+    };
+
+    #[tokio::test]
+    async fn stream_write_error_is_returned_after_job_completion_is_persisted() -> anyhow::Result<()>
+    {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let job_id = start_reconciliation_job(&paths, "system")?;
+        let (client, server) = duplex(64);
+        drop(client);
+
+        let result = stream_started_reconciliation_job(
+            paths.clone(),
+            crate::protocol::transport(server),
+            true,
+            &job_id,
+            "system",
+        )
+        .await;
+
+        assert!(result.is_err());
+        let database = Database::open(&paths)?;
+        let job = database
+            .recent_jobs()?
+            .into_iter()
+            .find(|job| job.id == job_id)
+            .ok_or_else(|| anyhow::anyhow!("missing job {job_id}"))?;
+        assert_eq!(job.status, JobStatus::Succeeded);
+
+        Ok(())
+    }
+
+    #[test]
+    fn background_reconciliation_failure_marks_started_job_failed() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let job_id = start_reconciliation_job(&paths, "system")?;
+
+        let result = complete_or_fail_background_reconciliation(&paths, &job_id, || {
+            Err(crate::DaemonError::Io(io::Error::other("reconcile failed")))
+        });
+
+        assert!(result.is_err());
+        let database = Database::open(&paths)?;
+        let job = database
+            .recent_jobs()?
+            .into_iter()
+            .find(|job| job.id == job_id)
+            .ok_or_else(|| anyhow::anyhow!("missing job {job_id}"))?;
+        assert_eq!(job.status, JobStatus::Failed);
+        assert_eq!(job.error.as_deref(), Some("I/O error: reconcile failed"));
+
+        Ok(())
+    }
 }

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5,6 +5,7 @@ mod protocol;
 mod reconciliation;
 mod server;
 mod supervisor;
+mod watcher;
 
 use std::future::Future;
 use std::io;
@@ -16,11 +17,12 @@ use tokio::task::JoinHandle;
 pub use error::DaemonError;
 pub use protocol::PROTOCOL_VERSION;
 pub use reconciliation::{
-    EnqueueResult, QueuedReconciliation, ReconciliationDebouncer, ReconciliationQueue,
-    ReconciliationScope, RunningReconciliation,
+    EnqueueResult, QueuedReconciliation, ReconciliationDebouncer, ReconciliationJob,
+    ReconciliationQueue, ReconciliationScope, ReconciliationScopeParseError, RunningReconciliation,
 };
 pub use supervisor::{
-    ProcessSpec, ProcessSupervisor, ReadinessCheck, wait_for_custom_readiness, wait_for_readiness,
+    AdoptedProcess, OwnedRuntime, ProcessSpec, ProcessSupervisor, ReadinessCheck,
+    wait_for_custom_readiness, wait_for_readiness,
 };
 
 #[derive(Debug)]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -2,7 +2,9 @@ mod error;
 mod ipc;
 mod jobs;
 mod protocol;
+mod reconciliation;
 mod server;
+mod supervisor;
 
 use std::future::Future;
 use std::io;
@@ -13,6 +15,13 @@ use tokio::task::JoinHandle;
 
 pub use error::DaemonError;
 pub use protocol::PROTOCOL_VERSION;
+pub use reconciliation::{
+    EnqueueResult, QueuedReconciliation, ReconciliationDebouncer, ReconciliationQueue,
+    ReconciliationScope, RunningReconciliation,
+};
+pub use supervisor::{
+    ProcessSpec, ProcessSupervisor, ReadinessCheck, wait_for_custom_readiness, wait_for_readiness,
+};
 
 #[derive(Debug)]
 pub struct RunningDaemon {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -11,6 +11,7 @@ use std::future::Future;
 use std::io;
 
 use state::{Database, PvPaths};
+use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -62,14 +63,19 @@ impl RunningDaemon {
 }
 
 pub fn run_blocking(paths: PvPaths) -> Result<(), DaemonError> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_io()
-        .build()?;
+    let runtime = build_runtime()?;
 
     runtime.block_on(async {
         let daemon = RunningDaemon::start(paths).await?;
         wait_for_shutdown(daemon, termination_signal()).await
     })
+}
+
+fn build_runtime() -> io::Result<Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
 }
 
 async fn wait_for_shutdown(
@@ -130,7 +136,18 @@ mod tests {
     use state::PvPaths;
     use tokio::sync::oneshot;
 
-    use super::{DaemonError, RunningDaemon, wait_for_shutdown};
+    use super::{DaemonError, RunningDaemon, build_runtime, wait_for_shutdown};
+
+    #[test]
+    fn daemon_runtime_enables_tokio_timers() -> anyhow::Result<()> {
+        let runtime = build_runtime()?;
+
+        runtime.block_on(async {
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        });
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn shutdown_wait_returns_when_server_task_fails_before_signal() {

--- a/crates/daemon/src/reconciliation.rs
+++ b/crates/daemon/src/reconciliation.rs
@@ -10,9 +10,17 @@ use tokio::sync::Notify;
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ReconciliationScope {
     System,
-    Project { id: String },
-    Resource { name: String, track: String },
+    Project {
+        id: ReconciliationScopeComponent,
+    },
+    Resource {
+        name: ReconciliationScopeComponent,
+        track: ReconciliationScopeComponent,
+    },
 }
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ReconciliationScopeComponent(String);
 
 #[derive(Clone)]
 pub struct ReconciliationQueue {
@@ -106,7 +114,7 @@ impl ReconciliationQueue {
     ) -> Result<EnqueueResult, E> {
         let mut state = lock_queue_state(&self.inner);
 
-        if let Some(job) = matching_job(&state, &scope) {
+        if let Some(job) = matching_queued_job(&state, &scope) {
             return Ok(EnqueueResult::Coalesced(job));
         }
 
@@ -260,6 +268,66 @@ impl ReconciliationJob {
     }
 }
 
+impl ReconciliationScope {
+    pub fn project(id: impl Into<String>) -> Result<Self, ReconciliationScopeParseError> {
+        let id = id.into();
+        let scope = format!("project:{id}");
+        let id = ReconciliationScopeComponent::new(id, "id", &scope, 2)?;
+
+        Ok(Self::Project { id })
+    }
+
+    pub fn resource(
+        name: impl Into<String>,
+        track: impl Into<String>,
+    ) -> Result<Self, ReconciliationScopeParseError> {
+        let name = name.into();
+        let track = track.into();
+        let scope = format!("resource:{name}:{track}");
+        let name = ReconciliationScopeComponent::new(name, "name", &scope, 3)?;
+        let track = ReconciliationScopeComponent::new(track, "track", &scope, 3)?;
+
+        Ok(Self::Resource { name, track })
+    }
+}
+
+impl ReconciliationScopeComponent {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn new(
+        value: String,
+        component: &'static str,
+        scope: &str,
+        expected_components: usize,
+    ) -> Result<Self, ReconciliationScopeParseError> {
+        if value.is_empty() {
+            return Err(ReconciliationScopeParseError::EmptyComponent {
+                scope: scope.to_string(),
+                component,
+            });
+        }
+
+        let actual_components = scope.split(':').count();
+        if actual_components != expected_components {
+            return Err(ReconciliationScopeParseError::InvalidComponentCount {
+                scope: scope.to_string(),
+                expected: expected_components,
+                actual: actual_components,
+            });
+        }
+
+        Ok(Self(value))
+    }
+}
+
+impl fmt::Display for ReconciliationScopeComponent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
 impl fmt::Display for ReconciliationScope {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -278,7 +346,9 @@ impl FromStr for ReconciliationScope {
 
         match parts.as_slice() {
             ["system"] => Ok(Self::System),
-            ["project", id] if !id.is_empty() => Ok(Self::Project { id: id.to_string() }),
+            ["project", id] if !id.is_empty() => Ok(Self::Project {
+                id: ReconciliationScopeComponent((*id).to_string()),
+            }),
             ["project", _id] => Err(ReconciliationScopeParseError::EmptyComponent {
                 scope: scope.to_string(),
                 component: "id",
@@ -290,8 +360,8 @@ impl FromStr for ReconciliationScope {
             }),
             ["resource", name, track] if !name.is_empty() && !track.is_empty() => {
                 Ok(Self::Resource {
-                    name: name.to_string(),
-                    track: track.to_string(),
+                    name: ReconciliationScopeComponent((*name).to_string()),
+                    track: ReconciliationScopeComponent((*track).to_string()),
                 })
             }
             ["resource", "", _track] => Err(ReconciliationScopeParseError::EmptyComponent {
@@ -314,13 +384,11 @@ impl FromStr for ReconciliationScope {
     }
 }
 
-fn matching_job(state: &QueueState, scope: &ReconciliationScope) -> Option<ReconciliationJob> {
-    state
-        .active
-        .iter()
-        .chain(state.queued.iter())
-        .find(|job| &job.scope == scope)
-        .cloned()
+fn matching_queued_job(
+    state: &QueueState,
+    scope: &ReconciliationScope,
+) -> Option<ReconciliationJob> {
+    state.queued.iter().find(|job| &job.scope == scope).cloned()
 }
 
 fn remove_queued_job(inner: &QueueInner, job: &ReconciliationJob) {
@@ -381,14 +449,10 @@ mod tests {
         let duplicate = queue.enqueue(ReconciliationScope::System, || {
             Ok::<String, anyhow::Error>("job_duplicate".to_string())
         })?;
-        assert!(matches!(
-            duplicate,
-            EnqueueResult::Coalesced(job) if job.job_id() == "job_1"
-        ));
+        let trailing = queued(duplicate)?;
+        assert_eq!(trailing.job_id(), "job_duplicate");
 
-        let project_scope = ReconciliationScope::Project {
-            id: "project_1".to_string(),
-        };
+        let project_scope = ReconciliationScope::project("project_1")?;
         let project = queued(queue.enqueue(project_scope.clone(), || {
             Ok::<String, anyhow::Error>("job_2".to_string())
         })?)?;
@@ -396,6 +460,10 @@ mod tests {
         assert!(project_wait.is_err());
 
         first_run.finish();
+
+        let trailing_run = timeout(Duration::from_secs(1), trailing.wait_for_turn()).await?;
+        assert_eq!(trailing_run.scope(), &ReconciliationScope::System);
+        trailing_run.finish();
 
         let project = queued(queue.enqueue(project_scope.clone(), || {
             Ok::<String, anyhow::Error>("job_3".to_string())
@@ -430,14 +498,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn duplicate_active_scope_runs_one_trailing_reconciliation() -> anyhow::Result<()> {
+        let queue = ReconciliationQueue::new();
+        let active = queued(queue.enqueue(ReconciliationScope::System, || {
+            Ok::<String, anyhow::Error>("job_1".to_string())
+        })?)?
+        .wait_for_turn()
+        .await;
+
+        let trailing = queued(queue.enqueue(ReconciliationScope::System, || {
+            Ok::<String, anyhow::Error>("job_2".to_string())
+        })?)?;
+        let duplicate_trailing = queue.enqueue(ReconciliationScope::System, || {
+            Ok::<String, anyhow::Error>("job_3".to_string())
+        })?;
+
+        assert!(matches!(
+            duplicate_trailing,
+            EnqueueResult::Coalesced(job) if job.job_id() == "job_2"
+        ));
+
+        active.finish();
+
+        let running = timeout(Duration::from_secs(1), trailing.wait_for_turn()).await?;
+        assert_eq!(running.job_id(), "job_2");
+        running.finish();
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn debounce_coalesces_bursts_before_queueing_reconciliation() -> anyhow::Result<()> {
         let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
         let debouncer = ReconciliationDebouncer::new(Duration::from_millis(10), move |scope| {
             let _sent = sender.send(scope);
         });
-        let project_scope = ReconciliationScope::Project {
-            id: "project_1".to_string(),
-        };
+        let project_scope = ReconciliationScope::project("project_1")?;
 
         debouncer.request(ReconciliationScope::System).await;
         debouncer.request(ReconciliationScope::System).await;
@@ -460,7 +556,7 @@ mod tests {
         assert!(matches!(
             "resource:mysql:8.4".parse::<ReconciliationScope>(),
             Ok(ReconciliationScope::Resource { name, track })
-                if name == "mysql" && track == "8.4"
+                if name.as_str() == "mysql" && track.as_str() == "8.4"
         ));
         assert!(matches!(
             "resource:mysql:8.4:extra".parse::<ReconciliationScope>(),
@@ -481,6 +577,25 @@ mod tests {
             "unknown:scope".parse::<ReconciliationScope>(),
             Err(ReconciliationScopeParseError::UnknownScope { scope })
                 if scope == "unknown:scope"
+        ));
+    }
+
+    #[test]
+    fn scope_constructors_reject_ambiguous_components() {
+        assert!(matches!(
+            ReconciliationScope::project(""),
+            Err(ReconciliationScopeParseError::EmptyComponent {
+                component: "id",
+                ..
+            })
+        ));
+        assert!(matches!(
+            ReconciliationScope::project("project:one"),
+            Err(ReconciliationScopeParseError::InvalidComponentCount { .. })
+        ));
+        assert!(matches!(
+            ReconciliationScope::resource("mysql", "8.4:debug"),
+            Err(ReconciliationScopeParseError::InvalidComponentCount { .. })
         ));
     }
 

--- a/crates/daemon/src/reconciliation.rs
+++ b/crates/daemon/src/reconciliation.rs
@@ -1,10 +1,11 @@
 use std::collections::{BTreeSet, VecDeque};
 use std::fmt;
 use std::str::FromStr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
-use tokio::sync::{Mutex, Notify};
+use thiserror::Error;
+use tokio::sync::Notify;
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ReconciliationScope {
@@ -20,25 +21,51 @@ pub struct ReconciliationQueue {
 
 pub enum EnqueueResult {
     Queued(QueuedReconciliation),
-    Coalesced,
+    Coalesced(ReconciliationJob),
 }
 
-#[derive(Clone)]
-pub struct QueuedReconciliation {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReconciliationJob {
     scope: ReconciliationScope,
+    job_id: String,
+}
+
+pub struct QueuedReconciliation {
+    job: ReconciliationJob,
     inner: Arc<QueueInner>,
+    released: bool,
 }
 
 pub struct RunningReconciliation {
-    scope: ReconciliationScope,
+    job: ReconciliationJob,
     inner: Arc<QueueInner>,
+    finished: bool,
 }
 
 #[derive(Clone)]
 pub struct ReconciliationDebouncer {
-    queue: ReconciliationQueue,
     delay: Duration,
     state: Arc<DebounceState>,
+    handler: Arc<dyn Fn(ReconciliationScope) + Send + Sync>,
+}
+
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum ReconciliationScopeParseError {
+    #[error("unknown reconciliation scope `{scope}`")]
+    UnknownScope { scope: String },
+
+    #[error("reconciliation scope `{scope}` has {actual} components; expected {expected}")]
+    InvalidComponentCount {
+        scope: String,
+        expected: usize,
+        actual: usize,
+    },
+
+    #[error("reconciliation scope `{scope}` has an empty {component} component")]
+    EmptyComponent {
+        scope: String,
+        component: &'static str,
+    },
 }
 
 struct QueueInner {
@@ -52,8 +79,8 @@ struct DebounceState {
 
 #[derive(Debug, Default)]
 struct QueueState {
-    active: Option<ReconciliationScope>,
-    queued: VecDeque<ReconciliationScope>,
+    active: Option<ReconciliationJob>,
+    queued: VecDeque<ReconciliationJob>,
 }
 
 #[derive(Debug, Default)]
@@ -72,20 +99,29 @@ impl ReconciliationQueue {
         }
     }
 
-    pub async fn enqueue(&self, scope: ReconciliationScope) -> EnqueueResult {
-        let mut state = self.inner.state.lock().await;
+    pub fn enqueue<E>(
+        &self,
+        scope: ReconciliationScope,
+        create_job_id: impl FnOnce() -> Result<String, E>,
+    ) -> Result<EnqueueResult, E> {
+        let mut state = lock_queue_state(&self.inner);
 
-        if state.active.as_ref() == Some(&scope) || state.queued.contains(&scope) {
-            return EnqueueResult::Coalesced;
+        if let Some(job) = matching_job(&state, &scope) {
+            return Ok(EnqueueResult::Coalesced(job));
         }
 
-        state.queued.push_back(scope.clone());
+        let job = ReconciliationJob {
+            scope,
+            job_id: create_job_id()?,
+        };
+        state.queued.push_back(job.clone());
         self.inner.notify.notify_waiters();
 
-        EnqueueResult::Queued(QueuedReconciliation {
-            scope,
+        Ok(EnqueueResult::Queued(QueuedReconciliation {
+            job,
             inner: Arc::clone(&self.inner),
-        })
+            released: false,
+        }))
     }
 }
 
@@ -97,18 +133,25 @@ impl Default for ReconciliationQueue {
 
 impl QueuedReconciliation {
     pub async fn wait_for_turn(self) -> RunningReconciliation {
+        let mut queued = self;
+
         loop {
-            let notified = self.inner.notify.notified();
+            let notified = queued.inner.notify.notified();
 
             {
-                let mut state = self.inner.state.lock().await;
-                if state.active.is_none() && state.queued.front() == Some(&self.scope) {
-                    state.queued.pop_front();
-                    state.active = Some(self.scope.clone());
+                let mut state = lock_queue_state(&queued.inner);
+                if state.active.is_none()
+                    && let Some(front) = state.queued.front()
+                    && front.job_id == queued.job.job_id
+                    && let Some(job) = state.queued.pop_front()
+                {
+                    state.active = Some(job.clone());
+                    queued.released = true;
 
                     return RunningReconciliation {
-                        scope: self.scope,
-                        inner: Arc::clone(&self.inner),
+                        job,
+                        inner: Arc::clone(&queued.inner),
+                        finished: false,
                     };
                 }
             }
@@ -116,37 +159,64 @@ impl QueuedReconciliation {
             notified.await;
         }
     }
+
+    pub fn job_id(&self) -> &str {
+        &self.job.job_id
+    }
+}
+
+impl Drop for QueuedReconciliation {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+
+        remove_queued_job(&self.inner, &self.job);
+    }
 }
 
 impl RunningReconciliation {
     pub fn scope(&self) -> &ReconciliationScope {
-        &self.scope
+        &self.job.scope
     }
 
-    pub async fn finish(self) {
-        let mut state = self.inner.state.lock().await;
+    pub fn job_id(&self) -> &str {
+        &self.job.job_id
+    }
 
-        if state.active.as_ref() == Some(&self.scope) {
-            state.active = None;
-            self.inner.notify.notify_waiters();
+    pub fn finish(mut self) {
+        release_active_job(&self.inner, &self.job);
+        self.finished = true;
+    }
+}
+
+impl Drop for RunningReconciliation {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
         }
+
+        release_active_job(&self.inner, &self.job);
     }
 }
 
 impl ReconciliationDebouncer {
-    pub fn new(queue: ReconciliationQueue, delay: Duration) -> Self {
+    pub fn new(
+        delay: Duration,
+        handler: impl Fn(ReconciliationScope) + Send + Sync + 'static,
+    ) -> Self {
         Self {
-            queue,
             delay,
             state: Arc::new(DebounceState {
                 inner: Mutex::new(DebounceInner::default()),
             }),
+            handler: Arc::new(handler),
         }
     }
 
     pub async fn request(&self, scope: ReconciliationScope) {
         let should_spawn = {
-            let mut inner = self.state.inner.lock().await;
+            let mut inner = lock_debounce_state(&self.state);
             inner.pending.insert(scope);
 
             if inner.worker_running {
@@ -169,14 +239,24 @@ impl ReconciliationDebouncer {
         tokio::time::sleep(self.delay).await;
 
         let scopes = {
-            let mut inner = self.state.inner.lock().await;
+            let mut inner = lock_debounce_state(&self.state);
             inner.worker_running = false;
             std::mem::take(&mut inner.pending)
         };
 
         for scope in scopes {
-            let _result = self.queue.enqueue(scope).await;
+            (self.handler)(scope);
         }
+    }
+}
+
+impl ReconciliationJob {
+    pub fn scope(&self) -> &ReconciliationScope {
+        &self.scope
+    }
+
+    pub fn job_id(&self) -> &str {
+        &self.job_id
     }
 }
 
@@ -191,33 +271,92 @@ impl fmt::Display for ReconciliationScope {
 }
 
 impl FromStr for ReconciliationScope {
-    type Err = ();
+    type Err = ReconciliationScopeParseError;
 
     fn from_str(scope: &str) -> Result<Self, Self::Err> {
-        if scope == "system" {
-            return Ok(Self::System);
-        }
+        let parts = scope.split(':').collect::<Vec<_>>();
 
-        if let Some(id) = scope.strip_prefix("project:")
-            && !id.is_empty()
-        {
-            return Ok(Self::Project { id: id.to_string() });
-        }
-
-        if let Some(resource) = scope.strip_prefix("resource:") {
-            let Some((name, track)) = resource.split_once(':') else {
-                return Err(());
-            };
-
-            if !name.is_empty() && !track.is_empty() {
-                return Ok(Self::Resource {
+        match parts.as_slice() {
+            ["system"] => Ok(Self::System),
+            ["project", id] if !id.is_empty() => Ok(Self::Project { id: id.to_string() }),
+            ["project", _id] => Err(ReconciliationScopeParseError::EmptyComponent {
+                scope: scope.to_string(),
+                component: "id",
+            }),
+            ["project", ..] => Err(ReconciliationScopeParseError::InvalidComponentCount {
+                scope: scope.to_string(),
+                expected: 2,
+                actual: parts.len(),
+            }),
+            ["resource", name, track] if !name.is_empty() && !track.is_empty() => {
+                Ok(Self::Resource {
                     name: name.to_string(),
                     track: track.to_string(),
-                });
+                })
             }
+            ["resource", "", _track] => Err(ReconciliationScopeParseError::EmptyComponent {
+                scope: scope.to_string(),
+                component: "name",
+            }),
+            ["resource", _name, ""] => Err(ReconciliationScopeParseError::EmptyComponent {
+                scope: scope.to_string(),
+                component: "track",
+            }),
+            ["resource", ..] => Err(ReconciliationScopeParseError::InvalidComponentCount {
+                scope: scope.to_string(),
+                expected: 3,
+                actual: parts.len(),
+            }),
+            _ => Err(ReconciliationScopeParseError::UnknownScope {
+                scope: scope.to_string(),
+            }),
         }
+    }
+}
 
-        Err(())
+fn matching_job(state: &QueueState, scope: &ReconciliationScope) -> Option<ReconciliationJob> {
+    state
+        .active
+        .iter()
+        .chain(state.queued.iter())
+        .find(|job| &job.scope == scope)
+        .cloned()
+}
+
+fn remove_queued_job(inner: &QueueInner, job: &ReconciliationJob) {
+    let mut state = lock_queue_state(inner);
+    let queued_len = state.queued.len();
+    state.queued.retain(|queued| queued.job_id != job.job_id);
+
+    if state.queued.len() != queued_len {
+        inner.notify.notify_waiters();
+    }
+}
+
+fn release_active_job(inner: &QueueInner, job: &ReconciliationJob) {
+    let mut state = lock_queue_state(inner);
+
+    if state
+        .active
+        .as_ref()
+        .is_some_and(|active| active.job_id == job.job_id)
+    {
+        state.active = None;
+        inner.notify.notify_waiters();
+    }
+}
+
+fn lock_queue_state(inner: &QueueInner) -> MutexGuard<'_, QueueState> {
+    match inner.state.lock() {
+        Ok(state) => state,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn lock_debounce_state(state: &DebounceState) -> MutexGuard<'_, DebounceInner> {
+    match state.inner.lock() {
+        Ok(inner) => inner,
+        Err(poisoned) => poisoned.into_inner(),
     }
 }
 
@@ -227,39 +366,75 @@ mod tests {
 
     use super::{
         EnqueueResult, QueuedReconciliation, ReconciliationDebouncer, ReconciliationQueue,
-        ReconciliationScope,
+        ReconciliationScope, ReconciliationScopeParseError,
     };
 
     #[tokio::test]
     async fn queue_runs_one_scope_at_a_time_and_coalesces_duplicates() -> anyhow::Result<()> {
         let queue = ReconciliationQueue::new();
-        let first = queued(queue.enqueue(ReconciliationScope::System).await)?;
+        let first = queued(queue.enqueue(ReconciliationScope::System, || {
+            Ok::<String, anyhow::Error>("job_1".to_string())
+        })?)?;
         let first_run = first.wait_for_turn().await;
+        assert_eq!(first_run.job_id(), "job_1");
 
-        let duplicate = queue.enqueue(ReconciliationScope::System).await;
-        assert!(matches!(duplicate, EnqueueResult::Coalesced));
+        let duplicate = queue.enqueue(ReconciliationScope::System, || {
+            Ok::<String, anyhow::Error>("job_duplicate".to_string())
+        })?;
+        assert!(matches!(
+            duplicate,
+            EnqueueResult::Coalesced(job) if job.job_id() == "job_1"
+        ));
 
         let project_scope = ReconciliationScope::Project {
             id: "project_1".to_string(),
         };
-        let project = queued(queue.enqueue(project_scope.clone()).await)?;
-        let project_wait =
-            timeout(Duration::from_millis(10), project.clone().wait_for_turn()).await;
+        let project = queued(queue.enqueue(project_scope.clone(), || {
+            Ok::<String, anyhow::Error>("job_2".to_string())
+        })?)?;
+        let project_wait = timeout(Duration::from_millis(10), project.wait_for_turn()).await;
         assert!(project_wait.is_err());
 
-        first_run.finish().await;
+        first_run.finish();
 
+        let project = queued(queue.enqueue(project_scope.clone(), || {
+            Ok::<String, anyhow::Error>("job_3".to_string())
+        })?)?;
         let project_run = timeout(Duration::from_secs(1), project.wait_for_turn()).await?;
         assert_eq!(project_run.scope(), &project_scope);
-        project_run.finish().await;
+        assert_eq!(project_run.job_id(), "job_3");
+        project_run.finish();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dropping_running_reconciliation_releases_the_active_scope() -> anyhow::Result<()> {
+        let queue = ReconciliationQueue::new();
+        let running = queued(queue.enqueue(ReconciliationScope::System, || {
+            Ok::<String, anyhow::Error>("job_1".to_string())
+        })?)?
+        .wait_for_turn()
+        .await;
+
+        drop(running);
+
+        assert!(matches!(
+            queue.enqueue(ReconciliationScope::System, || {
+                Ok::<String, anyhow::Error>("job_2".to_string())
+            })?,
+            EnqueueResult::Queued(_)
+        ));
 
         Ok(())
     }
 
     #[tokio::test]
     async fn debounce_coalesces_bursts_before_queueing_reconciliation() -> anyhow::Result<()> {
-        let queue = ReconciliationQueue::new();
-        let debouncer = ReconciliationDebouncer::new(queue.clone(), Duration::from_millis(10));
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        let debouncer = ReconciliationDebouncer::new(Duration::from_millis(10), move |scope| {
+            let _sent = sender.send(scope);
+        });
         let project_scope = ReconciliationScope::Project {
             id: "project_1".to_string(),
         };
@@ -269,22 +444,53 @@ mod tests {
         debouncer.request(project_scope.clone()).await;
         sleep(Duration::from_millis(50)).await;
 
-        assert!(matches!(
-            queue.enqueue(ReconciliationScope::System).await,
-            EnqueueResult::Coalesced
-        ));
-        assert!(matches!(
-            queue.enqueue(project_scope).await,
-            EnqueueResult::Coalesced
-        ));
+        let mut scopes = Vec::new();
+        while let Ok(scope) = receiver.try_recv() {
+            scopes.push(scope);
+        }
+
+        scopes.sort();
+        assert_eq!(scopes, vec![ReconciliationScope::System, project_scope]);
 
         Ok(())
+    }
+
+    #[test]
+    fn scope_parser_rejects_extra_or_missing_components_with_typed_errors() {
+        assert!(matches!(
+            "resource:mysql:8.4".parse::<ReconciliationScope>(),
+            Ok(ReconciliationScope::Resource { name, track })
+                if name == "mysql" && track == "8.4"
+        ));
+        assert!(matches!(
+            "resource:mysql:8.4:extra".parse::<ReconciliationScope>(),
+            Err(ReconciliationScopeParseError::InvalidComponentCount {
+                scope,
+                expected: 3,
+                actual: 4,
+            }) if scope == "resource:mysql:8.4:extra"
+        ));
+        assert!(matches!(
+            "project:".parse::<ReconciliationScope>(),
+            Err(ReconciliationScopeParseError::EmptyComponent {
+                scope,
+                component: "id",
+            }) if scope == "project:"
+        ));
+        assert!(matches!(
+            "unknown:scope".parse::<ReconciliationScope>(),
+            Err(ReconciliationScopeParseError::UnknownScope { scope })
+                if scope == "unknown:scope"
+        ));
     }
 
     fn queued(result: EnqueueResult) -> anyhow::Result<QueuedReconciliation> {
         match result {
             EnqueueResult::Queued(queued) => Ok(queued),
-            EnqueueResult::Coalesced => Err(anyhow::anyhow!("scope unexpectedly coalesced")),
+            EnqueueResult::Coalesced(job) => Err(anyhow::anyhow!(
+                "scope unexpectedly coalesced into {}",
+                job.job_id()
+            )),
         }
     }
 }

--- a/crates/daemon/src/reconciliation.rs
+++ b/crates/daemon/src/reconciliation.rs
@@ -41,12 +41,14 @@ pub struct ReconciliationJob {
 pub struct QueuedReconciliation {
     job: ReconciliationJob,
     inner: Arc<QueueInner>,
+    abandon_job: Option<JobFinalizer>,
     released: bool,
 }
 
 pub struct RunningReconciliation {
     job: ReconciliationJob,
     inner: Arc<QueueInner>,
+    abandon_job: Option<JobFinalizer>,
     finished: bool,
 }
 
@@ -81,6 +83,8 @@ struct QueueInner {
     notify: Notify,
 }
 
+type JobFinalizer = Box<dyn FnOnce(&str) + Send + 'static>;
+
 struct DebounceState {
     inner: Mutex<DebounceInner>,
 }
@@ -112,6 +116,15 @@ impl ReconciliationQueue {
         scope: ReconciliationScope,
         create_job_id: impl FnOnce() -> Result<String, E>,
     ) -> Result<EnqueueResult, E> {
+        self.enqueue_with_abandon(scope, create_job_id, |_job_id| {})
+    }
+
+    pub(crate) fn enqueue_with_abandon<E>(
+        &self,
+        scope: ReconciliationScope,
+        create_job_id: impl FnOnce() -> Result<String, E>,
+        abandon_job: impl FnOnce(&str) + Send + 'static,
+    ) -> Result<EnqueueResult, E> {
         let mut state = lock_queue_state(&self.inner);
 
         if let Some(job) = matching_queued_job(&state, &scope) {
@@ -128,6 +141,7 @@ impl ReconciliationQueue {
         Ok(EnqueueResult::Queued(QueuedReconciliation {
             job,
             inner: Arc::clone(&self.inner),
+            abandon_job: Some(Box::new(abandon_job)),
             released: false,
         }))
     }
@@ -154,11 +168,13 @@ impl QueuedReconciliation {
                     && let Some(job) = state.queued.pop_front()
                 {
                     state.active = Some(job.clone());
+                    let abandon_job = queued.abandon_job.take();
                     queued.released = true;
 
                     return RunningReconciliation {
                         job,
                         inner: Arc::clone(&queued.inner),
+                        abandon_job,
                         finished: false,
                     };
                 }
@@ -179,7 +195,11 @@ impl Drop for QueuedReconciliation {
             return;
         }
 
-        remove_queued_job(&self.inner, &self.job);
+        if remove_queued_job(&self.inner, &self.job)
+            && let Some(abandon_job) = self.abandon_job.take()
+        {
+            abandon_job(&self.job.job_id);
+        }
     }
 }
 
@@ -204,7 +224,11 @@ impl Drop for RunningReconciliation {
             return;
         }
 
-        release_active_job(&self.inner, &self.job);
+        if release_active_job(&self.inner, &self.job)
+            && let Some(abandon_job) = self.abandon_job.take()
+        {
+            abandon_job(&self.job.job_id);
+        }
     }
 }
 
@@ -391,17 +415,20 @@ fn matching_queued_job(
     state.queued.iter().find(|job| &job.scope == scope).cloned()
 }
 
-fn remove_queued_job(inner: &QueueInner, job: &ReconciliationJob) {
+fn remove_queued_job(inner: &QueueInner, job: &ReconciliationJob) -> bool {
     let mut state = lock_queue_state(inner);
     let queued_len = state.queued.len();
     state.queued.retain(|queued| queued.job_id != job.job_id);
 
     if state.queued.len() != queued_len {
         inner.notify.notify_waiters();
+        return true;
     }
+
+    false
 }
 
-fn release_active_job(inner: &QueueInner, job: &ReconciliationJob) {
+fn release_active_job(inner: &QueueInner, job: &ReconciliationJob) -> bool {
     let mut state = lock_queue_state(inner);
 
     if state
@@ -411,7 +438,10 @@ fn release_active_job(inner: &QueueInner, job: &ReconciliationJob) {
     {
         state.active = None;
         inner.notify.notify_waiters();
+        return true;
     }
+
+    false
 }
 
 fn lock_queue_state(inner: &QueueInner) -> MutexGuard<'_, QueueState> {

--- a/crates/daemon/src/reconciliation.rs
+++ b/crates/daemon/src/reconciliation.rs
@@ -1,0 +1,290 @@
+use std::collections::{BTreeSet, VecDeque};
+use std::fmt;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{Mutex, Notify};
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum ReconciliationScope {
+    System,
+    Project { id: String },
+    Resource { name: String, track: String },
+}
+
+#[derive(Clone)]
+pub struct ReconciliationQueue {
+    inner: Arc<QueueInner>,
+}
+
+pub enum EnqueueResult {
+    Queued(QueuedReconciliation),
+    Coalesced,
+}
+
+#[derive(Clone)]
+pub struct QueuedReconciliation {
+    scope: ReconciliationScope,
+    inner: Arc<QueueInner>,
+}
+
+pub struct RunningReconciliation {
+    scope: ReconciliationScope,
+    inner: Arc<QueueInner>,
+}
+
+#[derive(Clone)]
+pub struct ReconciliationDebouncer {
+    queue: ReconciliationQueue,
+    delay: Duration,
+    state: Arc<DebounceState>,
+}
+
+struct QueueInner {
+    state: Mutex<QueueState>,
+    notify: Notify,
+}
+
+struct DebounceState {
+    inner: Mutex<DebounceInner>,
+}
+
+#[derive(Debug, Default)]
+struct QueueState {
+    active: Option<ReconciliationScope>,
+    queued: VecDeque<ReconciliationScope>,
+}
+
+#[derive(Debug, Default)]
+struct DebounceInner {
+    pending: BTreeSet<ReconciliationScope>,
+    worker_running: bool,
+}
+
+impl ReconciliationQueue {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(QueueInner {
+                state: Mutex::new(QueueState::default()),
+                notify: Notify::new(),
+            }),
+        }
+    }
+
+    pub async fn enqueue(&self, scope: ReconciliationScope) -> EnqueueResult {
+        let mut state = self.inner.state.lock().await;
+
+        if state.active.as_ref() == Some(&scope) || state.queued.contains(&scope) {
+            return EnqueueResult::Coalesced;
+        }
+
+        state.queued.push_back(scope.clone());
+        self.inner.notify.notify_waiters();
+
+        EnqueueResult::Queued(QueuedReconciliation {
+            scope,
+            inner: Arc::clone(&self.inner),
+        })
+    }
+}
+
+impl Default for ReconciliationQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl QueuedReconciliation {
+    pub async fn wait_for_turn(self) -> RunningReconciliation {
+        loop {
+            let notified = self.inner.notify.notified();
+
+            {
+                let mut state = self.inner.state.lock().await;
+                if state.active.is_none() && state.queued.front() == Some(&self.scope) {
+                    state.queued.pop_front();
+                    state.active = Some(self.scope.clone());
+
+                    return RunningReconciliation {
+                        scope: self.scope,
+                        inner: Arc::clone(&self.inner),
+                    };
+                }
+            }
+
+            notified.await;
+        }
+    }
+}
+
+impl RunningReconciliation {
+    pub fn scope(&self) -> &ReconciliationScope {
+        &self.scope
+    }
+
+    pub async fn finish(self) {
+        let mut state = self.inner.state.lock().await;
+
+        if state.active.as_ref() == Some(&self.scope) {
+            state.active = None;
+            self.inner.notify.notify_waiters();
+        }
+    }
+}
+
+impl ReconciliationDebouncer {
+    pub fn new(queue: ReconciliationQueue, delay: Duration) -> Self {
+        Self {
+            queue,
+            delay,
+            state: Arc::new(DebounceState {
+                inner: Mutex::new(DebounceInner::default()),
+            }),
+        }
+    }
+
+    pub async fn request(&self, scope: ReconciliationScope) {
+        let should_spawn = {
+            let mut inner = self.state.inner.lock().await;
+            inner.pending.insert(scope);
+
+            if inner.worker_running {
+                false
+            } else {
+                inner.worker_running = true;
+                true
+            }
+        };
+
+        if should_spawn {
+            let debouncer = self.clone();
+            tokio::spawn(async move {
+                debouncer.flush_after_delay().await;
+            });
+        }
+    }
+
+    async fn flush_after_delay(self) {
+        tokio::time::sleep(self.delay).await;
+
+        let scopes = {
+            let mut inner = self.state.inner.lock().await;
+            inner.worker_running = false;
+            std::mem::take(&mut inner.pending)
+        };
+
+        for scope in scopes {
+            let _result = self.queue.enqueue(scope).await;
+        }
+    }
+}
+
+impl fmt::Display for ReconciliationScope {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::System => formatter.write_str("system"),
+            Self::Project { id } => write!(formatter, "project:{id}"),
+            Self::Resource { name, track } => write!(formatter, "resource:{name}:{track}"),
+        }
+    }
+}
+
+impl FromStr for ReconciliationScope {
+    type Err = ();
+
+    fn from_str(scope: &str) -> Result<Self, Self::Err> {
+        if scope == "system" {
+            return Ok(Self::System);
+        }
+
+        if let Some(id) = scope.strip_prefix("project:")
+            && !id.is_empty()
+        {
+            return Ok(Self::Project { id: id.to_string() });
+        }
+
+        if let Some(resource) = scope.strip_prefix("resource:") {
+            let Some((name, track)) = resource.split_once(':') else {
+                return Err(());
+            };
+
+            if !name.is_empty() && !track.is_empty() {
+                return Ok(Self::Resource {
+                    name: name.to_string(),
+                    track: track.to_string(),
+                });
+            }
+        }
+
+        Err(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::time::{Duration, sleep, timeout};
+
+    use super::{
+        EnqueueResult, QueuedReconciliation, ReconciliationDebouncer, ReconciliationQueue,
+        ReconciliationScope,
+    };
+
+    #[tokio::test]
+    async fn queue_runs_one_scope_at_a_time_and_coalesces_duplicates() -> anyhow::Result<()> {
+        let queue = ReconciliationQueue::new();
+        let first = queued(queue.enqueue(ReconciliationScope::System).await)?;
+        let first_run = first.wait_for_turn().await;
+
+        let duplicate = queue.enqueue(ReconciliationScope::System).await;
+        assert!(matches!(duplicate, EnqueueResult::Coalesced));
+
+        let project_scope = ReconciliationScope::Project {
+            id: "project_1".to_string(),
+        };
+        let project = queued(queue.enqueue(project_scope.clone()).await)?;
+        let project_wait =
+            timeout(Duration::from_millis(10), project.clone().wait_for_turn()).await;
+        assert!(project_wait.is_err());
+
+        first_run.finish().await;
+
+        let project_run = timeout(Duration::from_secs(1), project.wait_for_turn()).await?;
+        assert_eq!(project_run.scope(), &project_scope);
+        project_run.finish().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn debounce_coalesces_bursts_before_queueing_reconciliation() -> anyhow::Result<()> {
+        let queue = ReconciliationQueue::new();
+        let debouncer = ReconciliationDebouncer::new(queue.clone(), Duration::from_millis(10));
+        let project_scope = ReconciliationScope::Project {
+            id: "project_1".to_string(),
+        };
+
+        debouncer.request(ReconciliationScope::System).await;
+        debouncer.request(ReconciliationScope::System).await;
+        debouncer.request(project_scope.clone()).await;
+        sleep(Duration::from_millis(50)).await;
+
+        assert!(matches!(
+            queue.enqueue(ReconciliationScope::System).await,
+            EnqueueResult::Coalesced
+        ));
+        assert!(matches!(
+            queue.enqueue(project_scope).await,
+            EnqueueResult::Coalesced
+        ));
+
+        Ok(())
+    }
+
+    fn queued(result: EnqueueResult) -> anyhow::Result<QueuedReconciliation> {
+        match result {
+            EnqueueResult::Queued(queued) => Ok(queued),
+            EnqueueResult::Coalesced => Err(anyhow::anyhow!("scope unexpectedly coalesced")),
+        }
+    }
+}

--- a/crates/daemon/src/server.rs
+++ b/crates/daemon/src/server.rs
@@ -43,19 +43,25 @@ pub(crate) async fn serve(
     );
     let watcher =
         ProjectConfigWatcher::new(paths.clone(), debouncer, PROJECT_CONFIG_WATCH_INTERVAL);
-    connections.spawn(async move {
-        watcher.run().await;
-
-        Ok::<(), DaemonError>(())
-    });
+    let mut watcher_task = tokio::spawn(watcher.run());
 
     loop {
         tokio::select! {
             _ = &mut shutdown => {
+                watcher_task.abort();
+                let _join_result = watcher_task.await;
                 connections.abort_all();
                 while connections.join_next().await.is_some() {}
 
                 return Ok(());
+            }
+            watcher_result = &mut watcher_task => {
+                match watcher_result {
+                    Ok(Ok(())) => return Ok(()),
+                    Ok(Err(error)) => return Err(error),
+                    Err(error) if error.is_panic() => return Err(error.into()),
+                    Err(_error) => return Ok(()),
+                }
             }
             accepted = listener.accept() => {
                 match accepted {

--- a/crates/daemon/src/server.rs
+++ b/crates/daemon/src/server.rs
@@ -14,6 +14,7 @@ use crate::protocol::{
     DaemonCommand, DaemonRequest, DaemonResponse, DaemonTransport, PROTOCOL_VERSION,
     ResponseStatus, write_line,
 };
+use crate::reconciliation::ReconciliationQueue;
 
 const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(50);
 const REQUEST_LINE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -24,6 +25,7 @@ pub(crate) async fn serve(
     mut shutdown: oneshot::Receiver<()>,
 ) -> Result<(), DaemonError> {
     let mut connections = JoinSet::new();
+    let queue = ReconciliationQueue::new();
 
     loop {
         tokio::select! {
@@ -37,9 +39,10 @@ pub(crate) async fn serve(
                 match accepted {
                     Ok((stream, _address)) => {
                         let connection_paths = paths.clone();
+                        let connection_queue = queue.clone();
 
                         connections.spawn(async move {
-                            handle_connection(connection_paths, stream).await
+                            handle_connection(connection_paths, connection_queue, stream).await
                         });
                     }
                     Err(_error) => {
@@ -59,7 +62,11 @@ pub(crate) async fn serve(
     }
 }
 
-async fn handle_connection(paths: PvPaths, stream: LocalStream) -> Result<(), DaemonError> {
+async fn handle_connection(
+    paths: PvPaths,
+    queue: ReconciliationQueue,
+    stream: LocalStream,
+) -> Result<(), DaemonError> {
     let mut transport = crate::protocol::transport(stream);
     let Some(line) = read_request_line(&mut transport, REQUEST_LINE_TIMEOUT).await? else {
         return Ok(());
@@ -94,7 +101,9 @@ async fn handle_connection(paths: PvPaths, stream: LocalStream) -> Result<(), Da
             )
             .await
         }
-        DaemonCommand::RunJob { kind, scope } => run_job(paths, transport, &kind, &scope).await,
+        DaemonCommand::RunJob { kind, scope } => {
+            run_job(paths, queue, transport, &kind, &scope).await
+        }
     }
 }
 

--- a/crates/daemon/src/server.rs
+++ b/crates/daemon/src/server.rs
@@ -9,14 +9,17 @@ use tokio::time::{sleep, timeout};
 
 use crate::DaemonError;
 use crate::ipc::{LocalListener, LocalStream};
-use crate::jobs::run_job;
+use crate::jobs::{run_background_reconciliation_job, run_job};
 use crate::protocol::{
     DaemonCommand, DaemonRequest, DaemonResponse, DaemonTransport, PROTOCOL_VERSION,
     ResponseStatus, write_line,
 };
 use crate::reconciliation::ReconciliationQueue;
+use crate::watcher::ProjectConfigWatcher;
 
 const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(50);
+const PROJECT_CONFIG_DEBOUNCE: Duration = Duration::from_millis(50);
+const PROJECT_CONFIG_WATCH_INTERVAL: Duration = Duration::from_millis(100);
 const REQUEST_LINE_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub(crate) async fn serve(
@@ -26,6 +29,25 @@ pub(crate) async fn serve(
 ) -> Result<(), DaemonError> {
     let mut connections = JoinSet::new();
     let queue = ReconciliationQueue::new();
+    let background_paths = paths.clone();
+    let background_queue = queue.clone();
+    let debouncer = crate::reconciliation::ReconciliationDebouncer::new(
+        PROJECT_CONFIG_DEBOUNCE,
+        move |scope| {
+            let paths = background_paths.clone();
+            let queue = background_queue.clone();
+            let _task = tokio::spawn(async move {
+                let _result = run_background_reconciliation_job(paths, queue, scope).await;
+            });
+        },
+    );
+    let watcher =
+        ProjectConfigWatcher::new(paths.clone(), debouncer, PROJECT_CONFIG_WATCH_INTERVAL);
+    connections.spawn(async move {
+        watcher.run().await;
+
+        Ok::<(), DaemonError>(())
+    });
 
     loop {
         tokio::select! {

--- a/crates/daemon/src/server.rs
+++ b/crates/daemon/src/server.rs
@@ -9,7 +9,9 @@ use tokio::time::{sleep, timeout};
 
 use crate::DaemonError;
 use crate::ipc::{LocalListener, LocalStream};
-use crate::jobs::{run_background_reconciliation_job, run_job};
+use crate::jobs::{
+    record_background_reconciliation_error, run_background_reconciliation_job, run_job,
+};
 use crate::protocol::{
     DaemonCommand, DaemonRequest, DaemonResponse, DaemonTransport, PROTOCOL_VERSION,
     ResponseStatus, write_line,
@@ -37,7 +39,13 @@ pub(crate) async fn serve(
             let paths = background_paths.clone();
             let queue = background_queue.clone();
             let _task = tokio::spawn(async move {
-                let _result = run_background_reconciliation_job(paths, queue, scope).await;
+                let scope_text = scope.to_string();
+                if let Err(error) =
+                    run_background_reconciliation_job(paths.clone(), queue, scope).await
+                {
+                    let _result =
+                        record_background_reconciliation_error(&paths, &scope_text, &error);
+                }
             });
         },
     );

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -427,13 +427,13 @@ fn live_process_matches_spec(pid: u32, spec: &ProcessSpec) -> Result<bool, Daemo
     let Some(command_line) = live_process_command_line(pid)? else {
         return Ok(false);
     };
+    let Some(live_executable) = command_line.split_whitespace().next() else {
+        return Ok(false);
+    };
 
-    let command_matches = command_line.contains(spec.command.as_str())
+    let command_matches = live_executable == spec.command.as_str()
         || spec.command.file_name().is_some_and(|file_name| {
-            command_line
-                .split_whitespace()
-                .next()
-                .is_some_and(|command| command.ends_with(file_name))
+            live_executable == file_name || live_executable.ends_with(&format!("/{file_name}"))
         });
     Ok(command_matches)
 }

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -15,14 +15,23 @@ use crate::DaemonError;
 
 const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
+#[expect(
+    clippy::disallowed_types,
+    reason = "PV process supervisor verifies live process ownership"
+)]
+type StdCommand = std::process::Command;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProcessSpec {
     pub name: String,
     pub command: Utf8PathBuf,
     pub arguments: Vec<String>,
+    pub config_path: Utf8PathBuf,
     pub log_path: Utf8PathBuf,
     pub pid_path: Utf8PathBuf,
     pub metadata_path: Utf8PathBuf,
+    pub resource_name: String,
+    pub track: String,
 }
 
 #[derive(Debug)]
@@ -70,6 +79,12 @@ struct RuntimeMetadata {
     pid: u32,
     command: String,
     arguments: Vec<String>,
+    #[serde(default)]
+    config_path: String,
+    #[serde(default)]
+    resource_name: String,
+    #[serde(default)]
+    track: String,
     log_path: String,
     started_at: String,
 }
@@ -119,7 +134,7 @@ impl ProcessSupervisor {
             return Ok(None);
         };
 
-        if metadata.matches(spec, pid) && process_exists(pid)? {
+        if metadata.matches(spec, pid) && live_process_matches_spec(pid, spec)? {
             return Ok(Some(OwnedRuntime {
                 pid,
                 log_path: spec.log_path.clone(),
@@ -189,18 +204,26 @@ pub async fn wait_for_readiness(
     readiness_timeout: Duration,
 ) -> Result<(), DaemonError> {
     let started_at = Instant::now();
+    let mut last_error = None;
 
     while let Some(remaining) = remaining_timeout(started_at, readiness_timeout) {
         match timeout(remaining, check_once(&check)).await {
             Ok(Ok(())) => return Ok(()),
-            Ok(Err(_error)) => sleep(remaining.min(READINESS_POLL_INTERVAL)).await,
-            Err(_elapsed) => break,
+            Ok(Err(error)) => {
+                last_error = Some(error.to_string());
+                sleep(remaining.min(READINESS_POLL_INTERVAL)).await;
+            }
+            Err(elapsed) => {
+                last_error = Some(elapsed.to_string());
+                break;
+            }
         }
     }
 
     Err(DaemonError::ReadinessTimedOut {
         check: check.name(),
         timeout_ms: readiness_timeout.as_millis(),
+        last_error,
     })
 }
 
@@ -214,18 +237,26 @@ where
     Fut: Future<Output = bool>,
 {
     let started_at = Instant::now();
+    let mut last_error = None;
 
     while let Some(remaining) = remaining_timeout(started_at, readiness_timeout) {
         match timeout(remaining, check()).await {
             Ok(true) => return Ok(()),
-            Ok(false) => sleep(remaining.min(READINESS_POLL_INTERVAL)).await,
-            Err(_elapsed) => break,
+            Ok(false) => {
+                last_error = Some("custom readiness returned false".to_string());
+                sleep(remaining.min(READINESS_POLL_INTERVAL)).await;
+            }
+            Err(elapsed) => {
+                last_error = Some(elapsed.to_string());
+                break;
+            }
         }
     }
 
     Err(DaemonError::ReadinessTimedOut {
         check: format!("custom:{name}"),
         timeout_ms: readiness_timeout.as_millis(),
+        last_error,
     })
 }
 
@@ -329,6 +360,9 @@ fn write_runtime_metadata(spec: &ProcessSpec, pid: u32) -> Result<(), DaemonErro
         pid,
         command: spec.command.to_string(),
         arguments: spec.arguments.clone(),
+        config_path: spec.config_path.to_string(),
+        resource_name: spec.resource_name.clone(),
+        track: spec.track.clone(),
         log_path: spec.log_path.to_string(),
         started_at,
     };
@@ -385,6 +419,42 @@ fn process_exists(pid: u32) -> Result<bool, DaemonError> {
     }
 }
 
+fn live_process_matches_spec(pid: u32, spec: &ProcessSpec) -> Result<bool, DaemonError> {
+    if !process_exists(pid)? {
+        return Ok(false);
+    }
+
+    let Some(command_line) = live_process_command_line(pid)? else {
+        return Ok(false);
+    };
+
+    let command_matches = command_line.contains(spec.command.as_str())
+        || spec.command.file_name().is_some_and(|file_name| {
+            command_line
+                .split_whitespace()
+                .next()
+                .is_some_and(|command| command.ends_with(file_name))
+        });
+    Ok(command_matches)
+}
+
+fn live_process_command_line(pid: u32) -> Result<Option<String>, DaemonError> {
+    let output = StdCommand::new("/bin/ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+
+    let command_line = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if command_line.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(command_line))
+}
+
 fn process_not_found(error: &io::Error) -> bool {
     error.kind() == io::ErrorKind::NotFound || error.raw_os_error() == Some(3)
 }
@@ -395,6 +465,9 @@ impl RuntimeMetadata {
             && self.pid == pid
             && self.command == spec.command.as_str()
             && self.arguments == spec.arguments
+            && self.config_path == spec.config_path.as_str()
+            && self.resource_name == spec.resource_name
+            && self.track == spec.track
             && self.log_path == spec.log_path.as_str()
     }
 }

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -3,9 +3,9 @@ use std::time::Duration;
 use std::{future::Future, io};
 
 use camino::{Utf8Path, Utf8PathBuf};
-use rustix::process::{Pid, Signal, kill_process_group};
-use serde::Serialize;
-use state::{PvPaths, fs};
+use rustix::process::{Pid, Signal, kill_process_group, test_kill_process};
+use serde::{Deserialize, Serialize};
+use state::{PvPaths, StateError, fs};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::process::Child;
@@ -39,6 +39,19 @@ pub struct ManagedProcess {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OwnedRuntime {
+    pid: u32,
+    log_path: Utf8PathBuf,
+    pid_path: Utf8PathBuf,
+    metadata_path: Utf8PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdoptedProcess {
+    owned: OwnedRuntime,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ReadinessCheck {
     Tcp {
         host: String,
@@ -51,13 +64,13 @@ pub enum ReadinessCheck {
     },
 }
 
-#[derive(Serialize)]
-struct RuntimeMetadata<'metadata> {
-    name: &'metadata str,
+#[derive(Deserialize, Serialize)]
+struct RuntimeMetadata {
+    name: String,
     pid: u32,
-    command: &'metadata str,
-    arguments: &'metadata [String],
-    log_path: &'metadata str,
+    command: String,
+    arguments: Vec<String>,
+    log_path: String,
     started_at: String,
 }
 
@@ -75,13 +88,16 @@ impl ProcessSupervisor {
         command.stdout(Stdio::from(stdout));
         command.stderr(Stdio::from(stderr));
 
-        let child = command.spawn()?;
+        let mut child = command.spawn()?;
         let Some(pid) = child.id() else {
             return Err(DaemonError::MissingProcessId { name: spec.name });
         };
 
-        fs::write_sensitive_file(&spec.pid_path, &format!("{pid}\n"))?;
-        write_runtime_metadata(&spec, pid)?;
+        if let Err(error) = persist_runtime_files(&spec, pid) {
+            terminate_spawned_child(pid, &mut child).await;
+
+            return Err(error);
+        }
 
         Ok(ManagedProcess {
             pid,
@@ -90,6 +106,35 @@ impl ProcessSupervisor {
             pid_path: spec.pid_path,
             metadata_path: spec.metadata_path,
         })
+    }
+
+    pub fn verify_ownership(
+        &self,
+        spec: &ProcessSpec,
+    ) -> Result<Option<OwnedRuntime>, DaemonError> {
+        let Some(pid) = read_pid_file(&spec.pid_path)? else {
+            return Ok(None);
+        };
+        let Some(metadata) = read_runtime_metadata(&spec.metadata_path)? else {
+            return Ok(None);
+        };
+
+        if metadata.matches(spec, pid) && process_exists(pid)? {
+            return Ok(Some(OwnedRuntime {
+                pid,
+                log_path: spec.log_path.clone(),
+                pid_path: spec.pid_path.clone(),
+                metadata_path: spec.metadata_path.clone(),
+            }));
+        }
+
+        Ok(None)
+    }
+
+    pub fn adopt(&self, spec: &ProcessSpec) -> Result<Option<AdoptedProcess>, DaemonError> {
+        Ok(self
+            .verify_ownership(spec)?
+            .map(|owned| AdoptedProcess { owned }))
     }
 }
 
@@ -111,15 +156,31 @@ impl ManagedProcess {
     }
 
     pub async fn stop(mut self, grace_period: Duration) -> Result<(), DaemonError> {
+        if self.child.try_wait()?.is_some() {
+            return Ok(());
+        }
+
         let process_group = process_group_pid(self.pid)?;
-        kill_process_group(process_group, Signal::TERM).map_err(io::Error::from)?;
+        signal_process_group(process_group, Signal::TERM)?;
 
         if timeout(grace_period, self.child.wait()).await.is_err() {
-            kill_process_group(process_group, Signal::KILL).map_err(io::Error::from)?;
+            signal_process_group(process_group, Signal::KILL)?;
             self.child.wait().await?;
         }
 
         Ok(())
+    }
+}
+
+impl OwnedRuntime {
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+}
+
+impl AdoptedProcess {
+    pub fn pid(&self) -> u32 {
+        self.owned.pid()
     }
 }
 
@@ -129,12 +190,12 @@ pub async fn wait_for_readiness(
 ) -> Result<(), DaemonError> {
     let started_at = Instant::now();
 
-    while started_at.elapsed() < readiness_timeout {
-        if check_once(&check).await.is_ok() {
-            return Ok(());
+    while let Some(remaining) = remaining_timeout(started_at, readiness_timeout) {
+        match timeout(remaining, check_once(&check)).await {
+            Ok(Ok(())) => return Ok(()),
+            Ok(Err(_error)) => sleep(remaining.min(READINESS_POLL_INTERVAL)).await,
+            Err(_elapsed) => break,
         }
-
-        sleep(READINESS_POLL_INTERVAL).await;
     }
 
     Err(DaemonError::ReadinessTimedOut {
@@ -154,18 +215,24 @@ where
 {
     let started_at = Instant::now();
 
-    while started_at.elapsed() < readiness_timeout {
-        if check().await {
-            return Ok(());
+    while let Some(remaining) = remaining_timeout(started_at, readiness_timeout) {
+        match timeout(remaining, check()).await {
+            Ok(true) => return Ok(()),
+            Ok(false) => sleep(remaining.min(READINESS_POLL_INTERVAL)).await,
+            Err(_elapsed) => break,
         }
-
-        sleep(READINESS_POLL_INTERVAL).await;
     }
 
     Err(DaemonError::ReadinessTimedOut {
         check: format!("custom:{name}"),
         timeout_ms: readiness_timeout.as_millis(),
     })
+}
+
+fn remaining_timeout(started_at: Instant, readiness_timeout: Duration) -> Option<Duration> {
+    readiness_timeout
+        .checked_sub(started_at.elapsed())
+        .filter(|remaining| !remaining.is_zero())
 }
 
 impl ReadinessCheck {
@@ -215,6 +282,28 @@ fn process_group_pid(pid: u32) -> Result<Pid, DaemonError> {
     })
 }
 
+fn signal_process_group(process_group: Pid, signal: Signal) -> Result<(), DaemonError> {
+    match kill_process_group(process_group, signal) {
+        Ok(()) => Ok(()),
+        Err(source) => {
+            let error = io::Error::from(source);
+            if process_not_found(&error) {
+                return Ok(());
+            }
+
+            Err(error.into())
+        }
+    }
+}
+
+async fn terminate_spawned_child(pid: u32, child: &mut Child) {
+    if let Ok(process_group) = process_group_pid(pid) {
+        let _result = signal_process_group(process_group, Signal::KILL);
+    }
+
+    let _result = child.wait().await;
+}
+
 #[expect(
     clippy::disallowed_types,
     reason = "PV process supervisor owns child process spawning"
@@ -228,14 +317,19 @@ fn process_command(spec: &ProcessSpec) -> tokio::process::Command {
     command
 }
 
+fn persist_runtime_files(spec: &ProcessSpec, pid: u32) -> Result<(), DaemonError> {
+    fs::write_sensitive_file(&spec.pid_path, &format!("{pid}\n"))?;
+    write_runtime_metadata(spec, pid)
+}
+
 fn write_runtime_metadata(spec: &ProcessSpec, pid: u32) -> Result<(), DaemonError> {
     let started_at = timestamp()?;
     let metadata = RuntimeMetadata {
-        name: &spec.name,
+        name: spec.name.clone(),
         pid,
-        command: spec.command.as_str(),
-        arguments: &spec.arguments,
-        log_path: spec.log_path.as_str(),
+        command: spec.command.to_string(),
+        arguments: spec.arguments.clone(),
+        log_path: spec.log_path.to_string(),
         started_at,
     };
     let encoded = serde_json::to_string(&metadata)?;
@@ -243,6 +337,66 @@ fn write_runtime_metadata(spec: &ProcessSpec, pid: u32) -> Result<(), DaemonErro
     fs::write_sensitive_file(&spec.metadata_path, &encoded)?;
 
     Ok(())
+}
+
+fn read_pid_file(path: &Utf8Path) -> Result<Option<u32>, DaemonError> {
+    let Some(content) = read_optional_file(path)? else {
+        return Ok(None);
+    };
+    let pid = content
+        .trim()
+        .parse::<u32>()
+        .map_err(|source| io::Error::new(io::ErrorKind::InvalidData, source))?;
+
+    Ok(Some(pid))
+}
+
+fn read_runtime_metadata(path: &Utf8Path) -> Result<Option<RuntimeMetadata>, DaemonError> {
+    let Some(content) = read_optional_file(path)? else {
+        return Ok(None);
+    };
+
+    Ok(Some(serde_json::from_str(&content)?))
+}
+
+fn read_optional_file(path: &Utf8Path) -> Result<Option<String>, DaemonError> {
+    match fs::read_to_string(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(StateError::Filesystem { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+            Ok(None)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn process_exists(pid: u32) -> Result<bool, DaemonError> {
+    let pid = process_group_pid(pid)?;
+
+    match test_kill_process(pid) {
+        Ok(()) => Ok(true),
+        Err(source) => {
+            let error = io::Error::from(source);
+            if process_not_found(&error) {
+                return Ok(false);
+            }
+
+            Err(error.into())
+        }
+    }
+}
+
+fn process_not_found(error: &io::Error) -> bool {
+    error.kind() == io::ErrorKind::NotFound || error.raw_os_error() == Some(3)
+}
+
+impl RuntimeMetadata {
+    fn matches(&self, spec: &ProcessSpec, pid: u32) -> bool {
+        self.name == spec.name
+            && self.pid == pid
+            && self.command == spec.command.as_str()
+            && self.arguments == spec.arguments
+            && self.log_path == spec.log_path.as_str()
+    }
 }
 
 fn timestamp() -> Result<String, DaemonError> {

--- a/crates/daemon/src/supervisor.rs
+++ b/crates/daemon/src/supervisor.rs
@@ -1,0 +1,253 @@
+use std::process::Stdio;
+use std::time::Duration;
+use std::{future::Future, io};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use rustix::process::{Pid, Signal, kill_process_group};
+use serde::Serialize;
+use state::{PvPaths, fs};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::process::Child;
+use tokio::time::{Instant, sleep, timeout};
+
+use crate::DaemonError;
+
+const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessSpec {
+    pub name: String,
+    pub command: Utf8PathBuf,
+    pub arguments: Vec<String>,
+    pub log_path: Utf8PathBuf,
+    pub pid_path: Utf8PathBuf,
+    pub metadata_path: Utf8PathBuf,
+}
+
+#[derive(Debug)]
+pub struct ProcessSupervisor {
+    paths: PvPaths,
+}
+
+pub struct ManagedProcess {
+    pid: u32,
+    child: Child,
+    log_path: Utf8PathBuf,
+    pid_path: Utf8PathBuf,
+    metadata_path: Utf8PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ReadinessCheck {
+    Tcp {
+        host: String,
+        port: u16,
+    },
+    Http {
+        host: String,
+        port: u16,
+        path: String,
+    },
+}
+
+#[derive(Serialize)]
+struct RuntimeMetadata<'metadata> {
+    name: &'metadata str,
+    pid: u32,
+    command: &'metadata str,
+    arguments: &'metadata [String],
+    log_path: &'metadata str,
+    started_at: String,
+}
+
+impl ProcessSupervisor {
+    pub fn new(paths: PvPaths) -> Self {
+        Self { paths }
+    }
+
+    pub async fn start(&self, spec: ProcessSpec) -> Result<ManagedProcess, DaemonError> {
+        state::fs::ensure_layout(&self.paths)?;
+
+        let stdout = fs::open_append_file(&spec.log_path)?;
+        let stderr = fs::open_append_file(&spec.log_path)?;
+        let mut command = process_command(&spec);
+        command.stdout(Stdio::from(stdout));
+        command.stderr(Stdio::from(stderr));
+
+        let child = command.spawn()?;
+        let Some(pid) = child.id() else {
+            return Err(DaemonError::MissingProcessId { name: spec.name });
+        };
+
+        fs::write_sensitive_file(&spec.pid_path, &format!("{pid}\n"))?;
+        write_runtime_metadata(&spec, pid)?;
+
+        Ok(ManagedProcess {
+            pid,
+            child,
+            log_path: spec.log_path,
+            pid_path: spec.pid_path,
+            metadata_path: spec.metadata_path,
+        })
+    }
+}
+
+impl ManagedProcess {
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    pub fn log_path(&self) -> &Utf8Path {
+        &self.log_path
+    }
+
+    pub fn pid_path(&self) -> &Utf8Path {
+        &self.pid_path
+    }
+
+    pub fn metadata_path(&self) -> &Utf8Path {
+        &self.metadata_path
+    }
+
+    pub async fn stop(mut self, grace_period: Duration) -> Result<(), DaemonError> {
+        let process_group = process_group_pid(self.pid)?;
+        kill_process_group(process_group, Signal::TERM).map_err(io::Error::from)?;
+
+        if timeout(grace_period, self.child.wait()).await.is_err() {
+            kill_process_group(process_group, Signal::KILL).map_err(io::Error::from)?;
+            self.child.wait().await?;
+        }
+
+        Ok(())
+    }
+}
+
+pub async fn wait_for_readiness(
+    check: ReadinessCheck,
+    readiness_timeout: Duration,
+) -> Result<(), DaemonError> {
+    let started_at = Instant::now();
+
+    while started_at.elapsed() < readiness_timeout {
+        if check_once(&check).await.is_ok() {
+            return Ok(());
+        }
+
+        sleep(READINESS_POLL_INTERVAL).await;
+    }
+
+    Err(DaemonError::ReadinessTimedOut {
+        check: check.name(),
+        timeout_ms: readiness_timeout.as_millis(),
+    })
+}
+
+pub async fn wait_for_custom_readiness<F, Fut>(
+    name: &str,
+    readiness_timeout: Duration,
+    mut check: F,
+) -> Result<(), DaemonError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let started_at = Instant::now();
+
+    while started_at.elapsed() < readiness_timeout {
+        if check().await {
+            return Ok(());
+        }
+
+        sleep(READINESS_POLL_INTERVAL).await;
+    }
+
+    Err(DaemonError::ReadinessTimedOut {
+        check: format!("custom:{name}"),
+        timeout_ms: readiness_timeout.as_millis(),
+    })
+}
+
+impl ReadinessCheck {
+    fn name(&self) -> String {
+        match self {
+            Self::Tcp { host, port } => format!("tcp:{host}:{port}"),
+            Self::Http { host, port, path } => format!("http:{host}:{port}{path}"),
+        }
+    }
+}
+
+async fn check_once(check: &ReadinessCheck) -> Result<(), DaemonError> {
+    match check {
+        ReadinessCheck::Tcp { host, port } => {
+            let _stream = TcpStream::connect((host.as_str(), *port)).await?;
+            Ok(())
+        }
+        ReadinessCheck::Http { host, port, path } => {
+            let mut stream = TcpStream::connect((host.as_str(), *port)).await?;
+            let request =
+                format!("GET {path} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
+            stream.write_all(request.as_bytes()).await?;
+
+            let mut response = [0_u8; 12];
+            let bytes = stream.read(&mut response).await?;
+            let status_is_success = bytes >= 10
+                && (response.starts_with(b"HTTP/1.1 2") || response.starts_with(b"HTTP/1.0 2"));
+
+            if status_is_success {
+                return Ok(());
+            }
+
+            Err(io::Error::other("HTTP readiness returned non-success status").into())
+        }
+    }
+}
+
+fn process_group_pid(pid: u32) -> Result<Pid, DaemonError> {
+    let raw_pid =
+        i32::try_from(pid).map_err(|source| io::Error::new(io::ErrorKind::InvalidInput, source))?;
+
+    Pid::from_raw(raw_pid).ok_or_else(|| {
+        DaemonError::Io(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "process id must be positive",
+        ))
+    })
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "PV process supervisor owns child process spawning"
+)]
+fn process_command(spec: &ProcessSpec) -> tokio::process::Command {
+    let mut command = tokio::process::Command::new(&spec.command);
+    command.args(&spec.arguments);
+    #[cfg(unix)]
+    command.process_group(0);
+
+    command
+}
+
+fn write_runtime_metadata(spec: &ProcessSpec, pid: u32) -> Result<(), DaemonError> {
+    let started_at = timestamp()?;
+    let metadata = RuntimeMetadata {
+        name: &spec.name,
+        pid,
+        command: spec.command.as_str(),
+        arguments: &spec.arguments,
+        log_path: spec.log_path.as_str(),
+        started_at,
+    };
+    let encoded = serde_json::to_string(&metadata)?;
+
+    fs::write_sensitive_file(&spec.metadata_path, &encoded)?;
+
+    Ok(())
+}
+
+fn timestamp() -> Result<String, DaemonError> {
+    let format =
+        time::macros::format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]Z");
+
+    Ok(time::OffsetDateTime::now_utc().format(format)?)
+}

--- a/crates/daemon/src/watcher.rs
+++ b/crates/daemon/src/watcher.rs
@@ -48,19 +48,7 @@ impl ProjectConfigWatcher {
         let mut current_configs = BTreeMap::new();
 
         for watch in watches {
-            let modified_at = match fs::modified_at(&watch.config_path) {
-                Ok(modified_at) => modified_at,
-                Err(_error) => {
-                    current_configs.insert(
-                        watch.project_id,
-                        WatchedConfig {
-                            path: watch.config_path,
-                            modified_at: None,
-                        },
-                    );
-                    continue;
-                }
-            };
+            let modified_at = fs::modified_at(&watch.config_path)?;
             let watched_config = WatchedConfig {
                 path: watch.config_path,
                 modified_at,
@@ -112,8 +100,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn watcher_keeps_polling_when_one_project_config_path_is_unreadable() -> anyhow::Result<()>
-    {
+    async fn watcher_returns_project_config_modified_at_errors_to_the_task_owner()
+    -> anyhow::Result<()> {
         let tempdir = tempdir()?;
         let paths = PvPaths::for_home(tempdir.path().join("home"));
         let project_path = tempdir.path().join("project");
@@ -151,7 +139,13 @@ mod tests {
         let debouncer = ReconciliationDebouncer::new(Duration::from_millis(1), |_scope| {});
         let mut watcher = ProjectConfigWatcher::new(paths, debouncer, Duration::from_millis(1));
 
-        watcher.poll_once().await?;
+        let result = watcher.poll_once().await;
+
+        assert!(matches!(
+            result,
+            Err(crate::DaemonError::State(state::StateError::Filesystem { source, .. }))
+                if source.kind() == std::io::ErrorKind::InvalidInput
+        ));
 
         Ok(())
     }

--- a/crates/daemon/src/watcher.rs
+++ b/crates/daemon/src/watcher.rs
@@ -35,9 +35,9 @@ impl ProjectConfigWatcher {
         }
     }
 
-    pub(crate) async fn run(mut self) {
+    pub(crate) async fn run(mut self) -> Result<(), DaemonError> {
         loop {
-            let _result = self.poll_once().await;
+            self.poll_once().await?;
             sleep(self.poll_interval).await;
         }
     }
@@ -70,6 +70,32 @@ impl ProjectConfigWatcher {
         }
 
         self.watched_configs = current_configs;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use camino_tempfile::tempdir;
+    use tokio::time::timeout;
+
+    use super::ProjectConfigWatcher;
+    use crate::reconciliation::ReconciliationDebouncer;
+
+    #[tokio::test]
+    async fn watcher_returns_poll_errors_to_the_task_owner() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let paths = state::PvPaths::for_home(tempdir.path().join("home"));
+        state::fs::write_sensitive_file(paths.root(), "not a directory")?;
+        let debouncer = ReconciliationDebouncer::new(Duration::from_millis(1), |_scope| {});
+        let watcher = ProjectConfigWatcher::new(paths, debouncer, Duration::from_millis(1));
+
+        let result = timeout(Duration::from_millis(50), watcher.run()).await?;
+
+        assert!(result.is_err());
 
         Ok(())
     }

--- a/crates/daemon/src/watcher.rs
+++ b/crates/daemon/src/watcher.rs
@@ -48,7 +48,19 @@ impl ProjectConfigWatcher {
         let mut current_configs = BTreeMap::new();
 
         for watch in watches {
-            let modified_at = fs::modified_at(&watch.config_path)?;
+            let modified_at = match fs::modified_at(&watch.config_path) {
+                Ok(modified_at) => modified_at,
+                Err(_error) => {
+                    current_configs.insert(
+                        watch.project_id,
+                        WatchedConfig {
+                            path: watch.config_path,
+                            modified_at: None,
+                        },
+                    );
+                    continue;
+                }
+            };
             let watched_config = WatchedConfig {
                 path: watch.config_path,
                 modified_at,
@@ -58,12 +70,9 @@ impl ProjectConfigWatcher {
                 .watched_configs
                 .insert(watch.project_id.clone(), watched_config.clone())
                 && previous_config != watched_config
+                && let Ok(scope) = ReconciliationScope::project(watch.project_id.clone())
             {
-                self.debouncer
-                    .request(ReconciliationScope::Project {
-                        id: watch.project_id.clone(),
-                    })
-                    .await;
+                self.debouncer.request(scope).await;
             }
 
             current_configs.insert(watch.project_id, watched_config);
@@ -80,6 +89,8 @@ mod tests {
     use std::time::Duration;
 
     use camino_tempfile::tempdir;
+    use rusqlite::params;
+    use state::{Database, PvPaths, fs};
     use tokio::time::timeout;
 
     use super::ProjectConfigWatcher;
@@ -88,14 +99,59 @@ mod tests {
     #[tokio::test]
     async fn watcher_returns_poll_errors_to_the_task_owner() -> anyhow::Result<()> {
         let tempdir = tempdir()?;
-        let paths = state::PvPaths::for_home(tempdir.path().join("home"));
-        state::fs::write_sensitive_file(paths.root(), "not a directory")?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        fs::write_sensitive_file(paths.root(), "not a directory")?;
         let debouncer = ReconciliationDebouncer::new(Duration::from_millis(1), |_scope| {});
         let watcher = ProjectConfigWatcher::new(paths, debouncer, Duration::from_millis(1));
 
         let result = timeout(Duration::from_millis(50), watcher.run()).await?;
 
         assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn watcher_keeps_polling_when_one_project_config_path_is_unreadable() -> anyhow::Result<()>
+    {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let project_path = tempdir.path().join("project");
+        let config_path = project_path.join("pv.yml");
+        fs::write_sensitive_file(&config_path, "php: '8.3'\n")?;
+        let mut database = Database::open(&paths)?;
+        state::testing::transaction(&mut database, |transaction| {
+            transaction.execute(
+                "INSERT INTO projects (id, path, primary_hostname, config_path, created_at, updated_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    "bad_project",
+                    "/tmp/bad",
+                    "bad.test",
+                    "bad\0path",
+                    "2026-05-25T00:00:00Z",
+                    "2026-05-25T00:00:00Z",
+                ],
+            )?;
+            transaction.execute(
+                "INSERT INTO projects (id, path, primary_hostname, config_path, created_at, updated_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    "good_project",
+                    project_path.as_str(),
+                    "good.test",
+                    config_path.as_str(),
+                    "2026-05-25T00:00:00Z",
+                    "2026-05-25T00:00:00Z",
+                ],
+            )?;
+
+            Ok(())
+        })?;
+        let debouncer = ReconciliationDebouncer::new(Duration::from_millis(1), |_scope| {});
+        let mut watcher = ProjectConfigWatcher::new(paths, debouncer, Duration::from_millis(1));
+
+        watcher.poll_once().await?;
 
         Ok(())
     }

--- a/crates/daemon/src/watcher.rs
+++ b/crates/daemon/src/watcher.rs
@@ -1,0 +1,76 @@
+use std::collections::BTreeMap;
+use std::time::{Duration, SystemTime};
+
+use camino::Utf8PathBuf;
+use state::{Database, PvPaths, fs};
+use tokio::time::sleep;
+
+use crate::DaemonError;
+use crate::reconciliation::{ReconciliationDebouncer, ReconciliationScope};
+
+pub(crate) struct ProjectConfigWatcher {
+    paths: PvPaths,
+    debouncer: ReconciliationDebouncer,
+    poll_interval: Duration,
+    watched_configs: BTreeMap<String, WatchedConfig>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct WatchedConfig {
+    path: Utf8PathBuf,
+    modified_at: Option<SystemTime>,
+}
+
+impl ProjectConfigWatcher {
+    pub(crate) fn new(
+        paths: PvPaths,
+        debouncer: ReconciliationDebouncer,
+        poll_interval: Duration,
+    ) -> Self {
+        Self {
+            paths,
+            debouncer,
+            poll_interval,
+            watched_configs: BTreeMap::new(),
+        }
+    }
+
+    pub(crate) async fn run(mut self) {
+        loop {
+            let _result = self.poll_once().await;
+            sleep(self.poll_interval).await;
+        }
+    }
+
+    async fn poll_once(&mut self) -> Result<(), DaemonError> {
+        let database = Database::open(&self.paths)?;
+        let watches = database.project_config_watches()?;
+        let mut current_configs = BTreeMap::new();
+
+        for watch in watches {
+            let modified_at = fs::modified_at(&watch.config_path)?;
+            let watched_config = WatchedConfig {
+                path: watch.config_path,
+                modified_at,
+            };
+
+            if let Some(previous_config) = self
+                .watched_configs
+                .insert(watch.project_id.clone(), watched_config.clone())
+                && previous_config != watched_config
+            {
+                self.debouncer
+                    .request(ReconciliationScope::Project {
+                        id: watch.project_id.clone(),
+                    })
+                    .await;
+            }
+
+            current_configs.insert(watch.project_id, watched_config);
+        }
+
+        self.watched_configs = current_configs;
+
+        Ok(())
+    }
+}

--- a/crates/daemon/tests/daemon_foundation.rs
+++ b/crates/daemon/tests/daemon_foundation.rs
@@ -3,7 +3,7 @@ use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
 use rusqlite::params;
 use serde_json::{Value, json};
-use state::{Database, JobRecord, PvPaths};
+use state::{Database, JobRecord, JobStatus, PvPaths};
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
@@ -101,6 +101,35 @@ async fn valid_reconciliation_scopes_stream_stub_completion() -> Result<()> {
     assert_with_normalized_timestamps(
         "valid_reconciliation_scopes_stream_stub_completion",
         (project_lines, resource_lines, database.recent_jobs()?),
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_reconciliation_scope_reports_scope_parse_failure() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let daemon = daemon::RunningDaemon::start(paths.clone()).await?;
+
+    let lines = request_lines(
+        &paths,
+        json!({
+            "protocol_version": daemon::PROTOCOL_VERSION,
+            "command": "run_job",
+            "kind": "reconcile",
+            "scope": "project:",
+        }),
+    )
+    .await?;
+
+    daemon.shutdown().await?;
+
+    let database = Database::open(&paths)?;
+
+    assert_with_normalized_timestamps(
+        "invalid_reconciliation_scope_reports_scope_parse_failure",
+        (lines, database.recent_jobs()?),
     )?;
 
     Ok(())
@@ -286,12 +315,14 @@ async fn project_config_watcher_enqueues_project_reconciliation() -> Result<()> 
 
     write_file_after_modified_time_tick(&config_path, "php: '8.4'\n").await?;
 
-    let job = wait_for_job_scope(&paths, "project:project_1").await?;
+    let job = wait_for_succeeded_job_scope(&paths, "project:project_1").await?;
 
     daemon.shutdown().await?;
 
     assert_eq!(job.kind, "reconcile");
     assert_eq!(job.scope, "project:project_1");
+    assert_eq!(job.status, JobStatus::Succeeded);
+    assert_eq!(job.summary.as_deref(), Some("stub job completed"));
 
     Ok(())
 }
@@ -340,13 +371,13 @@ async fn request_lines(paths: &PvPaths, request: Value) -> Result<Vec<Value>> {
     Ok(lines)
 }
 
-async fn wait_for_job_scope(paths: &PvPaths, scope: &str) -> Result<JobRecord> {
+async fn wait_for_succeeded_job_scope(paths: &PvPaths, scope: &str) -> Result<JobRecord> {
     for _attempt in 0..50 {
         let database = Database::open(paths)?;
         if let Some(job) = database
             .recent_jobs()?
             .into_iter()
-            .find(|job| job.scope == scope)
+            .find(|job| job.scope == scope && job.status == JobStatus::Succeeded)
         {
             return Ok(job);
         }
@@ -354,7 +385,9 @@ async fn wait_for_job_scope(paths: &PvPaths, scope: &str) -> Result<JobRecord> {
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
-    Err(anyhow::anyhow!("job with scope {scope:?} was not recorded"))
+    Err(anyhow::anyhow!(
+        "succeeded job with scope {scope:?} was not recorded"
+    ))
 }
 
 async fn write_file_after_modified_time_tick(path: &camino::Utf8Path, content: &str) -> Result<()> {

--- a/crates/daemon/tests/daemon_foundation.rs
+++ b/crates/daemon/tests/daemon_foundation.rs
@@ -1,8 +1,9 @@
 use anyhow::Result;
 use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
+use rusqlite::params;
 use serde_json::{Value, json};
-use state::{Database, PvPaths};
+use state::{Database, JobRecord, PvPaths};
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::UnixStream;
@@ -257,6 +258,45 @@ async fn disconnected_job_stream_still_persists_final_status() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn project_config_watcher_enqueues_project_reconciliation() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project_path = tempdir.path().join("project");
+    let config_path = project_path.join("pv.yml");
+    state::fs::write_sensitive_file(&config_path, "php: '8.3'\n")?;
+    let mut database = Database::open(&paths)?;
+    state::testing::transaction(&mut database, |transaction| {
+        transaction.execute(
+            "INSERT INTO projects (id, path, primary_hostname, config_path, created_at, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                "project_1",
+                project_path.as_str(),
+                "project.test",
+                config_path.as_str(),
+                "2026-05-24T00:00:00Z",
+                "2026-05-24T00:00:00Z",
+            ],
+        )?;
+
+        Ok(())
+    })?;
+    let daemon = daemon::RunningDaemon::start(paths.clone()).await?;
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    state::fs::write_sensitive_file(&config_path, "php: '8.4'\n")?;
+
+    let job = wait_for_job_scope(&paths, "project:project_1").await?;
+
+    daemon.shutdown().await?;
+
+    assert_eq!(job.kind, "reconcile");
+    assert_eq!(job.scope, "project:project_1");
+
+    Ok(())
+}
+
 fn assert_with_normalized_timestamps(
     name: &'static str,
     snapshot: impl std::fmt::Debug,
@@ -299,4 +339,21 @@ async fn request_lines(paths: &PvPaths, request: Value) -> Result<Vec<Value>> {
     }
 
     Ok(lines)
+}
+
+async fn wait_for_job_scope(paths: &PvPaths, scope: &str) -> Result<JobRecord> {
+    for _attempt in 0..50 {
+        let database = Database::open(paths)?;
+        if let Some(job) = database
+            .recent_jobs()?
+            .into_iter()
+            .find(|job| job.scope == scope)
+        {
+            return Ok(job);
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    Err(anyhow::anyhow!("job with scope {scope:?} was not recorded"))
 }

--- a/crates/daemon/tests/daemon_foundation.rs
+++ b/crates/daemon/tests/daemon_foundation.rs
@@ -67,6 +67,45 @@ async fn unsupported_job_streams_failure_event_and_persists_failed_status() -> R
 }
 
 #[tokio::test]
+async fn valid_reconciliation_scopes_stream_stub_completion() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let daemon = daemon::RunningDaemon::start(paths.clone()).await?;
+
+    let project_lines = request_lines(
+        &paths,
+        json!({
+            "protocol_version": daemon::PROTOCOL_VERSION,
+            "command": "run_job",
+            "kind": "reconcile",
+            "scope": "project:project_1",
+        }),
+    )
+    .await?;
+    let resource_lines = request_lines(
+        &paths,
+        json!({
+            "protocol_version": daemon::PROTOCOL_VERSION,
+            "command": "run_job",
+            "kind": "reconcile",
+            "scope": "resource:mysql:8.4",
+        }),
+    )
+    .await?;
+
+    daemon.shutdown().await?;
+
+    let database = Database::open(&paths)?;
+
+    assert_with_normalized_timestamps(
+        "valid_reconciliation_scopes_stream_stub_completion",
+        (project_lines, resource_lines, database.recent_jobs()?),
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn protocol_mismatch_returns_restart_guidance_without_creating_a_job() -> Result<()> {
     let tempdir = tempdir()?;
     let paths = PvPaths::for_home(tempdir.path().join("home"));

--- a/crates/daemon/tests/daemon_foundation.rs
+++ b/crates/daemon/tests/daemon_foundation.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
 use rusqlite::params;
@@ -284,8 +284,7 @@ async fn project_config_watcher_enqueues_project_reconciliation() -> Result<()> 
     })?;
     let daemon = daemon::RunningDaemon::start(paths.clone()).await?;
 
-    tokio::time::sleep(Duration::from_millis(250)).await;
-    state::fs::write_sensitive_file(&config_path, "php: '8.4'\n")?;
+    write_file_after_modified_time_tick(&config_path, "php: '8.4'\n").await?;
 
     let job = wait_for_job_scope(&paths, "project:project_1").await?;
 
@@ -356,4 +355,19 @@ async fn wait_for_job_scope(paths: &PvPaths, scope: &str) -> Result<JobRecord> {
     }
 
     Err(anyhow::anyhow!("job with scope {scope:?} was not recorded"))
+}
+
+async fn write_file_after_modified_time_tick(path: &camino::Utf8Path, content: &str) -> Result<()> {
+    let before = state::fs::modified_at(path)?;
+
+    for _attempt in 0..20 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        state::fs::write_sensitive_file(path, content)?;
+
+        if state::fs::modified_at(path)? != before {
+            return Ok(());
+        }
+    }
+
+    Err(anyhow!("modified time did not advance for {path}"))
 }

--- a/crates/daemon/tests/snapshots/daemon_foundation__invalid_reconciliation_scope_reports_scope_parse_failure.snap
+++ b/crates/daemon/tests/snapshots/daemon_foundation__invalid_reconciliation_scope_reports_scope_parse_failure.snap
@@ -1,0 +1,43 @@
+---
+source: crates/daemon/tests/daemon_foundation.rs
+assertion_line: 338
+expression: snapshot
+---
+(
+    [
+        Object {
+            "job_id": String("job_000001"),
+            "message": String("job accepted"),
+            "protocol_version": Number(1),
+            "status": String("accepted"),
+            "type": String("response"),
+        },
+        Object {
+            "job_id": String("job_000001"),
+            "kind": String("reconcile"),
+            "scope": String("project:"),
+            "type": String("job_started"),
+        },
+        Object {
+            "error": String("invalid reconciliation scope `project:`: reconciliation scope `project:` has an empty id component"),
+            "job_id": String("job_000001"),
+            "type": String("job_failed"),
+        },
+    ],
+    [
+        JobRecord {
+            id: "job_000001",
+            kind: "reconcile",
+            scope: "project:",
+            status: Failed,
+            started_at: "<timestamp>",
+            finished_at: Some(
+                "<timestamp>",
+            ),
+            summary: None,
+            error: Some(
+                "invalid reconciliation scope `project:`: reconciliation scope `project:` has an empty id component",
+            ),
+        },
+    ],
+)

--- a/crates/daemon/tests/snapshots/daemon_foundation__valid_reconciliation_scopes_stream_stub_completion.snap
+++ b/crates/daemon/tests/snapshots/daemon_foundation__valid_reconciliation_scopes_stream_stub_completion.snap
@@ -1,0 +1,96 @@
+---
+source: crates/daemon/tests/daemon_foundation.rs
+expression: snapshot
+---
+(
+    [
+        Object {
+            "job_id": String("job_000001"),
+            "message": String("job accepted"),
+            "protocol_version": Number(1),
+            "status": String("accepted"),
+            "type": String("response"),
+        },
+        Object {
+            "job_id": String("job_000001"),
+            "kind": String("reconcile"),
+            "scope": String("project:project_1"),
+            "type": String("job_started"),
+        },
+        Object {
+            "job_id": String("job_000001"),
+            "message": String("stub job started"),
+            "type": String("log"),
+        },
+        Object {
+            "job_id": String("job_000001"),
+            "message": String("stub job completed without reconciliation work"),
+            "type": String("progress"),
+        },
+        Object {
+            "job_id": String("job_000001"),
+            "summary": String("stub job completed"),
+            "type": String("job_completed"),
+        },
+    ],
+    [
+        Object {
+            "job_id": String("job_000002"),
+            "message": String("job accepted"),
+            "protocol_version": Number(1),
+            "status": String("accepted"),
+            "type": String("response"),
+        },
+        Object {
+            "job_id": String("job_000002"),
+            "kind": String("reconcile"),
+            "scope": String("resource:mysql:8.4"),
+            "type": String("job_started"),
+        },
+        Object {
+            "job_id": String("job_000002"),
+            "message": String("stub job started"),
+            "type": String("log"),
+        },
+        Object {
+            "job_id": String("job_000002"),
+            "message": String("stub job completed without reconciliation work"),
+            "type": String("progress"),
+        },
+        Object {
+            "job_id": String("job_000002"),
+            "summary": String("stub job completed"),
+            "type": String("job_completed"),
+        },
+    ],
+    [
+        JobRecord {
+            id: "job_000002",
+            kind: "reconcile",
+            scope: "resource:mysql:8.4",
+            status: Succeeded,
+            started_at: "<timestamp>",
+            finished_at: Some(
+                "<timestamp>",
+            ),
+            summary: Some(
+                "stub job completed",
+            ),
+            error: None,
+        },
+        JobRecord {
+            id: "job_000001",
+            kind: "reconcile",
+            scope: "project:project_1",
+            status: Succeeded,
+            started_at: "<timestamp>",
+            finished_at: Some(
+                "<timestamp>",
+            ),
+            summary: Some(
+                "stub job completed",
+            ),
+            error: None,
+        },
+    ],
+)

--- a/crates/daemon/tests/snapshots/supervisor_foundation__supervisor_captures_logs_and_runtime_metadata_then_stops_child.snap
+++ b/crates/daemon/tests/snapshots/supervisor_foundation__supervisor_captures_logs_and_runtime_metadata_then_stops_child.snap
@@ -11,9 +11,12 @@ expression: "(\"<pid>\", log, metadata)"
             String("printf 'runtime ready\\n'; sleep 30"),
         ],
         "command": String("/bin/sh"),
+        "config_path": String("<home>/.pv/config/test-runtime.json"),
         "log_path": String("<home>/.pv/logs/test-runtime.log"),
         "name": String("test-runtime"),
         "pid": String("<pid>"),
+        "resource_name": String("test-runtime"),
         "started_at": String("<timestamp>"),
+        "track": String("test"),
     },
 )

--- a/crates/daemon/tests/snapshots/supervisor_foundation__supervisor_captures_logs_and_runtime_metadata_then_stops_child.snap
+++ b/crates/daemon/tests/snapshots/supervisor_foundation__supervisor_captures_logs_and_runtime_metadata_then_stops_child.snap
@@ -1,0 +1,19 @@
+---
+source: crates/daemon/tests/supervisor_foundation.rs
+expression: "(\"<pid>\", log, metadata)"
+---
+(
+    "<pid>",
+    "runtime ready\n",
+    Object {
+        "arguments": Array [
+            String("-c"),
+            String("printf 'runtime ready\\n'; sleep 30"),
+        ],
+        "command": String("/bin/sh"),
+        "log_path": String("<home>/.pv/logs/test-runtime.log"),
+        "name": String("test-runtime"),
+        "pid": String("<pid>"),
+        "started_at": String("<timestamp>"),
+    },
+)

--- a/crates/daemon/tests/supervisor_foundation.rs
+++ b/crates/daemon/tests/supervisor_foundation.rs
@@ -1,0 +1,144 @@
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use camino_tempfile::tempdir;
+use daemon::{
+    ProcessSpec, ProcessSupervisor, ReadinessCheck, wait_for_custom_readiness, wait_for_readiness,
+};
+use insta::{Settings, assert_debug_snapshot};
+use serde_json::json;
+use state::PvPaths;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::time::sleep;
+
+#[tokio::test]
+async fn tcp_readiness_succeeds_for_listening_ports_and_times_out() -> Result<()> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+
+    wait_for_readiness(
+        ReadinessCheck::Tcp {
+            host: "127.0.0.1".to_string(),
+            port,
+        },
+        Duration::from_secs(1),
+    )
+    .await?;
+
+    drop(listener);
+    let result = wait_for_readiness(
+        ReadinessCheck::Tcp {
+            host: "127.0.0.1".to_string(),
+            port,
+        },
+        Duration::from_millis(10),
+    )
+    .await;
+
+    assert!(result.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn http_readiness_succeeds_for_successful_responses() -> Result<()> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+    let server = tokio::spawn(async move {
+        let (mut stream, _address) = listener.accept().await?;
+        let mut request = [0_u8; 1024];
+        let _bytes = stream.read(&mut request).await?;
+        stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+            .await?;
+
+        Ok::<(), std::io::Error>(())
+    });
+
+    wait_for_readiness(
+        ReadinessCheck::Http {
+            host: "127.0.0.1".to_string(),
+            port,
+            path: "/health".to_string(),
+        },
+        Duration::from_secs(1),
+    )
+    .await?;
+    server.await??;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn custom_readiness_retries_until_the_check_succeeds() -> Result<()> {
+    let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let check_attempts = std::sync::Arc::clone(&attempts);
+
+    wait_for_custom_readiness("test-custom", Duration::from_secs(1), move || {
+        let attempts = std::sync::Arc::clone(&check_attempts);
+        async move { attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst) > 0 }
+    })
+    .await?;
+
+    assert!(attempts.load(std::sync::atomic::Ordering::SeqCst) >= 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn supervisor_captures_logs_and_runtime_metadata_then_stops_child() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+    let supervisor = ProcessSupervisor::new(paths.clone());
+    let process = supervisor
+        .start(ProcessSpec {
+            name: "test-runtime".to_string(),
+            command: "/bin/sh".into(),
+            arguments: vec![
+                "-c".to_string(),
+                "printf 'runtime ready\\n'; sleep 30".to_string(),
+            ],
+            log_path: paths.logs().join("test-runtime.log"),
+            pid_path: paths.run().join("test-runtime.pid"),
+            metadata_path: paths.run().join("test-runtime.json"),
+        })
+        .await?;
+
+    let log = wait_for_file_contains(process.log_path(), "runtime ready").await?;
+    let mut metadata: serde_json::Value =
+        serde_json::from_str(&state::testing::read_to_string(process.metadata_path())?)?;
+    let pid = process.pid();
+    assert!(pid > 0);
+    metadata["pid"] = json!("<pid>");
+    metadata["log_path"] = json!("<home>/.pv/logs/test-runtime.log");
+    metadata["started_at"] = json!("<timestamp>");
+
+    process.stop(Duration::from_secs(1)).await?;
+
+    with_normalized_process_values(|| {
+        assert_debug_snapshot!(("<pid>", log, metadata));
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
+async fn wait_for_file_contains(path: &camino::Utf8Path, needle: &str) -> Result<String> {
+    for _attempt in 0..50 {
+        let content = state::testing::read_to_string(path)?;
+
+        if content.contains(needle) {
+            return Ok(content);
+        }
+
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    Err(anyhow!("file {path} did not contain {needle:?}"))
+}
+
+fn with_normalized_process_values(assertion: impl FnOnce() -> Result<()>) -> Result<()> {
+    Settings::clone_current().bind(assertion)
+}

--- a/crates/daemon/tests/supervisor_foundation.rs
+++ b/crates/daemon/tests/supervisor_foundation.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 use state::PvPaths;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
-use tokio::time::{Instant, sleep, timeout};
+use tokio::time::{sleep, timeout};
 
 #[tokio::test]
 async fn tcp_readiness_succeeds_for_listening_ports_and_times_out() -> Result<()> {
@@ -81,7 +81,6 @@ async fn http_readiness_times_out_even_when_the_server_keeps_the_socket_open() -
 
         Ok::<(), std::io::Error>(())
     });
-    let started_at = Instant::now();
 
     let result = timeout(
         Duration::from_millis(250),
@@ -97,7 +96,6 @@ async fn http_readiness_times_out_even_when_the_server_keeps_the_socket_open() -
     .await?;
 
     assert!(result.is_err());
-    assert!(started_at.elapsed() < Duration::from_millis(200));
     server.abort();
 
     Ok(())
@@ -121,8 +119,6 @@ async fn custom_readiness_retries_until_the_check_succeeds() -> Result<()> {
 
 #[tokio::test]
 async fn custom_readiness_timeout_bounds_a_hanging_check_future() -> Result<()> {
-    let started_at = Instant::now();
-
     let result = timeout(
         Duration::from_millis(250),
         wait_for_custom_readiness("hanging-custom", Duration::from_millis(30), || {
@@ -132,7 +128,6 @@ async fn custom_readiness_timeout_bounds_a_hanging_check_future() -> Result<()> 
     .await?;
 
     assert!(result.is_err());
-    assert!(started_at.elapsed() < Duration::from_millis(200));
 
     Ok(())
 }

--- a/crates/daemon/tests/supervisor_foundation.rs
+++ b/crates/daemon/tests/supervisor_foundation.rs
@@ -322,6 +322,51 @@ async fn supervisor_rejects_metadata_for_a_reused_pid_with_a_different_command()
     Ok(())
 }
 
+#[tokio::test]
+async fn supervisor_rejects_reused_pid_when_expected_command_only_appears_in_arguments()
+-> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+    let supervisor = ProcessSupervisor::new(paths.clone());
+    let fake_command = paths.root().join("fake-pv-runtime");
+    let actual = supervisor
+        .start(process_spec(
+            &paths,
+            "argument-runtime",
+            "/bin/sh",
+            vec!["-c".to_string(), format!("sleep 30 # {fake_command}")],
+        ))
+        .await?;
+    let forged = process_spec(
+        &paths,
+        "forged-argument-runtime",
+        fake_command.clone(),
+        Vec::new(),
+    );
+    state::fs::write_sensitive_file(&forged.pid_path, &format!("{}\n", actual.pid()))?;
+    state::fs::write_sensitive_file(
+        &forged.metadata_path,
+        &serde_json::to_string(&json!({
+            "name": "forged-argument-runtime",
+            "pid": actual.pid(),
+            "command": fake_command.as_str(),
+            "arguments": [],
+            "config_path": forged.config_path.as_str(),
+            "resource_name": "forged-argument-runtime",
+            "track": "test",
+            "log_path": forged.log_path.as_str(),
+            "started_at": "2026-05-25T00:00:00Z",
+        }))?,
+    )?;
+
+    assert!(supervisor.verify_ownership(&forged)?.is_none());
+
+    actual.stop(Duration::from_secs(1)).await?;
+
+    Ok(())
+}
+
 async fn wait_for_file_contains(path: &camino::Utf8Path, needle: &str) -> Result<String> {
     for _attempt in 0..50 {
         let content = state::testing::read_to_string(path)?;

--- a/crates/daemon/tests/supervisor_foundation.rs
+++ b/crates/daemon/tests/supervisor_foundation.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use anyhow::{Result, anyhow};
+use camino::Utf8PathBuf;
 use camino_tempfile::tempdir;
 use daemon::{
     ProcessSpec, ProcessSupervisor, ReadinessCheck, wait_for_custom_readiness, wait_for_readiness,
@@ -38,6 +39,51 @@ async fn tcp_readiness_succeeds_for_listening_ports_and_times_out() -> Result<()
     .await;
 
     assert!(result.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn readiness_timeout_reports_the_last_probe_failure() -> Result<()> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+    let server = tokio::spawn(async move {
+        let result: Result<(), std::io::Error> = async {
+            loop {
+                let (mut stream, _address) = listener.accept().await?;
+                let mut request = [0_u8; 1024];
+                let _bytes = stream.read(&mut request).await?;
+                stream
+                    .write_all(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n")
+                    .await?;
+            }
+
+            #[expect(unreachable_code, reason = "test server runs until aborted")]
+            Ok(())
+        }
+        .await;
+
+        result
+    });
+
+    let result = wait_for_readiness(
+        ReadinessCheck::Http {
+            host: "127.0.0.1".to_string(),
+            port,
+            path: "/health".to_string(),
+        },
+        Duration::from_millis(30),
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        Err(daemon::DaemonError::ReadinessTimedOut {
+            last_error: Some(reason),
+            ..
+        }) if reason.contains("HTTP readiness returned non-success status")
+    ));
+    server.abort();
 
     Ok(())
 }
@@ -139,17 +185,15 @@ async fn supervisor_captures_logs_and_runtime_metadata_then_stops_child() -> Res
     state::fs::ensure_layout(&paths)?;
     let supervisor = ProcessSupervisor::new(paths.clone());
     let process = supervisor
-        .start(ProcessSpec {
-            name: "test-runtime".to_string(),
-            command: "/bin/sh".into(),
-            arguments: vec![
+        .start(process_spec(
+            &paths,
+            "test-runtime",
+            "/bin/sh",
+            vec![
                 "-c".to_string(),
                 "printf 'runtime ready\\n'; sleep 30".to_string(),
             ],
-            log_path: paths.logs().join("test-runtime.log"),
-            pid_path: paths.run().join("test-runtime.pid"),
-            metadata_path: paths.run().join("test-runtime.json"),
-        })
+        ))
         .await?;
 
     let log = wait_for_file_contains(process.log_path(), "runtime ready").await?;
@@ -158,6 +202,7 @@ async fn supervisor_captures_logs_and_runtime_metadata_then_stops_child() -> Res
     let pid = process.pid();
     assert!(pid > 0);
     metadata["pid"] = json!("<pid>");
+    metadata["config_path"] = json!("<home>/.pv/config/test-runtime.json");
     metadata["log_path"] = json!("<home>/.pv/logs/test-runtime.log");
     metadata["started_at"] = json!("<timestamp>");
 
@@ -186,9 +231,12 @@ async fn supervisor_terminates_child_when_runtime_metadata_persistence_fails() -
             name: "metadata-failure".to_string(),
             command: "/bin/sh".into(),
             arguments: vec!["-c".to_string(), "sleep 30".to_string()],
+            config_path: paths.config().join("metadata-failure.json"),
             log_path: paths.logs().join("metadata-failure.log"),
             pid_path: pid_path.clone(),
             metadata_path: metadata_parent_blocker.join("metadata.json"),
+            resource_name: "metadata-failure".to_string(),
+            track: "test".to_string(),
         })
         .await;
 
@@ -206,14 +254,12 @@ async fn supervisor_verifies_and_adopts_owned_runtime_metadata() -> Result<()> {
     let paths = PvPaths::for_home(tempdir.path().join("home"));
     state::fs::ensure_layout(&paths)?;
     let supervisor = ProcessSupervisor::new(paths.clone());
-    let spec = ProcessSpec {
-        name: "adoptable-runtime".to_string(),
-        command: "/bin/sh".into(),
-        arguments: vec!["-c".to_string(), "sleep 30".to_string()],
-        log_path: paths.logs().join("adoptable-runtime.log"),
-        pid_path: paths.run().join("adoptable-runtime.pid"),
-        metadata_path: paths.run().join("adoptable-runtime.json"),
-    };
+    let spec = process_spec(
+        &paths,
+        "adoptable-runtime",
+        "/bin/sh",
+        vec!["-c".to_string(), "while true; do sleep 1; done".to_string()],
+    );
     let process = supervisor.start(spec.clone()).await?;
 
     let owned = supervisor
@@ -229,6 +275,49 @@ async fn supervisor_verifies_and_adopts_owned_runtime_metadata() -> Result<()> {
     process.stop(Duration::from_secs(1)).await?;
 
     assert!(supervisor.adopt(&spec)?.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn supervisor_rejects_metadata_for_a_reused_pid_with_a_different_command() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+    let supervisor = ProcessSupervisor::new(paths.clone());
+    let actual = supervisor
+        .start(process_spec(
+            &paths,
+            "actual-runtime",
+            "/bin/sh",
+            vec!["-c".to_string(), "sleep 30".to_string()],
+        ))
+        .await?;
+    let forged = process_spec(
+        &paths,
+        "forged-runtime",
+        "/bin/echo",
+        vec!["not-the-live-process".to_string()],
+    );
+    state::fs::write_sensitive_file(&forged.pid_path, &format!("{}\n", actual.pid()))?;
+    state::fs::write_sensitive_file(
+        &forged.metadata_path,
+        &serde_json::to_string(&json!({
+            "name": "forged-runtime",
+            "pid": actual.pid(),
+            "command": "/bin/echo",
+            "arguments": ["not-the-live-process"],
+            "config_path": forged.config_path.as_str(),
+            "resource_name": "forged-runtime",
+            "track": "test",
+            "log_path": forged.log_path.as_str(),
+            "started_at": "2026-05-25T00:00:00Z",
+        }))?,
+    )?;
+
+    assert!(supervisor.verify_ownership(&forged)?.is_none());
+
+    actual.stop(Duration::from_secs(1)).await?;
 
     Ok(())
 }
@@ -264,4 +353,23 @@ async fn wait_for_process_exit(pid: u32) -> Result<()> {
 
 fn with_normalized_process_values(assertion: impl FnOnce() -> Result<()>) -> Result<()> {
     Settings::clone_current().bind(assertion)
+}
+
+fn process_spec(
+    paths: &PvPaths,
+    name: &str,
+    command: impl Into<Utf8PathBuf>,
+    arguments: Vec<String>,
+) -> ProcessSpec {
+    ProcessSpec {
+        name: name.to_string(),
+        command: command.into(),
+        arguments,
+        config_path: paths.config().join(format!("{name}.json")),
+        log_path: paths.logs().join(format!("{name}.log")),
+        pid_path: paths.run().join(format!("{name}.pid")),
+        metadata_path: paths.run().join(format!("{name}.json")),
+        resource_name: name.to_string(),
+        track: "test".to_string(),
+    }
 }

--- a/crates/daemon/tests/supervisor_foundation.rs
+++ b/crates/daemon/tests/supervisor_foundation.rs
@@ -6,11 +6,12 @@ use daemon::{
     ProcessSpec, ProcessSupervisor, ReadinessCheck, wait_for_custom_readiness, wait_for_readiness,
 };
 use insta::{Settings, assert_debug_snapshot};
+use rustix::process::{Pid, test_kill_process};
 use serde_json::json;
 use state::PvPaths;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
-use tokio::time::sleep;
+use tokio::time::{Instant, sleep, timeout};
 
 #[tokio::test]
 async fn tcp_readiness_succeeds_for_listening_ports_and_times_out() -> Result<()> {
@@ -71,6 +72,38 @@ async fn http_readiness_succeeds_for_successful_responses() -> Result<()> {
 }
 
 #[tokio::test]
+async fn http_readiness_times_out_even_when_the_server_keeps_the_socket_open() -> Result<()> {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let port = listener.local_addr()?.port();
+    let server = tokio::spawn(async move {
+        let (_stream, _address) = listener.accept().await?;
+        sleep(Duration::from_secs(1)).await;
+
+        Ok::<(), std::io::Error>(())
+    });
+    let started_at = Instant::now();
+
+    let result = timeout(
+        Duration::from_millis(250),
+        wait_for_readiness(
+            ReadinessCheck::Http {
+                host: "127.0.0.1".to_string(),
+                port,
+                path: "/health".to_string(),
+            },
+            Duration::from_millis(30),
+        ),
+    )
+    .await?;
+
+    assert!(result.is_err());
+    assert!(started_at.elapsed() < Duration::from_millis(200));
+    server.abort();
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn custom_readiness_retries_until_the_check_succeeds() -> Result<()> {
     let attempts = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let check_attempts = std::sync::Arc::clone(&attempts);
@@ -82,6 +115,24 @@ async fn custom_readiness_retries_until_the_check_succeeds() -> Result<()> {
     .await?;
 
     assert!(attempts.load(std::sync::atomic::Ordering::SeqCst) >= 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn custom_readiness_timeout_bounds_a_hanging_check_future() -> Result<()> {
+    let started_at = Instant::now();
+
+    let result = timeout(
+        Duration::from_millis(250),
+        wait_for_custom_readiness("hanging-custom", Duration::from_millis(30), || {
+            std::future::pending::<bool>()
+        }),
+    )
+    .await?;
+
+    assert!(result.is_err());
+    assert!(started_at.elapsed() < Duration::from_millis(200));
 
     Ok(())
 }
@@ -125,6 +176,68 @@ async fn supervisor_captures_logs_and_runtime_metadata_then_stops_child() -> Res
     Ok(())
 }
 
+#[tokio::test]
+async fn supervisor_terminates_child_when_runtime_metadata_persistence_fails() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+    let supervisor = ProcessSupervisor::new(paths.clone());
+    let metadata_parent_blocker = paths.run().join("metadata-parent");
+    let pid_path = paths.run().join("metadata-failure.pid");
+    state::fs::write_sensitive_file(&metadata_parent_blocker, "not a directory")?;
+
+    let result = supervisor
+        .start(ProcessSpec {
+            name: "metadata-failure".to_string(),
+            command: "/bin/sh".into(),
+            arguments: vec!["-c".to_string(), "sleep 30".to_string()],
+            log_path: paths.logs().join("metadata-failure.log"),
+            pid_path: pid_path.clone(),
+            metadata_path: metadata_parent_blocker.join("metadata.json"),
+        })
+        .await;
+
+    assert!(result.is_err());
+    let pid = wait_for_file_contains(&pid_path, "\n").await?;
+    let pid = pid.trim().parse::<u32>()?;
+    wait_for_process_exit(pid).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn supervisor_verifies_and_adopts_owned_runtime_metadata() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::ensure_layout(&paths)?;
+    let supervisor = ProcessSupervisor::new(paths.clone());
+    let spec = ProcessSpec {
+        name: "adoptable-runtime".to_string(),
+        command: "/bin/sh".into(),
+        arguments: vec!["-c".to_string(), "sleep 30".to_string()],
+        log_path: paths.logs().join("adoptable-runtime.log"),
+        pid_path: paths.run().join("adoptable-runtime.pid"),
+        metadata_path: paths.run().join("adoptable-runtime.json"),
+    };
+    let process = supervisor.start(spec.clone()).await?;
+
+    let owned = supervisor
+        .verify_ownership(&spec)?
+        .ok_or_else(|| anyhow!("runtime was not verified as PV-owned"))?;
+    let adopted = supervisor
+        .adopt(&spec)?
+        .ok_or_else(|| anyhow!("runtime was not adopted"))?;
+
+    assert_eq!(owned.pid(), process.pid());
+    assert_eq!(adopted.pid(), process.pid());
+
+    process.stop(Duration::from_secs(1)).await?;
+
+    assert!(supervisor.adopt(&spec)?.is_none());
+
+    Ok(())
+}
+
 async fn wait_for_file_contains(path: &camino::Utf8Path, needle: &str) -> Result<String> {
     for _attempt in 0..50 {
         let content = state::testing::read_to_string(path)?;
@@ -137,6 +250,21 @@ async fn wait_for_file_contains(path: &camino::Utf8Path, needle: &str) -> Result
     }
 
     Err(anyhow!("file {path} did not contain {needle:?}"))
+}
+
+async fn wait_for_process_exit(pid: u32) -> Result<()> {
+    let raw_pid = i32::try_from(pid)?;
+    let pid = Pid::from_raw(raw_pid).ok_or_else(|| anyhow!("invalid process id {raw_pid}"))?;
+
+    for _attempt in 0..50 {
+        if test_kill_process(pid).is_err() {
+            return Ok(());
+        }
+
+        sleep(Duration::from_millis(20)).await;
+    }
+
+    Err(anyhow!("process {pid:?} was still running"))
 }
 
 fn with_normalized_process_values(assertion: impl FnOnce() -> Result<()>) -> Result<()> {

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -6,6 +6,7 @@ use crate::{PvPaths, StateError, fs, migrations};
 
 const BUSY_TIMEOUT: Duration = Duration::from_millis(250);
 const RECENT_JOB_LIMIT: i64 = 100;
+const PORT_CANDIDATE_LIMIT: usize = 10;
 
 #[derive(Debug)]
 pub struct Database {
@@ -59,6 +60,27 @@ pub struct JobRecord {
     pub error: Option<String>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortRequest {
+    pub name: String,
+    pub owner_kind: String,
+    pub resource_name: Option<String>,
+    pub track: Option<String>,
+    pub preferred_port: u16,
+    pub fallback_start: u16,
+    pub fallback_end: u16,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PortAssignment {
+    pub name: String,
+    pub port: u16,
+    pub owner_kind: String,
+    pub resource_name: Option<String>,
+    pub track: Option<String>,
+    pub updated_at: String,
+}
+
 struct JobRecordRow {
     id: String,
     kind: String,
@@ -68,6 +90,15 @@ struct JobRecordRow {
     finished_at: Option<String>,
     summary: Option<String>,
     error: Option<String>,
+}
+
+struct PortAssignmentRow {
+    name: String,
+    port: u16,
+    owner_kind: String,
+    resource_name: Option<String>,
+    track: Option<String>,
+    updated_at: String,
 }
 
 impl Database {
@@ -201,6 +232,58 @@ impl Database {
         Ok(jobs)
     }
 
+    pub fn assign_port(
+        &mut self,
+        request: PortRequest,
+        mut is_available: impl FnMut(u16) -> bool,
+    ) -> Result<PortAssignment, StateError> {
+        if let Some(existing) = self.port_assignment(&request.name)?
+            && is_available(existing.port)
+        {
+            return Ok(existing);
+        }
+
+        let assigned_ports = self.assigned_port_numbers_except(&request.name)?;
+
+        for candidate in request.candidates() {
+            if assigned_ports.contains(&candidate) || !is_available(candidate) {
+                continue;
+            }
+
+            return self.upsert_port(request, candidate);
+        }
+
+        Err(StateError::NoAvailablePort {
+            name: request.name,
+            preferred_port: request.preferred_port,
+            fallback_start: request.fallback_start,
+            fallback_end: request.fallback_end,
+            attempts: PORT_CANDIDATE_LIMIT,
+        })
+    }
+
+    pub fn release_port(&mut self, name: &str) -> Result<bool, StateError> {
+        let deleted = self
+            .connection
+            .execute("DELETE FROM ports WHERE name = ?1", params![name])?;
+
+        Ok(deleted > 0)
+    }
+
+    pub fn assigned_ports(&self) -> Result<Vec<PortAssignment>, StateError> {
+        let mut statement = self.connection.prepare(
+            "SELECT name, port, owner_kind, resource_name, track, updated_at FROM ports ORDER BY name",
+        )?;
+        let rows = statement.query_map([], port_assignment_from_row)?;
+        let mut assignments = Vec::new();
+
+        for row in rows {
+            assignments.push(row?.into_assignment());
+        }
+
+        Ok(assignments)
+    }
+
     pub(crate) fn transaction<T>(
         &mut self,
         operation: impl FnOnce(&Transaction<'_>) -> rusqlite::Result<T>,
@@ -259,6 +342,114 @@ impl Database {
 
         Ok(tables)
     }
+
+    fn port_assignment(&self, name: &str) -> Result<Option<PortAssignment>, StateError> {
+        let mut statement = self.connection.prepare(
+            "SELECT name, port, owner_kind, resource_name, track, updated_at FROM ports WHERE name = ?1",
+        )?;
+        let mut rows = statement.query_map(params![name], port_assignment_from_row)?;
+
+        match rows.next() {
+            Some(row) => Ok(Some(row?.into_assignment())),
+            None => Ok(None),
+        }
+    }
+
+    fn assigned_port_numbers_except(&self, name: &str) -> Result<Vec<u16>, StateError> {
+        let mut statement = self
+            .connection
+            .prepare("SELECT port FROM ports WHERE name != ?1 ORDER BY port")?;
+        let rows = statement.query_map(params![name], |row| row.get::<_, u16>(0))?;
+        let mut ports = Vec::new();
+
+        for row in rows {
+            ports.push(row?);
+        }
+
+        Ok(ports)
+    }
+
+    fn upsert_port(
+        &mut self,
+        request: PortRequest,
+        port: u16,
+    ) -> Result<PortAssignment, StateError> {
+        let updated_at = timestamp()?;
+
+        self.transaction(|transaction| {
+            transaction.execute(
+                "INSERT INTO ports (name, port, owner_kind, resource_name, track, updated_at)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                ON CONFLICT(name) DO UPDATE SET
+                    port = excluded.port,
+                    owner_kind = excluded.owner_kind,
+                    resource_name = excluded.resource_name,
+                    track = excluded.track,
+                    updated_at = excluded.updated_at",
+                params![
+                    request.name,
+                    port,
+                    request.owner_kind,
+                    request.resource_name,
+                    request.track,
+                    updated_at,
+                ],
+            )?;
+
+            Ok(())
+        })?;
+
+        Ok(PortAssignment {
+            name: request.name,
+            port,
+            owner_kind: request.owner_kind,
+            resource_name: request.resource_name,
+            track: request.track,
+            updated_at,
+        })
+    }
+}
+
+impl PortRequest {
+    fn candidates(&self) -> Vec<u16> {
+        let mut candidates = vec![self.preferred_port];
+
+        for port in self.fallback_start..=self.fallback_end {
+            if candidates.len() >= PORT_CANDIDATE_LIMIT {
+                break;
+            }
+
+            if port != self.preferred_port {
+                candidates.push(port);
+            }
+        }
+
+        candidates
+    }
+}
+
+impl PortAssignmentRow {
+    fn into_assignment(self) -> PortAssignment {
+        PortAssignment {
+            name: self.name,
+            port: self.port,
+            owner_kind: self.owner_kind,
+            resource_name: self.resource_name,
+            track: self.track,
+            updated_at: self.updated_at,
+        }
+    }
+}
+
+fn port_assignment_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PortAssignmentRow> {
+    Ok(PortAssignmentRow {
+        name: row.get(0)?,
+        port: row.get(1)?,
+        owner_kind: row.get(2)?,
+        resource_name: row.get(3)?,
+        track: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
 }
 
 fn configure_connection(connection: &Connection) -> Result<(), StateError> {

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -1,6 +1,8 @@
+use std::collections::BTreeSet;
 use std::time::Duration;
 
-use rusqlite::{Connection, Transaction, params};
+use camino::Utf8PathBuf;
+use rusqlite::{Connection, Transaction, TransactionBehavior, params};
 
 use crate::{PvPaths, StateError, fs, migrations};
 
@@ -62,13 +64,24 @@ pub struct JobRecord {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PortRequest {
-    pub name: String,
-    pub owner_kind: String,
-    pub resource_name: Option<String>,
-    pub track: Option<String>,
-    pub preferred_port: u16,
-    pub fallback_start: u16,
-    pub fallback_end: u16,
+    owner: PortOwner,
+    preferred_port: u16,
+    fallback_start: u16,
+    fallback_end: u16,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PortOwner {
+    Dns,
+    Gateway,
+    ProjectWorker {
+        project_id: String,
+        php_track: String,
+    },
+    Resource {
+        name: String,
+        track: String,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -79,6 +92,12 @@ pub struct PortAssignment {
     pub resource_name: Option<String>,
     pub track: Option<String>,
     pub updated_at: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProjectConfigWatch {
+    pub project_id: String,
+    pub config_path: Utf8PathBuf,
 }
 
 struct JobRecordRow {
@@ -237,28 +256,48 @@ impl Database {
         request: PortRequest,
         mut is_available: impl FnMut(u16) -> bool,
     ) -> Result<PortAssignment, StateError> {
-        if let Some(existing) = self.port_assignment(&request.name)?
+        let request_name = request.name();
+        let candidates = request.candidates();
+        let transaction = self
+            .connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)?;
+
+        if let Some(existing) = port_assignment_in_transaction(&transaction, &request_name)?
             && is_available(existing.port)
         {
+            transaction.commit()?;
+
             return Ok(existing);
         }
 
-        let assigned_ports = self.assigned_port_numbers_except(&request.name)?;
+        let assigned_ports =
+            assigned_port_numbers_except_in_transaction(&transaction, &request_name)?;
 
-        for candidate in request.candidates() {
+        for candidate in candidates.iter().copied() {
             if assigned_ports.contains(&candidate) || !is_available(candidate) {
                 continue;
             }
 
-            return self.upsert_port(request, candidate);
+            let updated_at = timestamp()?;
+            upsert_port_in_transaction(&transaction, &request, candidate, &updated_at)?;
+            transaction.commit()?;
+
+            return Ok(PortAssignment {
+                name: request_name,
+                port: candidate,
+                owner_kind: request.owner.kind().to_string(),
+                resource_name: request.owner.resource_name(),
+                track: request.owner.track(),
+                updated_at,
+            });
         }
 
         Err(StateError::NoAvailablePort {
-            name: request.name,
+            name: request_name,
             preferred_port: request.preferred_port,
             fallback_start: request.fallback_start,
             fallback_end: request.fallback_end,
-            attempts: PORT_CANDIDATE_LIMIT,
+            attempts: candidates.len(),
         })
     }
 
@@ -282,6 +321,25 @@ impl Database {
         }
 
         Ok(assignments)
+    }
+
+    pub fn project_config_watches(&self) -> Result<Vec<ProjectConfigWatch>, StateError> {
+        let mut statement = self.connection.prepare(
+            "SELECT id, config_path FROM projects WHERE config_path IS NOT NULL ORDER BY id",
+        )?;
+        let rows = statement.query_map([], |row| {
+            Ok(ProjectConfigWatch {
+                project_id: row.get(0)?,
+                config_path: Utf8PathBuf::from(row.get::<_, String>(1)?),
+            })
+        })?;
+        let mut watches = Vec::new();
+
+        for row in rows {
+            watches.push(row?);
+        }
+
+        Ok(watches)
     }
 
     pub(crate) fn transaction<T>(
@@ -342,75 +400,76 @@ impl Database {
 
         Ok(tables)
     }
-
-    fn port_assignment(&self, name: &str) -> Result<Option<PortAssignment>, StateError> {
-        let mut statement = self.connection.prepare(
-            "SELECT name, port, owner_kind, resource_name, track, updated_at FROM ports WHERE name = ?1",
-        )?;
-        let mut rows = statement.query_map(params![name], port_assignment_from_row)?;
-
-        match rows.next() {
-            Some(row) => Ok(Some(row?.into_assignment())),
-            None => Ok(None),
-        }
-    }
-
-    fn assigned_port_numbers_except(&self, name: &str) -> Result<Vec<u16>, StateError> {
-        let mut statement = self
-            .connection
-            .prepare("SELECT port FROM ports WHERE name != ?1 ORDER BY port")?;
-        let rows = statement.query_map(params![name], |row| row.get::<_, u16>(0))?;
-        let mut ports = Vec::new();
-
-        for row in rows {
-            ports.push(row?);
-        }
-
-        Ok(ports)
-    }
-
-    fn upsert_port(
-        &mut self,
-        request: PortRequest,
-        port: u16,
-    ) -> Result<PortAssignment, StateError> {
-        let updated_at = timestamp()?;
-
-        self.transaction(|transaction| {
-            transaction.execute(
-                "INSERT INTO ports (name, port, owner_kind, resource_name, track, updated_at)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                ON CONFLICT(name) DO UPDATE SET
-                    port = excluded.port,
-                    owner_kind = excluded.owner_kind,
-                    resource_name = excluded.resource_name,
-                    track = excluded.track,
-                    updated_at = excluded.updated_at",
-                params![
-                    request.name,
-                    port,
-                    request.owner_kind,
-                    request.resource_name,
-                    request.track,
-                    updated_at,
-                ],
-            )?;
-
-            Ok(())
-        })?;
-
-        Ok(PortAssignment {
-            name: request.name,
-            port,
-            owner_kind: request.owner_kind,
-            resource_name: request.resource_name,
-            track: request.track,
-            updated_at,
-        })
-    }
 }
 
 impl PortRequest {
+    pub fn dns(preferred_port: u16, fallback_start: u16, fallback_end: u16) -> Self {
+        Self::new(PortOwner::Dns, preferred_port, fallback_start, fallback_end)
+    }
+
+    pub fn gateway(preferred_port: u16, fallback_start: u16, fallback_end: u16) -> Self {
+        Self::new(
+            PortOwner::Gateway,
+            preferred_port,
+            fallback_start,
+            fallback_end,
+        )
+    }
+
+    pub fn project_worker(
+        project_id: impl Into<String>,
+        php_track: impl Into<String>,
+        preferred_port: u16,
+        fallback_start: u16,
+        fallback_end: u16,
+    ) -> Self {
+        Self::new(
+            PortOwner::ProjectWorker {
+                project_id: project_id.into(),
+                php_track: php_track.into(),
+            },
+            preferred_port,
+            fallback_start,
+            fallback_end,
+        )
+    }
+
+    pub fn resource(
+        name: impl Into<String>,
+        track: impl Into<String>,
+        preferred_port: u16,
+        fallback_start: u16,
+        fallback_end: u16,
+    ) -> Self {
+        Self::new(
+            PortOwner::Resource {
+                name: name.into(),
+                track: track.into(),
+            },
+            preferred_port,
+            fallback_start,
+            fallback_end,
+        )
+    }
+
+    pub fn new(
+        owner: PortOwner,
+        preferred_port: u16,
+        fallback_start: u16,
+        fallback_end: u16,
+    ) -> Self {
+        Self {
+            owner,
+            preferred_port,
+            fallback_start,
+            fallback_end,
+        }
+    }
+
+    pub fn name(&self) -> String {
+        self.owner.storage_key()
+    }
+
     fn candidates(&self) -> Vec<u16> {
         let mut candidates = vec![self.preferred_port];
 
@@ -428,6 +487,44 @@ impl PortRequest {
     }
 }
 
+impl PortOwner {
+    fn storage_key(&self) -> String {
+        match self {
+            Self::Dns => "dns".to_string(),
+            Self::Gateway => "gateway".to_string(),
+            Self::ProjectWorker {
+                project_id,
+                php_track,
+            } => format!("project:{project_id}:php:{php_track}"),
+            Self::Resource { name, track } => format!("resource:{name}:{track}"),
+        }
+    }
+
+    const fn kind(&self) -> &'static str {
+        match self {
+            Self::Dns => "dns",
+            Self::Gateway => "gateway",
+            Self::ProjectWorker { .. } => "project_worker",
+            Self::Resource { .. } => "resource",
+        }
+    }
+
+    fn resource_name(&self) -> Option<String> {
+        match self {
+            Self::Resource { name, .. } => Some(name.clone()),
+            Self::Dns | Self::Gateway | Self::ProjectWorker { .. } => None,
+        }
+    }
+
+    fn track(&self) -> Option<String> {
+        match self {
+            Self::ProjectWorker { php_track, .. } => Some(php_track.clone()),
+            Self::Resource { track, .. } => Some(track.clone()),
+            Self::Dns | Self::Gateway => None,
+        }
+    }
+}
+
 impl PortAssignmentRow {
     fn into_assignment(self) -> PortAssignment {
         PortAssignment {
@@ -439,6 +536,65 @@ impl PortAssignmentRow {
             updated_at: self.updated_at,
         }
     }
+}
+
+fn port_assignment_in_transaction(
+    transaction: &Transaction<'_>,
+    name: &str,
+) -> rusqlite::Result<Option<PortAssignment>> {
+    let mut statement = transaction.prepare(
+        "SELECT name, port, owner_kind, resource_name, track, updated_at FROM ports WHERE name = ?1",
+    )?;
+    let mut rows = statement.query_map(params![name], port_assignment_from_row)?;
+
+    match rows.next() {
+        Some(row) => Ok(Some(row?.into_assignment())),
+        None => Ok(None),
+    }
+}
+
+fn assigned_port_numbers_except_in_transaction(
+    transaction: &Transaction<'_>,
+    name: &str,
+) -> rusqlite::Result<BTreeSet<u16>> {
+    let mut statement =
+        transaction.prepare("SELECT port FROM ports WHERE name != ?1 ORDER BY port")?;
+    let rows = statement.query_map(params![name], |row| row.get::<_, u16>(0))?;
+    let mut ports = BTreeSet::new();
+
+    for row in rows {
+        ports.insert(row?);
+    }
+
+    Ok(ports)
+}
+
+fn upsert_port_in_transaction(
+    transaction: &Transaction<'_>,
+    request: &PortRequest,
+    port: u16,
+    updated_at: &str,
+) -> rusqlite::Result<()> {
+    transaction.execute(
+        "INSERT INTO ports (name, port, owner_kind, resource_name, track, updated_at)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        ON CONFLICT(name) DO UPDATE SET
+            port = excluded.port,
+            owner_kind = excluded.owner_kind,
+            resource_name = excluded.resource_name,
+            track = excluded.track,
+            updated_at = excluded.updated_at",
+        params![
+            request.name(),
+            port,
+            request.owner.kind(),
+            request.owner.resource_name(),
+            request.owner.track(),
+            updated_at,
+        ],
+    )?;
+
+    Ok(())
 }
 
 fn port_assignment_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PortAssignmentRow> {

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -86,11 +86,8 @@ pub enum PortOwner {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PortAssignment {
-    pub name: String,
+    pub owner: PortOwner,
     pub port: u16,
-    pub owner_kind: String,
-    pub resource_name: Option<String>,
-    pub track: Option<String>,
     pub updated_at: String,
 }
 
@@ -112,12 +109,17 @@ struct JobRecordRow {
 }
 
 struct PortAssignmentRow {
-    name: String,
-    port: u16,
     owner_kind: String,
-    resource_name: Option<String>,
-    track: Option<String>,
+    owner_id: String,
+    owner_track: String,
+    port: u16,
     updated_at: String,
+}
+
+struct PortIdentity {
+    owner_kind: &'static str,
+    owner_id: String,
+    owner_track: String,
 }
 
 impl Database {
@@ -256,13 +258,14 @@ impl Database {
         request: PortRequest,
         mut is_available: impl FnMut(u16) -> bool,
     ) -> Result<PortAssignment, StateError> {
-        let request_name = request.name();
+        let identity = request.owner.identity()?;
+        let request_name = identity.display_name();
         let candidates = request.candidates();
         let transaction = self
             .connection
             .transaction_with_behavior(TransactionBehavior::Immediate)?;
 
-        if let Some(existing) = port_assignment_in_transaction(&transaction, &request_name)?
+        if let Some(existing) = port_assignment_in_transaction(&transaction, &identity)?
             && is_available(existing.port)
         {
             transaction.commit()?;
@@ -270,8 +273,7 @@ impl Database {
             return Ok(existing);
         }
 
-        let assigned_ports =
-            assigned_port_numbers_except_in_transaction(&transaction, &request_name)?;
+        let assigned_ports = assigned_port_numbers_except_in_transaction(&transaction, &identity)?;
 
         for candidate in candidates.iter().copied() {
             if assigned_ports.contains(&candidate) || !is_available(candidate) {
@@ -279,15 +281,12 @@ impl Database {
             }
 
             let updated_at = timestamp()?;
-            upsert_port_in_transaction(&transaction, &request, candidate, &updated_at)?;
+            upsert_port_in_transaction(&transaction, &identity, candidate, &updated_at)?;
             transaction.commit()?;
 
             return Ok(PortAssignment {
-                name: request_name,
+                owner: request.owner,
                 port: candidate,
-                owner_kind: request.owner.kind().to_string(),
-                resource_name: request.owner.resource_name(),
-                track: request.owner.track(),
                 updated_at,
             });
         }
@@ -301,23 +300,29 @@ impl Database {
         })
     }
 
-    pub fn release_port(&mut self, name: &str) -> Result<bool, StateError> {
-        let deleted = self
-            .connection
-            .execute("DELETE FROM ports WHERE name = ?1", params![name])?;
+    pub fn release_port(&mut self, owner: PortOwner) -> Result<bool, StateError> {
+        let identity = owner.identity()?;
+        let deleted = self.connection.execute(
+            "DELETE FROM ports WHERE owner_kind = ?1 AND owner_id = ?2 AND owner_track = ?3",
+            params![
+                identity.owner_kind,
+                identity.owner_id.as_str(),
+                identity.owner_track.as_str(),
+            ],
+        )?;
 
         Ok(deleted > 0)
     }
 
     pub fn assigned_ports(&self) -> Result<Vec<PortAssignment>, StateError> {
         let mut statement = self.connection.prepare(
-            "SELECT name, port, owner_kind, resource_name, track, updated_at FROM ports ORDER BY name",
+            "SELECT owner_kind, owner_id, owner_track, port, updated_at FROM ports ORDER BY owner_kind, owner_id, owner_track",
         )?;
         let rows = statement.query_map([], port_assignment_from_row)?;
         let mut assignments = Vec::new();
 
         for row in rows {
-            assignments.push(row?.into_assignment());
+            assignments.push(row?.into_assignment()?);
         }
 
         Ok(assignments)
@@ -467,7 +472,7 @@ impl PortRequest {
     }
 
     pub fn name(&self) -> String {
-        self.owner.storage_key()
+        self.owner.display_name()
     }
 
     fn candidates(&self) -> Vec<u16> {
@@ -488,78 +493,172 @@ impl PortRequest {
 }
 
 impl PortOwner {
-    fn storage_key(&self) -> String {
+    fn identity(&self) -> Result<PortIdentity, StateError> {
+        match self {
+            Self::Dns => Ok(PortIdentity {
+                owner_kind: "dns",
+                owner_id: "dns".to_string(),
+                owner_track: String::new(),
+            }),
+            Self::Gateway => Ok(PortIdentity {
+                owner_kind: "gateway",
+                owner_id: "gateway".to_string(),
+                owner_track: String::new(),
+            }),
+            Self::ProjectWorker {
+                project_id,
+                php_track,
+            } => {
+                self.validate_component("project_id", project_id)?;
+                self.validate_component("php_track", php_track)?;
+
+                Ok(PortIdentity {
+                    owner_kind: "project_worker",
+                    owner_id: project_id.clone(),
+                    owner_track: php_track.clone(),
+                })
+            }
+            Self::Resource { name, track } => {
+                self.validate_component("name", name)?;
+                self.validate_component("track", track)?;
+
+                Ok(PortIdentity {
+                    owner_kind: "resource",
+                    owner_id: name.clone(),
+                    owner_track: track.clone(),
+                })
+            }
+        }
+    }
+
+    fn from_database(
+        owner_kind: String,
+        owner_id: String,
+        owner_track: String,
+    ) -> Result<Self, StateError> {
+        match owner_kind.as_str() {
+            "dns" if owner_id == "dns" && owner_track.is_empty() => Ok(Self::Dns),
+            "dns" => Err(StateError::InvalidPortOwner {
+                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track),
+                reason: "dns ports must use owner id `dns` and an empty owner track",
+            }),
+            "gateway" if owner_id == "gateway" && owner_track.is_empty() => Ok(Self::Gateway),
+            "gateway" => Err(StateError::InvalidPortOwner {
+                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track),
+                reason: "gateway ports must use owner id `gateway` and an empty owner track",
+            }),
+            "project_worker" if !owner_id.is_empty() && !owner_track.is_empty() => {
+                Ok(Self::ProjectWorker {
+                    project_id: owner_id,
+                    php_track: owner_track,
+                })
+            }
+            "project_worker" => Err(StateError::InvalidPortOwner {
+                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track),
+                reason: "project worker ports must include a project id and php track",
+            }),
+            "resource" if !owner_id.is_empty() && !owner_track.is_empty() => Ok(Self::Resource {
+                name: owner_id,
+                track: owner_track,
+            }),
+            "resource" => Err(StateError::InvalidPortOwner {
+                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track),
+                reason: "resource ports must include a resource name and track",
+            }),
+            _ => Err(StateError::UnknownPortOwnerKind { owner_kind }),
+        }
+    }
+
+    fn validate_component(&self, component: &'static str, value: &str) -> Result<(), StateError> {
+        if value.is_empty() {
+            return Err(StateError::InvalidPortOwner {
+                owner: self.display_name(),
+                reason: match component {
+                    "project_id" => "project worker port owner project id must not be empty",
+                    "php_track" => "project worker port owner php track must not be empty",
+                    "name" => "resource port owner name must not be empty",
+                    "track" => "resource port owner track must not be empty",
+                    _ => "port owner component must not be empty",
+                },
+            });
+        }
+
+        Ok(())
+    }
+
+    fn display_name(&self) -> String {
         match self {
             Self::Dns => "dns".to_string(),
             Self::Gateway => "gateway".to_string(),
             Self::ProjectWorker {
                 project_id,
                 php_track,
-            } => format!("project:{project_id}:php:{php_track}"),
-            Self::Resource { name, track } => format!("resource:{name}:{track}"),
-        }
-    }
-
-    const fn kind(&self) -> &'static str {
-        match self {
-            Self::Dns => "dns",
-            Self::Gateway => "gateway",
-            Self::ProjectWorker { .. } => "project_worker",
-            Self::Resource { .. } => "resource",
-        }
-    }
-
-    fn resource_name(&self) -> Option<String> {
-        match self {
-            Self::Resource { name, .. } => Some(name.clone()),
-            Self::Dns | Self::Gateway | Self::ProjectWorker { .. } => None,
-        }
-    }
-
-    fn track(&self) -> Option<String> {
-        match self {
-            Self::ProjectWorker { php_track, .. } => Some(php_track.clone()),
-            Self::Resource { track, .. } => Some(track.clone()),
-            Self::Dns | Self::Gateway => None,
+            } => format!("project worker {project_id:?} php {php_track:?}"),
+            Self::Resource { name, track } => format!("resource {name:?} track {track:?}"),
         }
     }
 }
 
 impl PortAssignmentRow {
-    fn into_assignment(self) -> PortAssignment {
-        PortAssignment {
-            name: self.name,
+    fn into_assignment(self) -> Result<PortAssignment, StateError> {
+        let owner = PortOwner::from_database(self.owner_kind, self.owner_id, self.owner_track)?;
+
+        Ok(PortAssignment {
+            owner,
             port: self.port,
-            owner_kind: self.owner_kind,
-            resource_name: self.resource_name,
-            track: self.track,
             updated_at: self.updated_at,
-        }
+        })
+    }
+}
+
+impl PortIdentity {
+    fn display_name(&self) -> String {
+        describe_port_identity(self.owner_kind, &self.owner_id, &self.owner_track)
     }
 }
 
 fn port_assignment_in_transaction(
     transaction: &Transaction<'_>,
-    name: &str,
-) -> rusqlite::Result<Option<PortAssignment>> {
+    identity: &PortIdentity,
+) -> Result<Option<PortAssignment>, StateError> {
     let mut statement = transaction.prepare(
-        "SELECT name, port, owner_kind, resource_name, track, updated_at FROM ports WHERE name = ?1",
+        "SELECT owner_kind, owner_id, owner_track, port, updated_at
+        FROM ports
+        WHERE owner_kind = ?1 AND owner_id = ?2 AND owner_track = ?3",
     )?;
-    let mut rows = statement.query_map(params![name], port_assignment_from_row)?;
+    let mut rows = statement.query_map(
+        params![
+            identity.owner_kind,
+            identity.owner_id.as_str(),
+            identity.owner_track.as_str(),
+        ],
+        port_assignment_from_row,
+    )?;
 
     match rows.next() {
-        Some(row) => Ok(Some(row?.into_assignment())),
+        Some(row) => Ok(Some(row?.into_assignment()?)),
         None => Ok(None),
     }
 }
 
 fn assigned_port_numbers_except_in_transaction(
     transaction: &Transaction<'_>,
-    name: &str,
-) -> rusqlite::Result<BTreeSet<u16>> {
-    let mut statement =
-        transaction.prepare("SELECT port FROM ports WHERE name != ?1 ORDER BY port")?;
-    let rows = statement.query_map(params![name], |row| row.get::<_, u16>(0))?;
+    identity: &PortIdentity,
+) -> Result<BTreeSet<u16>, StateError> {
+    let mut statement = transaction.prepare(
+        "SELECT port
+        FROM ports
+        WHERE owner_kind != ?1 OR owner_id != ?2 OR owner_track != ?3
+        ORDER BY port",
+    )?;
+    let rows = statement.query_map(
+        params![
+            identity.owner_kind,
+            identity.owner_id.as_str(),
+            identity.owner_track.as_str(),
+        ],
+        |row| row.get::<_, u16>(0),
+    )?;
     let mut ports = BTreeSet::new();
 
     for row in rows {
@@ -571,25 +670,21 @@ fn assigned_port_numbers_except_in_transaction(
 
 fn upsert_port_in_transaction(
     transaction: &Transaction<'_>,
-    request: &PortRequest,
+    identity: &PortIdentity,
     port: u16,
     updated_at: &str,
 ) -> rusqlite::Result<()> {
     transaction.execute(
-        "INSERT INTO ports (name, port, owner_kind, resource_name, track, updated_at)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-        ON CONFLICT(name) DO UPDATE SET
+        "INSERT INTO ports (owner_kind, owner_id, owner_track, port, updated_at)
+        VALUES (?1, ?2, ?3, ?4, ?5)
+        ON CONFLICT(owner_kind, owner_id, owner_track) DO UPDATE SET
             port = excluded.port,
-            owner_kind = excluded.owner_kind,
-            resource_name = excluded.resource_name,
-            track = excluded.track,
             updated_at = excluded.updated_at",
         params![
-            request.name(),
+            identity.owner_kind,
+            identity.owner_id.as_str(),
+            identity.owner_track.as_str(),
             port,
-            request.owner.kind(),
-            request.owner.resource_name(),
-            request.owner.track(),
             updated_at,
         ],
     )?;
@@ -599,13 +694,20 @@ fn upsert_port_in_transaction(
 
 fn port_assignment_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PortAssignmentRow> {
     Ok(PortAssignmentRow {
-        name: row.get(0)?,
-        port: row.get(1)?,
-        owner_kind: row.get(2)?,
-        resource_name: row.get(3)?,
-        track: row.get(4)?,
-        updated_at: row.get(5)?,
+        owner_kind: row.get(0)?,
+        owner_id: row.get(1)?,
+        owner_track: row.get(2)?,
+        port: row.get(3)?,
+        updated_at: row.get(4)?,
     })
+}
+
+fn describe_port_identity(owner_kind: &str, owner_id: &str, owner_track: &str) -> String {
+    if owner_track.is_empty() {
+        return format!("{owner_kind} {owner_id:?}");
+    }
+
+    format!("{owner_kind} {owner_id:?} track {owner_track:?}")
 }
 
 fn configure_connection(connection: &Connection) -> Result<(), StateError> {

--- a/crates/state/src/error.rs
+++ b/crates/state/src/error.rs
@@ -54,6 +54,17 @@ pub enum StateError {
     #[error("daemon job `{id}` was not found")]
     JobNotFound { id: String },
 
+    #[error(
+        "no available port for {name}; tried preferred {preferred_port} and up to {attempts} candidates in {fallback_start}-{fallback_end}"
+    )]
+    NoAvailablePort {
+        name: String,
+        preferred_port: u16,
+        fallback_start: u16,
+        fallback_end: u16,
+        attempts: usize,
+    },
+
     #[error("time formatting failed: {0}")]
     TimeFormat(#[from] time::error::Format),
 

--- a/crates/state/src/error.rs
+++ b/crates/state/src/error.rs
@@ -54,6 +54,12 @@ pub enum StateError {
     #[error("daemon job `{id}` was not found")]
     JobNotFound { id: String },
 
+    #[error("invalid port owner `{owner}`: {reason}")]
+    InvalidPortOwner { owner: String, reason: &'static str },
+
+    #[error("unknown port owner kind `{owner_kind}`")]
+    UnknownPortOwnerKind { owner_kind: String },
+
     #[error(
         "no available port for {name}; tried preferred {preferred_port} and up to {attempts} candidates in {fallback_start}-{fallback_end}"
     )]

--- a/crates/state/src/fs.rs
+++ b/crates/state/src/fs.rs
@@ -59,6 +59,28 @@ pub fn remove_daemon_socket(paths: &PvPaths) -> Result<(), StateError> {
     remove_file(&path)
 }
 
+pub fn write_sensitive_file(path: &Utf8Path, content: &str) -> Result<(), StateError> {
+    ensure_parent_dir(path)?;
+    write_atomically(path, content)?;
+    secure_sensitive_file(path)
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "PV filesystem helper owns direct file handles"
+)]
+pub fn open_append_file(path: &Utf8Path) -> Result<std::fs::File, StateError> {
+    ensure_parent_dir(path)?;
+    let file = open_append_file_handle(path)?;
+    secure_sensitive_file(path)?;
+
+    Ok(file)
+}
+
+pub fn read_to_string(path: &Utf8Path) -> Result<String, StateError> {
+    read_utf8_file(path)
+}
+
 pub fn inspect_database_files(paths: &PvPaths) -> Result<Vec<DatabaseFileInspection>, StateError> {
     let mut entries = Vec::new();
 
@@ -114,6 +136,49 @@ fn ensure_user_dir(path: &Utf8Path) -> Result<(), StateError> {
     set_dir_mode(path, USER_ONLY_DIR_MODE)?;
     validate_mode(path, USER_ONLY_DIR_MODE)?;
     validate_owner(path)
+}
+
+fn ensure_parent_dir(path: &Utf8Path) -> Result<(), StateError> {
+    if let Some(parent) = path.parent() {
+        ensure_user_dir(parent)?;
+    }
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns atomic file writes"
+)]
+fn write_atomically(path: &Utf8Path, content: &str) -> Result<(), StateError> {
+    let temporary_path = path.with_extension("tmp");
+
+    std::fs::write(&temporary_path, content)
+        .map_err(|source| StateError::filesystem(temporary_path.clone(), source))?;
+    secure_sensitive_file(&temporary_path)?;
+    std::fs::rename(&temporary_path, path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "PV filesystem helper owns direct file handles"
+)]
+fn open_append_file_handle(path: &Utf8Path) -> Result<std::fs::File, StateError> {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct file reads"
+)]
+fn read_utf8_file(path: &Utf8Path) -> Result<String, StateError> {
+    std::fs::read_to_string(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
 }
 
 #[expect(

--- a/crates/state/src/fs.rs
+++ b/crates/state/src/fs.rs
@@ -1,9 +1,13 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::SystemTime;
+
 use camino::{Utf8Path, Utf8PathBuf};
 
 use crate::{PvPaths, StateError, backup};
 
 const USER_ONLY_DIR_MODE: u32 = 0o700;
 const SENSITIVE_FILE_MODE: u32 = 0o600;
+static TEMPORARY_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LayoutInspection {
@@ -81,6 +85,18 @@ pub fn read_to_string(path: &Utf8Path) -> Result<String, StateError> {
     read_utf8_file(path)
 }
 
+pub fn modified_at(path: &Utf8Path) -> Result<Option<SystemTime>, StateError> {
+    match file_modified_at(path) {
+        Ok(modified_at) => Ok(Some(modified_at)),
+        Err(StateError::Filesystem { source, .. })
+            if source.kind() == std::io::ErrorKind::NotFound =>
+        {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 pub fn inspect_database_files(paths: &PvPaths) -> Result<Vec<DatabaseFileInspection>, StateError> {
     let mut entries = Vec::new();
 
@@ -151,13 +167,21 @@ fn ensure_parent_dir(path: &Utf8Path) -> Result<(), StateError> {
     reason = "PV filesystem helper owns atomic file writes"
 )]
 fn write_atomically(path: &Utf8Path, content: &str) -> Result<(), StateError> {
-    let temporary_path = path.with_extension("tmp");
+    let temporary_path = temporary_path_for(path);
 
     std::fs::write(&temporary_path, content)
         .map_err(|source| StateError::filesystem(temporary_path.clone(), source))?;
     secure_sensitive_file(&temporary_path)?;
     std::fs::rename(&temporary_path, path)
         .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}
+
+fn temporary_path_for(path: &Utf8Path) -> Utf8PathBuf {
+    let file_name = path.file_name().unwrap_or("pv");
+    let process_id = std::process::id();
+    let counter = TEMPORARY_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    path.with_file_name(format!("{file_name}.{process_id}.{counter}.tmp"))
 }
 
 #[expect(
@@ -178,6 +202,19 @@ fn open_append_file_handle(path: &Utf8Path) -> Result<std::fs::File, StateError>
 )]
 fn read_utf8_file(path: &Utf8Path) -> Result<String, StateError> {
     std::fs::read_to_string(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct file metadata reads"
+)]
+fn file_modified_at(path: &Utf8Path) -> Result<SystemTime, StateError> {
+    let metadata = std::fs::metadata(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))?;
+
+    metadata
+        .modified()
         .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
 }
 
@@ -298,3 +335,28 @@ fn current_uid() -> u32 {
 
 #[cfg(not(unix))]
 compile_error!("PV v1 targets macOS and requires Unix filesystem permissions");
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8Path;
+
+    use super::temporary_path_for;
+
+    #[test]
+    fn temporary_paths_keep_the_target_extension_in_the_derived_name() {
+        let pid_temporary_path = temporary_path_for(Utf8Path::new("/tmp/pv/runtime.pid"));
+        let metadata_temporary_path = temporary_path_for(Utf8Path::new("/tmp/pv/runtime.json"));
+
+        assert_ne!(pid_temporary_path, metadata_temporary_path);
+        assert!(
+            pid_temporary_path
+                .file_name()
+                .is_some_and(|name| name.starts_with("runtime.pid."))
+        );
+        assert!(
+            metadata_temporary_path
+                .file_name()
+                .is_some_and(|name| name.starts_with("runtime.json."))
+        );
+    }
+}

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -6,7 +6,8 @@ mod migrations;
 mod paths;
 
 pub use database::{
-    Database, DatabaseInspection, JobRecord, JobStatus, PortAssignment, PortRequest,
+    Database, DatabaseInspection, JobRecord, JobStatus, PortAssignment, PortOwner, PortRequest,
+    ProjectConfigWatch,
 };
 pub use error::StateError;
 pub use paths::{PathSummaryEntry, PvPaths};
@@ -15,6 +16,7 @@ pub use paths::{PathSummaryEntry, PvPaths};
 pub mod testing {
     use rusqlite::Transaction;
 
+    use crate::fs::read_to_string as read_file_to_string;
     pub use crate::migrations::Migration;
     use crate::{Database, PvPaths, StateError};
 
@@ -30,7 +32,7 @@ pub mod testing {
     }
 
     pub fn read_to_string(path: &camino::Utf8Path) -> Result<String, StateError> {
-        crate::fs::read_to_string(path)
+        read_file_to_string(path)
     }
 
     pub fn transaction<T>(

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -5,7 +5,9 @@ pub mod fs;
 mod migrations;
 mod paths;
 
-pub use database::{Database, DatabaseInspection, JobRecord, JobStatus};
+pub use database::{
+    Database, DatabaseInspection, JobRecord, JobStatus, PortAssignment, PortRequest,
+};
 pub use error::StateError;
 pub use paths::{PathSummaryEntry, PvPaths};
 
@@ -25,6 +27,10 @@ pub mod testing {
 
     pub fn query_i64(database: &Database, sql: &str) -> Result<i64, StateError> {
         database.query_i64(sql)
+    }
+
+    pub fn read_to_string(path: &camino::Utf8Path) -> Result<String, StateError> {
+        crate::fs::read_to_string(path)
     }
 
     pub fn transaction<T>(

--- a/crates/state/src/sql/001_core_state_schema.sql
+++ b/crates/state/src/sql/001_core_state_schema.sql
@@ -101,12 +101,12 @@ CREATE TABLE resource_allocations (
 );
 
 CREATE TABLE ports (
-    name TEXT PRIMARY KEY,
-    port INTEGER NOT NULL UNIQUE,
     owner_kind TEXT NOT NULL,
-    resource_name TEXT,
-    track TEXT,
-    updated_at TEXT NOT NULL
+    owner_id TEXT NOT NULL,
+    owner_track TEXT NOT NULL,
+    port INTEGER NOT NULL UNIQUE,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (owner_kind, owner_id, owner_track)
 );
 
 CREATE TABLE observed_states (

--- a/crates/state/tests/snapshots/state_foundation__port_allocator_persists_reuses_avoids_collisions_and_releases_assignments.snap
+++ b/crates/state/tests/snapshots/state_foundation__port_allocator_persists_reuses_avoids_collisions_and_releases_assignments.snap
@@ -1,0 +1,81 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: "(assigned_mysql, reused_mysql, assigned_redis, released_mysql,\nreassigned_mysql, database.assigned_ports()?,)"
+---
+(
+    PortAssignment {
+        name: "resource:mysql:8.4",
+        port: 45000,
+        owner_kind: "resource",
+        resource_name: Some(
+            "mysql",
+        ),
+        track: Some(
+            "8.4",
+        ),
+        updated_at: "<timestamp>",
+    },
+    PortAssignment {
+        name: "resource:mysql:8.4",
+        port: 45000,
+        owner_kind: "resource",
+        resource_name: Some(
+            "mysql",
+        ),
+        track: Some(
+            "8.4",
+        ),
+        updated_at: "<timestamp>",
+    },
+    PortAssignment {
+        name: "resource:redis:8.6",
+        port: 45001,
+        owner_kind: "resource",
+        resource_name: Some(
+            "redis",
+        ),
+        track: Some(
+            "8.6",
+        ),
+        updated_at: "<timestamp>",
+    },
+    true,
+    PortAssignment {
+        name: "resource:mysql:8.4",
+        port: 45000,
+        owner_kind: "resource",
+        resource_name: Some(
+            "mysql",
+        ),
+        track: Some(
+            "8.4",
+        ),
+        updated_at: "<timestamp>",
+    },
+    [
+        PortAssignment {
+            name: "resource:mysql:8.4",
+            port: 45000,
+            owner_kind: "resource",
+            resource_name: Some(
+                "mysql",
+            ),
+            track: Some(
+                "8.4",
+            ),
+            updated_at: "<timestamp>",
+        },
+        PortAssignment {
+            name: "resource:redis:8.6",
+            port: 45001,
+            owner_kind: "resource",
+            resource_name: Some(
+                "redis",
+            ),
+            track: Some(
+                "8.6",
+            ),
+            updated_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/state/tests/snapshots/state_foundation__port_allocator_persists_reuses_avoids_collisions_and_releases_assignments.snap
+++ b/crates/state/tests/snapshots/state_foundation__port_allocator_persists_reuses_avoids_collisions_and_releases_assignments.snap
@@ -1,80 +1,57 @@
 ---
 source: crates/state/tests/state_foundation.rs
+assertion_line: 500
 expression: "(assigned_mysql, reused_mysql, assigned_redis, released_mysql,\nreassigned_mysql, database.assigned_ports()?,)"
 ---
 (
     PortAssignment {
-        name: "resource:mysql:8.4",
+        owner: Resource {
+            name: "mysql",
+            track: "8.4",
+        },
         port: 45000,
-        owner_kind: "resource",
-        resource_name: Some(
-            "mysql",
-        ),
-        track: Some(
-            "8.4",
-        ),
         updated_at: "<timestamp>",
     },
     PortAssignment {
-        name: "resource:mysql:8.4",
+        owner: Resource {
+            name: "mysql",
+            track: "8.4",
+        },
         port: 45000,
-        owner_kind: "resource",
-        resource_name: Some(
-            "mysql",
-        ),
-        track: Some(
-            "8.4",
-        ),
         updated_at: "<timestamp>",
     },
     PortAssignment {
-        name: "resource:redis:8.6",
+        owner: Resource {
+            name: "redis",
+            track: "8.6",
+        },
         port: 45001,
-        owner_kind: "resource",
-        resource_name: Some(
-            "redis",
-        ),
-        track: Some(
-            "8.6",
-        ),
         updated_at: "<timestamp>",
     },
     true,
     PortAssignment {
-        name: "resource:mysql:8.4",
+        owner: Resource {
+            name: "mysql",
+            track: "8.4",
+        },
         port: 45000,
-        owner_kind: "resource",
-        resource_name: Some(
-            "mysql",
-        ),
-        track: Some(
-            "8.4",
-        ),
         updated_at: "<timestamp>",
     },
     [
         PortAssignment {
-            name: "resource:mysql:8.4",
+            owner: Resource {
+                name: "mysql",
+                track: "8.4",
+            },
             port: 45000,
-            owner_kind: "resource",
-            resource_name: Some(
-                "mysql",
-            ),
-            track: Some(
-                "8.4",
-            ),
             updated_at: "<timestamp>",
         },
         PortAssignment {
-            name: "resource:redis:8.6",
+            owner: Resource {
+                name: "redis",
+                track: "8.6",
+            },
             port: 45001,
-            owner_kind: "resource",
-            resource_name: Some(
-                "redis",
-            ),
-            track: Some(
-                "8.6",
-            ),
             updated_at: "<timestamp>",
         },
     ],

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -484,24 +484,8 @@ fn port_allocator_persists_reuses_avoids_collisions_and_releases_assignments() -
     let tempdir = tempdir()?;
     let paths = PvPaths::for_home(tempdir.path().join("home"));
     let mut database = Database::open(&paths)?;
-    let mysql = PortRequest {
-        name: "resource:mysql:8.4".to_string(),
-        owner_kind: "resource".to_string(),
-        resource_name: Some("mysql".to_string()),
-        track: Some("8.4".to_string()),
-        preferred_port: 3306,
-        fallback_start: 45000,
-        fallback_end: 45009,
-    };
-    let redis = PortRequest {
-        name: "resource:redis:8.6".to_string(),
-        owner_kind: "resource".to_string(),
-        resource_name: Some("redis".to_string()),
-        track: Some("8.6".to_string()),
-        preferred_port: 45000,
-        fallback_start: 45000,
-        fallback_end: 45009,
-    };
+    let mysql = PortRequest::resource("mysql", "8.4", 3306, 45000, 45009);
+    let redis = PortRequest::resource("redis", "8.6", 45000, 45000, 45009);
 
     let assigned_mysql = database.assign_port(mysql.clone(), |port| port != 3306)?;
     let reused_mysql = database.assign_port(mysql.clone(), |port| port == assigned_mysql.port)?;
@@ -520,6 +504,33 @@ fn port_allocator_persists_reuses_avoids_collisions_and_releases_assignments() -
         ));
         Ok::<(), anyhow::Error>(())
     })?;
+
+    Ok(())
+}
+
+#[test]
+fn port_allocator_reports_the_documented_candidate_cap() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+
+    let single_candidate = database.assign_port(
+        PortRequest::resource("mysql", "8.4", 45000, 45000, 45000),
+        |_port| false,
+    );
+    let capped_candidates = database.assign_port(
+        PortRequest::resource("redis", "8.6", 45000, 45000, 45099),
+        |_port| false,
+    );
+
+    assert!(matches!(
+        single_candidate,
+        Err(StateError::NoAvailablePort { attempts: 1, .. })
+    ));
+    assert!(matches!(
+        capped_candidates,
+        Err(StateError::NoAvailablePort { attempts: 10, .. })
+    ));
 
     Ok(())
 }

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -4,7 +4,7 @@ use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
 use rusqlite::{Connection, params};
 use state::testing::Migration;
-use state::{Database, JobStatus, PortRequest, PvPaths, StateError};
+use state::{Database, JobStatus, PortOwner, PortRequest, PvPaths, StateError};
 
 #[test]
 fn paths_are_derived_from_an_injected_home() -> Result<()> {
@@ -490,7 +490,10 @@ fn port_allocator_persists_reuses_avoids_collisions_and_releases_assignments() -
     let assigned_mysql = database.assign_port(mysql.clone(), |port| port != 3306)?;
     let reused_mysql = database.assign_port(mysql.clone(), |port| port == assigned_mysql.port)?;
     let assigned_redis = database.assign_port(redis, |_port| true)?;
-    let released_mysql = database.release_port("resource:mysql:8.4")?;
+    let released_mysql = database.release_port(PortOwner::Resource {
+        name: "mysql".to_string(),
+        track: "8.4".to_string(),
+    })?;
     let reassigned_mysql = database.assign_port(mysql, |port| port != 3306)?;
 
     with_normalized_timestamps(|| {
@@ -504,6 +507,46 @@ fn port_allocator_persists_reuses_avoids_collisions_and_releases_assignments() -
         ));
         Ok::<(), anyhow::Error>(())
     })?;
+
+    Ok(())
+}
+
+#[test]
+fn port_allocator_keeps_owner_components_structured() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+    let mysql_debug = PortRequest::resource("mysql", "8.4:debug", 45000, 45000, 45009);
+    let mysql_track_resource = PortRequest::resource("mysql:8.4", "debug", 45000, 45000, 45009);
+
+    let assigned_mysql_debug = database.assign_port(mysql_debug, |_port| true)?;
+    let assigned_mysql_track_resource = database.assign_port(mysql_track_resource, |_port| true)?;
+    let released_mysql_debug = database.release_port(PortOwner::Resource {
+        name: "mysql".to_string(),
+        track: "8.4:debug".to_string(),
+    })?;
+
+    assert_eq!(
+        assigned_mysql_debug.owner,
+        PortOwner::Resource {
+            name: "mysql".to_string(),
+            track: "8.4:debug".to_string(),
+        }
+    );
+    assert_eq!(assigned_mysql_debug.port, 45000);
+    assert_eq!(
+        assigned_mysql_track_resource.owner,
+        PortOwner::Resource {
+            name: "mysql:8.4".to_string(),
+            track: "debug".to_string(),
+        }
+    );
+    assert_eq!(assigned_mysql_track_resource.port, 45001);
+    assert!(released_mysql_debug);
+    assert_eq!(
+        database.assigned_ports()?,
+        vec![assigned_mysql_track_resource]
+    );
 
     Ok(())
 }

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -4,7 +4,7 @@ use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
 use rusqlite::{Connection, params};
 use state::testing::Migration;
-use state::{Database, JobStatus, PvPaths, StateError};
+use state::{Database, JobStatus, PortRequest, PvPaths, StateError};
 
 #[test]
 fn paths_are_derived_from_an_injected_home() -> Result<()> {
@@ -207,6 +207,13 @@ fn with_normalized_backup_names(assertion: impl FnOnce() -> Result<()>) -> Resul
         r"pv\.db\.\d{8}-\d{6}(?:-\d+)?\.bak",
         "pv.db.<timestamp>.bak",
     );
+
+    settings.bind(assertion)
+}
+
+fn with_normalized_timestamps(assertion: impl FnOnce() -> Result<()>) -> Result<()> {
+    let mut settings = Settings::clone_current();
+    settings.add_filter(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", "<timestamp>");
 
     settings.bind(assertion)
 }
@@ -468,6 +475,51 @@ fn recent_jobs_returns_the_latest_one_hundred_jobs() -> Result<()> {
         jobs.last().map(|job| job.id.as_str()),
         stored_job_count,
     ));
+
+    Ok(())
+}
+
+#[test]
+fn port_allocator_persists_reuses_avoids_collisions_and_releases_assignments() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+    let mysql = PortRequest {
+        name: "resource:mysql:8.4".to_string(),
+        owner_kind: "resource".to_string(),
+        resource_name: Some("mysql".to_string()),
+        track: Some("8.4".to_string()),
+        preferred_port: 3306,
+        fallback_start: 45000,
+        fallback_end: 45009,
+    };
+    let redis = PortRequest {
+        name: "resource:redis:8.6".to_string(),
+        owner_kind: "resource".to_string(),
+        resource_name: Some("redis".to_string()),
+        track: Some("8.6".to_string()),
+        preferred_port: 45000,
+        fallback_start: 45000,
+        fallback_end: 45009,
+    };
+
+    let assigned_mysql = database.assign_port(mysql.clone(), |port| port != 3306)?;
+    let reused_mysql = database.assign_port(mysql.clone(), |port| port == assigned_mysql.port)?;
+    let assigned_redis = database.assign_port(redis, |_port| true)?;
+    let released_mysql = database.release_port("resource:mysql:8.4")?;
+    let reassigned_mysql = database.assign_port(mysql, |port| port != 3306)?;
+
+    with_normalized_timestamps(|| {
+        assert_debug_snapshot!((
+            assigned_mysql,
+            reused_mysql,
+            assigned_redis,
+            released_mysql,
+            reassigned_mysql,
+            database.assigned_ports()?,
+        ));
+        Ok::<(), anyhow::Error>(())
+    })?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add typed exact reconciliation scopes, drop-safe queue ownership, coalesced job attachment, and debounce primitives for M3
- add watcher-to-debouncer wiring so linked Project config changes enqueue project-scoped reconciliation jobs
- harden generic port allocation, process supervision ownership/adoption, readiness deadlines, process cleanup, and atomic file writes

## Roadmap
Implements PR 5: PV-030, PV-031, PV-032, PV-033, PV-034, PV-035, PV-036.

## Verification
- cargo fmt --all -- --check
- cargo nextest run -p daemon --no-capture
- cargo nextest run -p state --no-capture
- cargo nextest run --workspace --no-capture
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo shear
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queued, coalescing reconciliation with debouncing, serialized execution and enqueue/queued semantics.
  * Process supervision with lifecycle management, ownership/adoption and TCP/HTTP readiness probes.
  * Project config watcher that enqueues reconciliations on config changes.
  * Persistent port allocator with fallback, reuse and release; secure atomic file helpers.
  * Public API expanded to expose reconciliation and supervisor types.

* **Bug Fixes / Improvements**
  * Clearer timeout and missing-process error reporting; readiness errors include last probe details.

* **Tests**
  * Expanded integration and unit tests for reconciliation, supervision, readiness, port allocation and file helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prvious/pv/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->