### PR TITLE
feat(resources): add adapter install foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,10 +374,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -738,6 +773,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,10 +951,12 @@ dependencies = [
  "anyhow",
  "camino",
  "camino-tempfile",
+ "flate2",
  "insta",
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "thiserror",
  "time",
  "ureq",
@@ -1086,6 +1133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1231,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1702,6 +1766,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/crates/resources/Cargo.toml
+++ b/crates/resources/Cargo.toml
@@ -12,6 +12,8 @@ camino = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10"
+flate2 = "1.1.9"
+tar = "0.4.45"
 thiserror = { workspace = true }
 time = { workspace = true, features = ["parsing"] }
 ureq = { version = "3", default-features = false, features = ["rustls"] }

--- a/crates/resources/src/error.rs
+++ b/crates/resources/src/error.rs
@@ -96,6 +96,12 @@ pub enum ResourcesError {
         actual: String,
     },
 
+    #[error("invalid artifact archive `{path}`: {reason}")]
+    InvalidArtifactArchive { path: String, reason: String },
+
+    #[error("invalid artifact layout for `{resource}`: {reason}")]
+    InvalidArtifactLayout { resource: String, reason: String },
+
     #[error("filesystem error at `{path}`: {reason}")]
     Filesystem { path: String, reason: String },
 }

--- a/crates/resources/src/fs.rs
+++ b/crates/resources/src/fs.rs
@@ -142,7 +142,7 @@ fn create_file(path: &Utf8Path) -> Result<std::fs::File> {
     clippy::disallowed_methods,
     reason = "PV filesystem helper owns direct filesystem access"
 )]
-fn create_dir_all(path: &Utf8Path) -> Result<()> {
+pub(crate) fn create_dir_all(path: &Utf8Path) -> Result<()> {
     std::fs::create_dir_all(path).map_err(|source| filesystem_error(path, source))
 }
 
@@ -150,7 +150,7 @@ fn create_dir_all(path: &Utf8Path) -> Result<()> {
     clippy::disallowed_methods,
     reason = "PV filesystem helper owns direct filesystem access"
 )]
-fn rename(from: &Utf8Path, to: &Utf8Path) -> Result<()> {
+pub(crate) fn rename(from: &Utf8Path, to: &Utf8Path) -> Result<()> {
     std::fs::rename(from, to).map_err(|source| filesystem_error(to, source))
 }
 
@@ -160,6 +160,29 @@ fn rename(from: &Utf8Path, to: &Utf8Path) -> Result<()> {
 )]
 fn remove_file(path: &Utf8Path) -> std::io::Result<()> {
     std::fs::remove_file(path)
+}
+
+pub(crate) fn remove_dir_all_if_exists(path: &Utf8Path) -> Result<()> {
+    match remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(filesystem_error(path, source)),
+    }
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+fn remove_dir_all(path: &Utf8Path) -> std::io::Result<()> {
+    std::fs::remove_dir_all(path)
+}
+
+pub(crate) fn sync_directory(path: &Utf8Path) -> Result<()> {
+    let directory = open_file(path)?;
+    directory
+        .sync_all()
+        .map_err(|source| filesystem_error(path, source))
 }
 
 #[cfg(unix)]

--- a/crates/resources/src/fs.rs
+++ b/crates/resources/src/fs.rs
@@ -73,6 +73,14 @@ pub(crate) fn path_exists(path: &Utf8Path) -> bool {
     path.exists()
 }
 
+pub(crate) fn path_entry_exists(path: &Utf8Path) -> Result<bool> {
+    match symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(source) if source.kind() == ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(filesystem_error(path, source)),
+    }
+}
+
 pub(crate) fn path_is_directory(path: &Utf8Path) -> Result<bool> {
     symlink_metadata(path)
         .map(|metadata| metadata.is_dir())

--- a/crates/resources/src/fs.rs
+++ b/crates/resources/src/fs.rs
@@ -73,6 +73,12 @@ pub(crate) fn path_exists(path: &Utf8Path) -> bool {
     path.exists()
 }
 
+pub(crate) fn path_is_directory(path: &Utf8Path) -> Result<bool> {
+    symlink_metadata(path)
+        .map(|metadata| metadata.is_dir())
+        .map_err(|source| filesystem_error(path, source))
+}
+
 fn ensure_parent_dir(path: &Utf8Path) -> Result<()> {
     if let Some(parent) = path.parent() {
         create_dir_all(parent)?;
@@ -176,6 +182,14 @@ pub(crate) fn remove_dir_all_if_exists(path: &Utf8Path) -> Result<()> {
 )]
 fn remove_dir_all(path: &Utf8Path) -> std::io::Result<()> {
     std::fs::remove_dir_all(path)
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+fn symlink_metadata(path: &Utf8Path) -> std::io::Result<std::fs::Metadata> {
+    std::fs::symlink_metadata(path)
 }
 
 pub(crate) fn sync_directory(path: &Utf8Path) -> Result<()> {

--- a/crates/resources/src/identity.rs
+++ b/crates/resources/src/identity.rs
@@ -175,6 +175,8 @@ impl fmt::Display for PvVersion {
 
 fn validate_identity(kind: &'static str, value: String) -> Result<String> {
     let is_valid = !value.is_empty()
+        && value != "."
+        && value != ".."
         && value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'));

--- a/crates/resources/src/install.rs
+++ b/crates/resources/src/install.rs
@@ -43,6 +43,8 @@ impl ArtifactInstaller {
         artifact: &ManifestArtifact,
         archive_path: &Utf8Path,
     ) -> Result<ArtifactInstall> {
+        validate_artifact_matches_request(adapter.resource_name(), track, artifact)?;
+
         let track_dir = self
             .resources_dir
             .join(adapter.resource_name().as_str())
@@ -50,7 +52,7 @@ impl ArtifactInstaller {
         let releases_dir = track_dir.join("releases");
         let release_path = releases_dir.join(artifact.artifact_version().as_str());
         let current_path = track_dir.join("current");
-        let previous_release = current_release_name(&current_path)?;
+        let previous_release = current_release_name(adapter.resource_name(), &current_path)?;
 
         if fs::path_exists(&release_path) {
             adapter.validate_installation(&release_path)?;
@@ -88,6 +90,27 @@ impl ArtifactInstaller {
             current_path,
         ))
     }
+}
+
+fn validate_artifact_matches_request(
+    resource_name: &ResourceName,
+    track: &TrackName,
+    artifact: &ManifestArtifact,
+) -> Result<()> {
+    if artifact.resource_name() == resource_name && artifact.track() == track {
+        return Ok(());
+    }
+
+    Err(ResourcesError::InvalidArtifactLayout {
+        resource: resource_name.as_str().to_string(),
+        reason: format!(
+            "artifact belongs to `{}` track `{}`, not `{}` track `{}`",
+            artifact.resource_name(),
+            artifact.track(),
+            resource_name,
+            track
+        ),
+    })
 }
 
 impl ArtifactInstall {
@@ -324,20 +347,61 @@ fn update_current_pointer(track_dir: &Utf8Path, artifact_version: &ArtifactVersi
     Ok(())
 }
 
-fn current_release_name(current_path: &Utf8Path) -> Result<Option<String>> {
-    if !fs::path_exists(current_path) {
+fn current_release_name(
+    resource_name: &ResourceName,
+    current_path: &Utf8Path,
+) -> Result<Option<String>> {
+    if !fs::path_entry_exists(current_path)? {
         return Ok(None);
     }
 
     let target = read_link(current_path)?;
     let Some(version) = target.strip_prefix("releases/") else {
-        return Ok(None);
+        return Err(invalid_current_pointer(
+            resource_name,
+            current_path,
+            &target,
+        ));
     };
-    if version.contains('/') || version.is_empty() {
-        return Ok(None);
+    if version.contains('/')
+        || version.is_empty()
+        || ArtifactVersion::new(version.to_string()).is_err()
+    {
+        return Err(invalid_current_pointer(
+            resource_name,
+            current_path,
+            &target,
+        ));
+    }
+
+    let Some(track_dir) = current_path.parent() else {
+        return Err(invalid_current_pointer(
+            resource_name,
+            current_path,
+            &target,
+        ));
+    };
+    let target_path = track_dir.join(&target);
+    if !fs::path_entry_exists(&target_path)? || !fs::path_is_directory(&target_path)? {
+        return Err(invalid_current_pointer(
+            resource_name,
+            current_path,
+            &target,
+        ));
     }
 
     Ok(Some(version.to_string()))
+}
+
+fn invalid_current_pointer(
+    resource_name: &ResourceName,
+    current_path: &Utf8Path,
+    target: &str,
+) -> ResourcesError {
+    ResourcesError::InvalidArtifactLayout {
+        resource: resource_name.as_str().to_string(),
+        reason: format!("current pointer `{current_path}` targets invalid release `{target}`"),
+    }
 }
 
 fn prune_old_releases(

--- a/crates/resources/src/install.rs
+++ b/crates/resources/src/install.rs
@@ -1,0 +1,415 @@
+use std::path::{Component, Path};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use flate2::read::GzDecoder;
+use tar::Archive;
+
+use crate::fs;
+use crate::{ArtifactVersion, ManifestArtifact, ResourceName, ResourcesError, Result, TrackName};
+
+static INSTALL_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+pub trait ResourceAdapter {
+    fn resource_name(&self) -> &ResourceName;
+    fn validate_installation(&self, root: &Utf8Path) -> Result<()>;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArtifactInstaller {
+    resources_dir: Utf8PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArtifactInstall {
+    resource_name: ResourceName,
+    track: TrackName,
+    artifact_version: ArtifactVersion,
+    release_path: Utf8PathBuf,
+    current_path: Utf8PathBuf,
+}
+
+impl ArtifactInstaller {
+    pub fn new(resources_dir: impl Into<Utf8PathBuf>) -> Self {
+        Self {
+            resources_dir: resources_dir.into(),
+        }
+    }
+
+    pub fn install(
+        &self,
+        adapter: &impl ResourceAdapter,
+        track: &TrackName,
+        artifact: &ManifestArtifact,
+        archive_path: &Utf8Path,
+    ) -> Result<ArtifactInstall> {
+        let track_dir = self
+            .resources_dir
+            .join(adapter.resource_name().as_str())
+            .join(track.as_str());
+        let releases_dir = track_dir.join("releases");
+        let release_path = releases_dir.join(artifact.artifact_version().as_str());
+        let current_path = track_dir.join("current");
+        let previous_release = current_release_name(&current_path)?;
+
+        if fs::path_exists(&release_path) {
+            adapter.validate_installation(&release_path)?;
+            update_current_pointer(&track_dir, artifact.artifact_version())?;
+            prune_old_releases(
+                &releases_dir,
+                artifact.artifact_version(),
+                previous_release.as_deref(),
+            )?;
+
+            return Ok(ArtifactInstall::new(
+                adapter.resource_name().clone(),
+                track.clone(),
+                artifact.artifact_version().clone(),
+                release_path,
+                current_path,
+            ));
+        }
+
+        fs::create_dir_all(&releases_dir)?;
+        let staging_dir = staging_dir(&track_dir, artifact.artifact_version());
+
+        let result = unpack_validate_and_promote(
+            archive_path,
+            &staging_dir,
+            &release_path,
+            adapter,
+            artifact.artifact_version(),
+        );
+        if let Err(error) = result {
+            if let Err(_cleanup_error) = fs::remove_dir_all_if_exists(&staging_dir) {}
+
+            return Err(error);
+        }
+
+        update_current_pointer(&track_dir, artifact.artifact_version())?;
+        prune_old_releases(
+            &releases_dir,
+            artifact.artifact_version(),
+            previous_release.as_deref(),
+        )?;
+        fs::remove_dir_all_if_exists(&staging_dir)?;
+
+        Ok(ArtifactInstall::new(
+            adapter.resource_name().clone(),
+            track.clone(),
+            artifact.artifact_version().clone(),
+            release_path,
+            current_path,
+        ))
+    }
+}
+
+impl ArtifactInstall {
+    fn new(
+        resource_name: ResourceName,
+        track: TrackName,
+        artifact_version: ArtifactVersion,
+        release_path: Utf8PathBuf,
+        current_path: Utf8PathBuf,
+    ) -> Self {
+        Self {
+            resource_name,
+            track,
+            artifact_version,
+            release_path,
+            current_path,
+        }
+    }
+
+    pub fn resource_name(&self) -> &ResourceName {
+        &self.resource_name
+    }
+
+    pub fn track(&self) -> &TrackName {
+        &self.track
+    }
+
+    pub fn artifact_version(&self) -> &ArtifactVersion {
+        &self.artifact_version
+    }
+
+    pub fn release_path(&self) -> &Utf8Path {
+        &self.release_path
+    }
+
+    pub fn current_path(&self) -> &Utf8Path {
+        &self.current_path
+    }
+}
+
+fn unpack_validate_and_promote(
+    archive_path: &Utf8Path,
+    staging_dir: &Utf8Path,
+    release_path: &Utf8Path,
+    adapter: &impl ResourceAdapter,
+    artifact_version: &ArtifactVersion,
+) -> Result<()> {
+    fs::remove_dir_all_if_exists(staging_dir)?;
+    fs::create_dir_all(staging_dir)?;
+    let root = unpack_single_root_archive(archive_path, staging_dir)?;
+    adapter.validate_installation(&root)?;
+    fs::rename(&root, release_path)?;
+
+    if let Some(parent) = release_path.parent() {
+        fs::sync_directory(parent)?;
+    }
+
+    if !fs::path_exists(release_path) {
+        return Err(ResourcesError::InvalidArtifactLayout {
+            resource: adapter.resource_name().as_str().to_string(),
+            reason: format!("artifact `{artifact_version}` was not installed"),
+        });
+    }
+
+    Ok(())
+}
+
+fn unpack_single_root_archive(
+    archive_path: &Utf8Path,
+    staging_dir: &Utf8Path,
+) -> Result<Utf8PathBuf> {
+    let file = open_archive_file(archive_path)?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+    let mut root_name: Option<String> = None;
+    let entries = archive
+        .entries()
+        .map_err(|source| invalid_archive(archive_path, source))?;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|source| invalid_archive(archive_path, source))?;
+        let entry_path = entry
+            .path()
+            .map_err(|source| invalid_archive(archive_path, source))?;
+        let relative_path = clean_archive_path(archive_path, &entry_path)?;
+        let Some(first_component) = relative_path.components().next() else {
+            continue;
+        };
+
+        match root_name.as_deref() {
+            Some(root) if root != first_component.as_str() => {
+                return Err(ResourcesError::InvalidArtifactArchive {
+                    path: archive_path.to_string(),
+                    reason: "archive must contain exactly one top-level directory".to_string(),
+                });
+            }
+            None => root_name = Some(first_component.to_string()),
+            _ => {}
+        }
+
+        let output_path = staging_dir.join(&relative_path);
+        if let Some(parent) = output_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        entry
+            .unpack(&output_path)
+            .map_err(|source| invalid_archive(archive_path, source))?;
+    }
+
+    let Some(root_name) = root_name else {
+        return Err(ResourcesError::InvalidArtifactArchive {
+            path: archive_path.to_string(),
+            reason: "archive is empty".to_string(),
+        });
+    };
+
+    Ok(staging_dir.join(root_name))
+}
+
+fn clean_archive_path(archive_path: &Utf8Path, path: &Path) -> Result<Utf8PathBuf> {
+    let mut clean = Utf8PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Normal(value) => {
+                let Some(value) = value.to_str() else {
+                    return Err(ResourcesError::InvalidArtifactArchive {
+                        path: archive_path.to_string(),
+                        reason: "archive entry path is not valid UTF-8".to_string(),
+                    });
+                };
+                clean.push(value);
+            }
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(ResourcesError::InvalidArtifactArchive {
+                    path: archive_path.to_string(),
+                    reason: format!("archive entry `{}` is not relative", path.display()),
+                });
+            }
+        }
+    }
+
+    if clean.as_str().is_empty() {
+        return Err(ResourcesError::InvalidArtifactArchive {
+            path: archive_path.to_string(),
+            reason: "archive entry path is empty".to_string(),
+        });
+    }
+
+    Ok(clean)
+}
+
+fn staging_dir(track_dir: &Utf8Path, artifact_version: &ArtifactVersion) -> Utf8PathBuf {
+    let process_id = std::process::id();
+    let counter = INSTALL_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    track_dir.join(format!(
+        ".installing-{}-{process_id}-{counter}",
+        artifact_version.as_str()
+    ))
+}
+
+fn update_current_pointer(track_dir: &Utf8Path, artifact_version: &ArtifactVersion) -> Result<()> {
+    let current_path = track_dir.join("current");
+    let temporary_path = track_dir.join(format!(
+        "current.{}.{}.tmp",
+        std::process::id(),
+        INSTALL_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+
+    fs::remove_file_if_exists(&temporary_path)?;
+    symlink_dir(
+        Utf8Path::new(&format!("releases/{}", artifact_version.as_str())),
+        &temporary_path,
+    )?;
+    fs::rename(&temporary_path, &current_path)?;
+    fs::sync_directory(track_dir)?;
+
+    Ok(())
+}
+
+fn current_release_name(current_path: &Utf8Path) -> Result<Option<String>> {
+    if !fs::path_exists(current_path) {
+        return Ok(None);
+    }
+
+    let target = read_link(current_path)?;
+    let Some(version) = target.strip_prefix("releases/") else {
+        return Ok(None);
+    };
+    if version.contains('/') || version.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(version.to_string()))
+}
+
+fn prune_old_releases(
+    releases_dir: &Utf8Path,
+    current: &ArtifactVersion,
+    previous: Option<&str>,
+) -> Result<()> {
+    for release in release_entries(releases_dir)? {
+        if release.name == current.as_str() || Some(release.name.as_str()) == previous {
+            continue;
+        }
+
+        fs::remove_dir_all_if_exists(&release.path)?;
+    }
+
+    fs::sync_directory(releases_dir)?;
+
+    Ok(())
+}
+
+struct ReleaseEntry {
+    name: String,
+    path: Utf8PathBuf,
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resource installer owns release directory pruning"
+)]
+fn release_entries(path: &Utf8Path) -> Result<Vec<ReleaseEntry>> {
+    let mut entries = Vec::new();
+
+    for entry in std::fs::read_dir(path).map_err(|source| ResourcesError::Filesystem {
+        path: path.to_string(),
+        reason: source.to_string(),
+    })? {
+        let entry = entry.map_err(|source| ResourcesError::Filesystem {
+            path: path.to_string(),
+            reason: source.to_string(),
+        })?;
+        if !entry
+            .file_type()
+            .map_err(|source| ResourcesError::Filesystem {
+                path: path.to_string(),
+                reason: source.to_string(),
+            })?
+            .is_dir()
+        {
+            continue;
+        }
+
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let path = Utf8PathBuf::from_path_buf(entry.path()).map_err(|path| {
+            ResourcesError::Filesystem {
+                path: path.to_string_lossy().into_owned(),
+                reason: "release path is not valid UTF-8".to_string(),
+            }
+        })?;
+        entries.push(ReleaseEntry { name, path });
+    }
+
+    Ok(entries)
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "resource installer owns archive file handles"
+)]
+fn open_archive_file(path: &Utf8Path) -> Result<std::fs::File> {
+    std::fs::File::open(path).map_err(|source| ResourcesError::Filesystem {
+        path: path.to_string(),
+        reason: source.to_string(),
+    })
+}
+
+fn invalid_archive(path: &Utf8Path, source: std::io::Error) -> ResourcesError {
+    ResourcesError::InvalidArtifactArchive {
+        path: path.to_string(),
+        reason: source.to_string(),
+    }
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resource installer owns current symlink inspection"
+)]
+fn read_link(path: &Utf8Path) -> Result<String> {
+    std::fs::read_link(path)
+        .map(|path| path.to_string_lossy().into_owned())
+        .map_err(|source| ResourcesError::Filesystem {
+            path: path.to_string(),
+            reason: source.to_string(),
+        })
+}
+
+#[cfg(unix)]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resource installer owns current symlink updates"
+)]
+fn symlink_dir(target: &Utf8Path, link: &Utf8Path) -> Result<()> {
+    std::os::unix::fs::symlink(target, link).map_err(|source| ResourcesError::Filesystem {
+        path: link.to_string(),
+        reason: source.to_string(),
+    })
+}
+
+#[cfg(not(unix))]
+fn symlink_dir(_target: &Utf8Path, link: &Utf8Path) -> Result<()> {
+    Err(ResourcesError::Filesystem {
+        path: link.to_string(),
+        reason: "PV artifact installs require Unix symlinks".to_string(),
+    })
+}

--- a/crates/resources/src/install.rs
+++ b/crates/resources/src/install.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use flate2::read::GzDecoder;
-use tar::Archive;
+use tar::{Archive, EntryType};
 
 use crate::fs;
 use crate::{ArtifactVersion, ManifestArtifact, ResourceName, ResourcesError, Result, TrackName};
@@ -54,45 +54,31 @@ impl ArtifactInstaller {
 
         if fs::path_exists(&release_path) {
             adapter.validate_installation(&release_path)?;
-            update_current_pointer(&track_dir, artifact.artifact_version())?;
-            prune_old_releases(
-                &releases_dir,
+        } else {
+            fs::create_dir_all(&releases_dir)?;
+            let staging_dir = staging_dir(&track_dir, artifact.artifact_version());
+
+            let result = unpack_validate_and_promote(
+                archive_path,
+                &staging_dir,
+                &release_path,
+                adapter,
                 artifact.artifact_version(),
-                previous_release.as_deref(),
-            )?;
+            );
+            if let Err(error) = result {
+                if let Err(_cleanup_error) = fs::remove_dir_all_if_exists(&staging_dir) {}
 
-            return Ok(ArtifactInstall::new(
-                adapter.resource_name().clone(),
-                track.clone(),
-                artifact.artifact_version().clone(),
-                release_path,
-                current_path,
-            ));
+                return Err(error);
+            }
+            fs::remove_dir_all_if_exists(&staging_dir)?;
         }
 
-        fs::create_dir_all(&releases_dir)?;
-        let staging_dir = staging_dir(&track_dir, artifact.artifact_version());
-
-        let result = unpack_validate_and_promote(
-            archive_path,
-            &staging_dir,
-            &release_path,
-            adapter,
-            artifact.artifact_version(),
-        );
-        if let Err(error) = result {
-            if let Err(_cleanup_error) = fs::remove_dir_all_if_exists(&staging_dir) {}
-
-            return Err(error);
-        }
-
-        update_current_pointer(&track_dir, artifact.artifact_version())?;
         prune_old_releases(
             &releases_dir,
             artifact.artifact_version(),
             previous_release.as_deref(),
         )?;
-        fs::remove_dir_all_if_exists(&staging_dir)?;
+        update_current_pointer(&track_dir, artifact.artifact_version())?;
 
         Ok(ArtifactInstall::new(
             adapter.resource_name().clone(),
@@ -183,6 +169,10 @@ fn unpack_single_root_archive(
 
     for entry in entries {
         let mut entry = entry.map_err(|source| invalid_archive(archive_path, source))?;
+        if should_skip_archive_entry(entry.header().entry_type()) {
+            continue;
+        }
+        validate_archive_entry_type(archive_path, entry.header().entry_type())?;
         let entry_path = entry
             .path()
             .map_err(|source| invalid_archive(archive_path, source))?;
@@ -219,7 +209,56 @@ fn unpack_single_root_archive(
         });
     };
 
-    Ok(staging_dir.join(root_name))
+    let root_path = staging_dir.join(root_name);
+    if !fs::path_is_directory(&root_path)? {
+        return Err(ResourcesError::InvalidArtifactArchive {
+            path: archive_path.to_string(),
+            reason: "archive root is not a directory".to_string(),
+        });
+    }
+
+    Ok(root_path)
+}
+
+fn should_skip_archive_entry(entry_type: EntryType) -> bool {
+    entry_type.is_pax_global_extensions()
+        || entry_type.is_pax_local_extensions()
+        || entry_type.is_gnu_longname()
+        || entry_type.is_gnu_longlink()
+}
+
+fn validate_archive_entry_type(archive_path: &Utf8Path, entry_type: EntryType) -> Result<()> {
+    if entry_type.is_file() || entry_type.is_dir() {
+        return Ok(());
+    }
+
+    Err(ResourcesError::InvalidArtifactArchive {
+        path: archive_path.to_string(),
+        reason: format!(
+            "unsupported archive entry type `{}`",
+            archive_entry_type_name(entry_type)
+        ),
+    })
+}
+
+fn archive_entry_type_name(entry_type: EntryType) -> &'static str {
+    if entry_type.is_hard_link() {
+        "hard link"
+    } else if entry_type.is_symlink() {
+        "symlink"
+    } else if entry_type.is_character_special() {
+        "character special"
+    } else if entry_type.is_block_special() {
+        "block special"
+    } else if entry_type.is_fifo() {
+        "fifo"
+    } else if entry_type.is_contiguous() {
+        "contiguous file"
+    } else if entry_type.is_gnu_sparse() {
+        "sparse file"
+    } else {
+        "unknown"
+    }
 }
 
 fn clean_archive_path(archive_path: &Utf8Path, path: &Path) -> Result<Utf8PathBuf> {

--- a/crates/resources/src/lib.rs
+++ b/crates/resources/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 mod fs;
 pub mod http;
 pub mod identity;
+pub mod install;
 pub mod manifest;
 pub mod platform;
 pub mod registry;
@@ -15,6 +16,7 @@ pub use http::{ResourceHttpClient, UreqResourceHttpClient};
 pub use identity::{
     ArtifactVersion, PublishedAt, PvVersion, ResourceName, Sha256Digest, TrackName, TrackSelector,
 };
+pub use install::{ArtifactInstall, ArtifactInstaller, ResourceAdapter};
 pub use manifest::{ArtifactManifest, ManifestArtifact, ManifestSelection, RevocationState};
 pub use platform::{ArtifactPlatform, TargetPlatform};
 pub use registry::{ResourceCapability, ResourceDescriptor, ResourceKind};

--- a/crates/resources/src/manifest.rs
+++ b/crates/resources/src/manifest.rs
@@ -30,6 +30,8 @@ struct ManifestTrack {
 
 #[derive(Debug, Clone)]
 pub struct ManifestArtifact {
+    resource_name: ResourceName,
+    track: TrackName,
     artifact_version: ArtifactVersion,
     upstream_version: String,
     pv_build_revision: String,
@@ -212,7 +214,7 @@ impl ManifestResource {
                     });
                 }
 
-                ManifestTrack::from_raw(track, &raw.name)
+                ManifestTrack::from_raw(track, &name)
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -243,7 +245,7 @@ impl ManifestResource {
 }
 
 impl ManifestTrack {
-    fn from_raw(raw: RawTrack, resource: &str) -> Result<Self> {
+    fn from_raw(raw: RawTrack, resource: &ResourceName) -> Result<Self> {
         reject_reserved_track_name(&raw.name)?;
         let name = TrackName::new(raw.name.clone())?;
         let mut seen_artifacts = BTreeSet::new();
@@ -255,13 +257,14 @@ impl ManifestTrack {
                 if !seen_artifacts.insert(identity) {
                     return Err(ResourcesError::InvalidManifest {
                         reason: format!(
-                            "duplicate artifact identity in resource `{resource}` track `{}`",
+                            "duplicate artifact identity in resource `{}` track `{}`",
+                            resource.as_str(),
                             raw.name
                         ),
                     });
                 }
 
-                ManifestArtifact::from_raw(artifact)
+                ManifestArtifact::from_raw(artifact, resource, &name)
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -275,8 +278,8 @@ impl ManifestTrack {
         }
 
         let track = Self { name, artifacts };
-        track.validate_platform_specificity(resource)?;
-        track.validate_unique_published_at_slots(resource)?;
+        track.validate_platform_specificity(resource.as_str())?;
+        track.validate_unique_published_at_slots(resource.as_str())?;
 
         Ok(track)
     }
@@ -414,8 +417,10 @@ impl ManifestTrack {
 }
 
 impl ManifestArtifact {
-    fn from_raw(raw: RawArtifact) -> Result<Self> {
+    fn from_raw(raw: RawArtifact, resource_name: &ResourceName, track: &TrackName) -> Result<Self> {
         Ok(Self {
+            resource_name: resource_name.clone(),
+            track: track.clone(),
             artifact_version: ArtifactVersion::new(raw.artifact_version)?,
             upstream_version: raw.upstream_version,
             pv_build_revision: raw.pv_build_revision,
@@ -426,6 +431,14 @@ impl ManifestArtifact {
             published_at: PublishedAt::parse(raw.published_at)?,
             revocation_state: RevocationState::from_raw(raw.revoked, raw.revocation_reason)?,
         })
+    }
+
+    pub fn resource_name(&self) -> &ResourceName {
+        &self.resource_name
+    }
+
+    pub fn track(&self) -> &TrackName {
+        &self.track
     }
 
     pub fn artifact_version(&self) -> &ArtifactVersion {

--- a/crates/resources/tests/artifact_install.rs
+++ b/crates/resources/tests/artifact_install.rs
@@ -1,3 +1,6 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::tempdir;
@@ -8,7 +11,7 @@ use resources::{
     ArtifactInstall, ArtifactInstaller, ArtifactManifest, ManifestArtifact, ResourceAdapter,
     ResourceName, ResourcesError, TargetPlatform, TrackName,
 };
-use tar::{Builder, Header};
+use tar::{Builder, EntryType, Header};
 
 #[test]
 fn artifact_installer_unpacks_single_root_archive_and_updates_current_pointer() -> Result<()> {
@@ -109,6 +112,125 @@ fn artifact_installer_retains_current_and_previous_releases() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn artifact_installer_rejects_entries_that_can_escape_or_create_special_nodes() -> Result<()> {
+    let tempdir = tempdir()?;
+    let resources_dir = tempdir.path().join("resources");
+    let external_dir = tempdir.path().join("outside");
+    create_dir_all(&external_dir)?;
+    let installer = ArtifactInstaller::new(&resources_dir);
+    let adapter = RequiredPathAdapter::new("redis", &[])?;
+    let track = TrackName::new("7.2")?;
+
+    let symlink_archive = tempdir.path().join("symlink.tar.gz");
+    write_symlink_escape_archive(&symlink_archive, "redis-7.2.5-pv1", &external_dir)?;
+    let symlink_result = installer.install(&adapter, &track, &redis_artifact()?, &symlink_archive);
+
+    assert!(matches!(
+        symlink_result,
+        Err(ResourcesError::InvalidArtifactArchive { .. })
+    ));
+    assert!(!external_dir.join("redis-server").exists());
+
+    let hardlink_archive = tempdir.path().join("hardlink.tar.gz");
+    write_link_archive(&hardlink_archive, EntryType::Link)?;
+    let hardlink_result = installer.install(
+        &adapter,
+        &track,
+        &redis_artifact_with_version("7.2.6-pv1")?,
+        &hardlink_archive,
+    );
+    assert!(matches!(
+        hardlink_result,
+        Err(ResourcesError::InvalidArtifactArchive { .. })
+    ));
+
+    let fifo_archive = tempdir.path().join("fifo.tar.gz");
+    write_link_archive(&fifo_archive, EntryType::Fifo)?;
+    let fifo_result = installer.install(
+        &adapter,
+        &track,
+        &redis_artifact_with_version("7.2.7-pv1")?,
+        &fifo_archive,
+    );
+    assert!(matches!(
+        fifo_result,
+        Err(ResourcesError::InvalidArtifactArchive { .. })
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn artifact_installer_rejects_single_top_level_file_archive() -> Result<()> {
+    let tempdir = tempdir()?;
+    let archive_path = tempdir.path().join("redis.tar.gz");
+    write_fixture_archive(
+        &archive_path,
+        &[("redis-server", b"redis executable" as &[u8])],
+    )?;
+    let installer = ArtifactInstaller::new(tempdir.path().join("resources"));
+    let adapter = RequiredPathAdapter::new("redis", &[])?;
+    let artifact = redis_artifact()?;
+    let track = TrackName::new("7.2")?;
+
+    let result = installer.install(&adapter, &track, &artifact, &archive_path);
+
+    assert!(matches!(
+        result,
+        Err(ResourcesError::InvalidArtifactArchive { .. })
+    ));
+
+    Ok(())
+}
+
+#[test]
+#[cfg(unix)]
+fn artifact_installer_keeps_current_release_when_pruning_fails() -> Result<()> {
+    let tempdir = tempdir()?;
+    let installer = ArtifactInstaller::new(tempdir.path().join("resources"));
+    let adapter = RequiredPathAdapter::new("redis", &["bin/redis-server"])?;
+    let track = TrackName::new("7.2")?;
+    let current_archive = tempdir.path().join("7.2.5-pv1.tar.gz");
+    let next_archive = tempdir.path().join("7.2.6-pv1.tar.gz");
+    write_fixture_archive(
+        &current_archive,
+        &[("7.2.5-pv1/bin/redis-server", b"redis executable" as &[u8])],
+    )?;
+    write_fixture_archive(
+        &next_archive,
+        &[("7.2.6-pv1/bin/redis-server", b"redis executable" as &[u8])],
+    )?;
+    installer.install(
+        &adapter,
+        &track,
+        &redis_artifact_with_version("7.2.5-pv1")?,
+        &current_archive,
+    )?;
+    let releases_dir = tempdir.path().join("resources/redis/7.2/releases");
+    let stale_locked_dir = releases_dir.join("7.2.4-pv1/locked");
+    create_dir_all(&stale_locked_dir)?;
+    write_file(&stale_locked_dir.join("file"), b"locked")?;
+    set_dir_mode(&stale_locked_dir, 0o500)?;
+
+    let result = installer.install(
+        &adapter,
+        &track,
+        &redis_artifact_with_version("7.2.6-pv1")?,
+        &next_archive,
+    );
+
+    assert!(result.is_err());
+    assert_eq!(
+        read_link(&tempdir.path().join("resources/redis/7.2/current"))?,
+        "releases/7.2.5-pv1"
+    );
+
+    set_dir_mode(&stale_locked_dir, 0o700)?;
+
+    Ok(())
+}
+
 struct RequiredPathAdapter {
     resource_name: ResourceName,
     required_paths: Vec<Utf8PathBuf>,
@@ -202,6 +324,96 @@ fn write_fixture_archive(path: &Utf8Path, entries: &[(&str, &[u8])]) -> Result<(
 
     let encoder = builder.into_inner()?;
     encoder.finish()?;
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "resource install tests create fixture archives directly"
+)]
+fn write_symlink_escape_archive(
+    path: &Utf8Path,
+    root: &str,
+    external_dir: &Utf8Path,
+) -> Result<()> {
+    let file = std::fs::File::create(path)?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut builder = Builder::new(encoder);
+    let mut header = Header::new_gnu();
+    header.set_size(0);
+    header.set_entry_type(EntryType::Symlink);
+    header.set_cksum();
+    builder.append_link(&mut header, format!("{root}/bin"), external_dir)?;
+
+    let mut header = Header::new_gnu();
+    header.set_size(b"redis executable".len() as u64);
+    header.set_mode(0o755);
+    header.set_cksum();
+    builder.append_data(
+        &mut header,
+        format!("{root}/bin/redis-server"),
+        b"redis executable" as &[u8],
+    )?;
+
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "resource install tests create fixture archives directly"
+)]
+fn write_link_archive(path: &Utf8Path, entry_type: EntryType) -> Result<()> {
+    let file = std::fs::File::create(path)?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut builder = Builder::new(encoder);
+    let mut header = Header::new_gnu();
+    header.set_size(0);
+    header.set_entry_type(entry_type);
+    header.set_cksum();
+
+    if entry_type.is_hard_link() {
+        builder.append_link(&mut header, "redis-7.2.6-pv1/bin/redis-server", "target")?;
+    } else {
+        builder.append_data(&mut header, "redis-7.2.7-pv1/pipe", &[] as &[u8])?;
+    }
+
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resource install tests create pruning failure fixtures directly"
+)]
+fn set_dir_mode(path: &Utf8Path, mode: u32) -> Result<()> {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resource install tests create fixture directories directly"
+)]
+fn create_dir_all(path: &Utf8Path) -> Result<()> {
+    std::fs::create_dir_all(path)?;
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resource install tests create fixture files directly"
+)]
+fn write_file(path: &Utf8Path, content: &[u8]) -> Result<()> {
+    std::fs::write(path, content)?;
 
     Ok(())
 }

--- a/crates/resources/tests/artifact_install.rs
+++ b/crates/resources/tests/artifact_install.rs
@@ -1,0 +1,245 @@
+use anyhow::Result;
+use camino::{Utf8Path, Utf8PathBuf};
+use camino_tempfile::tempdir;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use insta::assert_debug_snapshot;
+use resources::{
+    ArtifactInstall, ArtifactInstaller, ArtifactManifest, ManifestArtifact, ResourceAdapter,
+    ResourceName, ResourcesError, TargetPlatform, TrackName,
+};
+use tar::{Builder, Header};
+
+#[test]
+fn artifact_installer_unpacks_single_root_archive_and_updates_current_pointer() -> Result<()> {
+    let tempdir = tempdir()?;
+    let archive_path = tempdir.path().join("redis.tar.gz");
+    write_fixture_archive(
+        &archive_path,
+        &[(
+            "redis-7.2.5-pv1/bin/redis-server",
+            b"redis executable" as &[u8],
+        )],
+    )?;
+    let installer = ArtifactInstaller::new(tempdir.path().join("resources"));
+    let adapter = RequiredPathAdapter::new("redis", &["bin/redis-server"])?;
+    let artifact = redis_artifact()?;
+    let track = TrackName::new("7.2")?;
+
+    let install = installer.install(&adapter, &track, &artifact, &archive_path)?;
+
+    assert_debug_snapshot!(install_summary(&install, tempdir.path())?);
+
+    Ok(())
+}
+
+#[test]
+fn artifact_installer_keeps_current_release_when_new_archive_fails_validation() -> Result<()> {
+    let tempdir = tempdir()?;
+    let first_archive_path = tempdir.path().join("redis-7.2.5.tar.gz");
+    let broken_archive_path = tempdir.path().join("redis-7.2.6.tar.gz");
+    write_fixture_archive(
+        &first_archive_path,
+        &[(
+            "redis-7.2.5-pv1/bin/redis-server",
+            b"redis executable" as &[u8],
+        )],
+    )?;
+    write_fixture_archive(
+        &broken_archive_path,
+        &[(
+            "redis-7.2.6-pv1/README.md",
+            b"missing redis-server" as &[u8],
+        )],
+    )?;
+    let installer = ArtifactInstaller::new(tempdir.path().join("resources"));
+    let adapter = RequiredPathAdapter::new("redis", &["bin/redis-server"])?;
+    let track = TrackName::new("7.2")?;
+    let first_artifact = redis_artifact()?;
+    let broken_artifact = redis_artifact_with_version("7.2.6-pv1")?;
+
+    let first_install =
+        installer.install(&adapter, &track, &first_artifact, &first_archive_path)?;
+    let failed_install =
+        installer.install(&adapter, &track, &broken_artifact, &broken_archive_path);
+
+    assert_debug_snapshot!((
+        failed_install,
+        read_link(first_install.current_path())?,
+        first_install.release_path().exists(),
+        first_install
+            .release_path()
+            .parent()
+            .map(sorted_file_names)
+            .transpose()?,
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn artifact_installer_retains_current_and_previous_releases() -> Result<()> {
+    let tempdir = tempdir()?;
+    let installer = ArtifactInstaller::new(tempdir.path().join("resources"));
+    let adapter = RequiredPathAdapter::new("redis", &["bin/redis-server"])?;
+    let track = TrackName::new("7.2")?;
+
+    for version in ["7.2.5-pv1", "7.2.6-pv1", "7.2.7-pv1"] {
+        let archive_path = tempdir.path().join(format!("{version}.tar.gz"));
+        write_fixture_archive(
+            &archive_path,
+            &[(
+                &format!("{version}/bin/redis-server"),
+                b"redis executable" as &[u8],
+            )],
+        )?;
+        let artifact = redis_artifact_with_version(version)?;
+        installer.install(&adapter, &track, &artifact, &archive_path)?;
+    }
+
+    let releases_dir = tempdir.path().join("resources/redis/7.2/releases");
+    let current_path = tempdir.path().join("resources/redis/7.2/current");
+
+    assert_eq!(
+        sorted_file_names(&releases_dir)?,
+        vec!["7.2.6-pv1", "7.2.7-pv1"]
+    );
+    assert_eq!(read_link(&current_path)?, "releases/7.2.7-pv1");
+
+    Ok(())
+}
+
+struct RequiredPathAdapter {
+    resource_name: ResourceName,
+    required_paths: Vec<Utf8PathBuf>,
+}
+
+impl RequiredPathAdapter {
+    fn new(resource_name: &str, required_paths: &[&str]) -> Result<Self> {
+        Ok(Self {
+            resource_name: ResourceName::new(resource_name)?,
+            required_paths: required_paths.iter().map(Utf8PathBuf::from).collect(),
+        })
+    }
+}
+
+impl ResourceAdapter for RequiredPathAdapter {
+    fn resource_name(&self) -> &ResourceName {
+        &self.resource_name
+    }
+
+    fn validate_installation(&self, root: &Utf8Path) -> resources::Result<()> {
+        for required_path in &self.required_paths {
+            let candidate = root.join(required_path);
+            if !candidate.exists() {
+                return Err(ResourcesError::InvalidArtifactLayout {
+                    resource: self.resource_name.as_str().to_string(),
+                    reason: format!("missing required path `{required_path}`"),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn redis_artifact() -> Result<ManifestArtifact> {
+    redis_artifact_with_version("7.2.5-pv1")
+}
+
+fn redis_artifact_with_version(version: &str) -> Result<ManifestArtifact> {
+    let manifest = VALID_MANIFEST.replace("7.2.5-pv1", version);
+    let parsed = ArtifactManifest::parse(&manifest)?;
+    let resource = ResourceName::new("redis")?;
+    let track = TrackName::new("7.2")?;
+    let selected = parsed.select_latest(&resource, &track, TargetPlatform::new("darwin-arm64")?)?;
+
+    Ok(selected.artifact().clone())
+}
+
+fn install_summary(install: &ArtifactInstall, root: &Utf8Path) -> Result<(String, String, String)> {
+    Ok((
+        relative_path(root, install.release_path())?,
+        relative_path(root, install.current_path())?,
+        read_link(install.current_path())?,
+    ))
+}
+
+fn relative_path(root: &Utf8Path, path: &Utf8Path) -> Result<String> {
+    Ok(path.strip_prefix(root)?.to_string())
+}
+
+fn sorted_file_names(path: &Utf8Path) -> Result<Vec<String>> {
+    let mut file_names = path
+        .read_dir_utf8()?
+        .map(|entry| {
+            entry
+                .map(|entry| entry.file_name().to_string())
+                .map_err(anyhow::Error::from)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    file_names.sort();
+
+    Ok(file_names)
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "resource install tests create fixture archives directly"
+)]
+fn write_fixture_archive(path: &Utf8Path, entries: &[(&str, &[u8])]) -> Result<()> {
+    let file = std::fs::File::create(path)?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut builder = Builder::new(encoder);
+
+    for (path, content) in entries {
+        let mut header = Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder.append_data(&mut header, path, *content)?;
+    }
+
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resource install tests inspect current symlink targets directly"
+)]
+fn read_link(path: &Utf8Path) -> Result<String> {
+    Ok(std::fs::read_link(path)?.to_string_lossy().into_owned())
+}
+
+const VALID_MANIFEST: &str = r#"
+{
+  "schema_version": 1,
+  "minimum_pv_version": "0.1.0",
+  "resources": [
+    {
+      "name": "redis",
+      "default_track": "7.2",
+      "tracks": [
+        {
+          "name": "7.2",
+          "artifacts": [
+            {
+              "artifact_version": "7.2.5-pv1",
+              "upstream_version": "7.2.5",
+              "pv_build_revision": "1",
+              "platform": "darwin-arm64",
+              "url": "https://artifacts.example.test/redis-7.2.5-pv1-darwin-arm64.tar.gz",
+              "sha256": "87698b18df0047a6404165a79250f5728ecc25b65fed27077ed9dff23e1232a9",
+              "size": 22,
+              "published_at": "2026-05-26T14:30:00Z"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+"#;

--- a/crates/resources/tests/artifact_install.rs
+++ b/crates/resources/tests/artifact_install.rs
@@ -37,6 +37,44 @@ fn artifact_installer_unpacks_single_root_archive_and_updates_current_pointer() 
 }
 
 #[test]
+fn artifact_installer_rejects_artifacts_selected_for_another_resource_or_track() -> Result<()> {
+    let tempdir = tempdir()?;
+    let installer = ArtifactInstaller::new(tempdir.path().join("resources"));
+    let adapter = RequiredPathAdapter::new("redis", &[])?;
+    let redis_track = TrackName::new("7.2")?;
+
+    let mysql_archive = tempdir.path().join("mysql.tar.gz");
+    write_fixture_archive(
+        &mysql_archive,
+        &[("7.2.5-pv1/bin/mysql", b"mysql executable" as &[u8])],
+    )?;
+    let mysql_artifact = manifest_artifact("mysql", "7.2", "7.2.5-pv1")?;
+    let resource_result =
+        installer.install(&adapter, &redis_track, &mysql_artifact, &mysql_archive);
+
+    assert!(matches!(
+        resource_result,
+        Err(ResourcesError::InvalidArtifactLayout { .. })
+    ));
+
+    let redis_8_archive = tempdir.path().join("redis-8.0.tar.gz");
+    write_fixture_archive(
+        &redis_8_archive,
+        &[("8.0.1-pv1/bin/redis-server", b"redis executable" as &[u8])],
+    )?;
+    let redis_8_artifact = manifest_artifact("redis", "8.0", "8.0.1-pv1")?;
+    let track_result =
+        installer.install(&adapter, &redis_track, &redis_8_artifact, &redis_8_archive);
+
+    assert!(matches!(
+        track_result,
+        Err(ResourcesError::InvalidArtifactLayout { .. })
+    ));
+
+    Ok(())
+}
+
+#[test]
 fn artifact_installer_keeps_current_release_when_new_archive_fails_validation() -> Result<()> {
     let tempdir = tempdir()?;
     let first_archive_path = tempdir.path().join("redis-7.2.5.tar.gz");
@@ -162,6 +200,45 @@ fn artifact_installer_rejects_entries_that_can_escape_or_create_special_nodes() 
 }
 
 #[test]
+fn artifact_installer_rejects_relative_and_absolute_archive_paths() -> Result<()> {
+    let tempdir = tempdir()?;
+    let resources_dir = tempdir.path().join("resources");
+    let external_dir = tempdir.path().join("outside");
+    create_dir_all(&external_dir)?;
+    let installer = ArtifactInstaller::new(&resources_dir);
+    let adapter = RequiredPathAdapter::new("redis", &[])?;
+    let artifact = redis_artifact()?;
+    let track = TrackName::new("7.2")?;
+
+    let relative_escape_archive = tempdir.path().join("relative-escape.tar.gz");
+    write_unchecked_path_archive(
+        &relative_escape_archive,
+        "redis-7.2.5-pv1/../../outside/redis-server",
+        b"redis executable",
+    )?;
+    let relative_result = installer.install(&adapter, &track, &artifact, &relative_escape_archive);
+
+    assert!(matches!(
+        relative_result,
+        Err(ResourcesError::InvalidArtifactArchive { .. })
+    ));
+    assert!(!external_dir.join("redis-server").exists());
+
+    let absolute_archive = tempdir.path().join("absolute.tar.gz");
+    let absolute_entry_path = format!("/tmp/pv-absolute-artifact-install-{}", std::process::id());
+    write_unchecked_path_archive(&absolute_archive, &absolute_entry_path, b"redis executable")?;
+    let absolute_result = installer.install(&adapter, &track, &artifact, &absolute_archive);
+
+    assert!(matches!(
+        absolute_result,
+        Err(ResourcesError::InvalidArtifactArchive { .. })
+    ));
+    assert!(!Utf8Path::new(&absolute_entry_path).exists());
+
+    Ok(())
+}
+
+#[test]
 fn artifact_installer_rejects_single_top_level_file_archive() -> Result<()> {
     let tempdir = tempdir()?;
     let archive_path = tempdir.path().join("redis.tar.gz");
@@ -178,6 +255,45 @@ fn artifact_installer_rejects_single_top_level_file_archive() -> Result<()> {
 
     assert!(matches!(
         result,
+        Err(ResourcesError::InvalidArtifactArchive { .. })
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn artifact_installer_rejects_empty_and_multi_root_archives() -> Result<()> {
+    let tempdir = tempdir()?;
+    let installer = ArtifactInstaller::new(tempdir.path().join("resources"));
+    let adapter = RequiredPathAdapter::new("redis", &[])?;
+    let artifact = redis_artifact()?;
+    let track = TrackName::new("7.2")?;
+
+    let empty_archive = tempdir.path().join("empty.tar.gz");
+    write_fixture_archive(&empty_archive, &[])?;
+    let empty_result = installer.install(&adapter, &track, &artifact, &empty_archive);
+    assert!(matches!(
+        empty_result,
+        Err(ResourcesError::InvalidArtifactArchive { .. })
+    ));
+
+    let multi_root_archive = tempdir.path().join("multi-root.tar.gz");
+    write_fixture_archive(
+        &multi_root_archive,
+        &[
+            (
+                "redis-7.2.5-pv1/bin/redis-server",
+                b"redis executable" as &[u8],
+            ),
+            (
+                "redis-7.2.5-pv1-extra/bin/redis-server",
+                b"redis executable" as &[u8],
+            ),
+        ],
+    )?;
+    let multi_root_result = installer.install(&adapter, &track, &artifact, &multi_root_archive);
+    assert!(matches!(
+        multi_root_result,
         Err(ResourcesError::InvalidArtifactArchive { .. })
     ));
 
@@ -231,6 +347,54 @@ fn artifact_installer_keeps_current_release_when_pruning_fails() -> Result<()> {
     Ok(())
 }
 
+#[test]
+#[cfg(unix)]
+fn artifact_installer_rejects_malformed_current_pointer_before_pruning() -> Result<()> {
+    let tempdir = tempdir()?;
+    let installer = ArtifactInstaller::new(tempdir.path().join("resources"));
+    let adapter = RequiredPathAdapter::new("redis", &["bin/redis-server"])?;
+    let track = TrackName::new("7.2")?;
+    let current_archive = tempdir.path().join("7.2.5-pv1.tar.gz");
+    let next_archive = tempdir.path().join("7.2.6-pv1.tar.gz");
+    write_fixture_archive(
+        &current_archive,
+        &[("7.2.5-pv1/bin/redis-server", b"redis executable" as &[u8])],
+    )?;
+    write_fixture_archive(
+        &next_archive,
+        &[("7.2.6-pv1/bin/redis-server", b"redis executable" as &[u8])],
+    )?;
+    installer.install(
+        &adapter,
+        &track,
+        &redis_artifact_with_version("7.2.5-pv1")?,
+        &current_archive,
+    )?;
+    let track_dir = tempdir.path().join("resources/redis/7.2");
+    let current_path = track_dir.join("current");
+    remove_file(&current_path)?;
+    symlink_dir("../outside-current", &current_path)?;
+
+    let result = installer.install(
+        &adapter,
+        &track,
+        &redis_artifact_with_version("7.2.6-pv1")?,
+        &next_archive,
+    );
+
+    assert!(matches!(
+        result,
+        Err(ResourcesError::InvalidArtifactLayout { .. })
+    ));
+    assert_eq!(
+        sorted_file_names(&track_dir.join("releases"))?,
+        vec!["7.2.5-pv1"]
+    );
+    assert_eq!(read_link(&current_path)?, "../outside-current");
+
+    Ok(())
+}
+
 struct RequiredPathAdapter {
     resource_name: ResourceName,
     required_paths: Vec<Utf8PathBuf>,
@@ -266,14 +430,32 @@ impl ResourceAdapter for RequiredPathAdapter {
 }
 
 fn redis_artifact() -> Result<ManifestArtifact> {
-    redis_artifact_with_version("7.2.5-pv1")
+    manifest_artifact("redis", "7.2", "7.2.5-pv1")
 }
 
 fn redis_artifact_with_version(version: &str) -> Result<ManifestArtifact> {
-    let manifest = VALID_MANIFEST.replace("7.2.5-pv1", version);
+    manifest_artifact("redis", "7.2", version)
+}
+
+fn manifest_artifact(
+    resource_name: &str,
+    track_name: &str,
+    version: &str,
+) -> Result<ManifestArtifact> {
+    let manifest = VALID_MANIFEST
+        .replace(
+            "\"name\": \"redis\"",
+            &format!("\"name\": \"{resource_name}\""),
+        )
+        .replace(
+            "\"default_track\": \"7.2\"",
+            &format!("\"default_track\": \"{track_name}\""),
+        )
+        .replace("\"name\": \"7.2\"", &format!("\"name\": \"{track_name}\""))
+        .replace("7.2.5-pv1", version);
     let parsed = ArtifactManifest::parse(&manifest)?;
-    let resource = ResourceName::new("redis")?;
-    let track = TrackName::new("7.2")?;
+    let resource = ResourceName::new(resource_name)?;
+    let track = TrackName::new(track_name)?;
     let selected = parsed.select_latest(&resource, &track, TargetPlatform::new("darwin-arm64")?)?;
 
     Ok(selected.artifact().clone())
@@ -321,6 +503,29 @@ fn write_fixture_archive(path: &Utf8Path, entries: &[(&str, &[u8])]) -> Result<(
         header.set_cksum();
         builder.append_data(&mut header, path, *content)?;
     }
+
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "resource install tests create malformed fixture archives directly"
+)]
+fn write_unchecked_path_archive(path: &Utf8Path, entry_path: &str, content: &[u8]) -> Result<()> {
+    let file = std::fs::File::create(path)?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut builder = Builder::new(encoder);
+    let mut header = Header::new_gnu();
+    let entry_path = entry_path.as_bytes();
+
+    header.as_mut_bytes()[..entry_path.len()].copy_from_slice(entry_path);
+    header.set_size(content.len() as u64);
+    header.set_mode(0o755);
+    header.set_cksum();
+    builder.append(&header, content)?;
 
     let encoder = builder.into_inner()?;
     encoder.finish()?;
@@ -414,6 +619,28 @@ fn create_dir_all(path: &Utf8Path) -> Result<()> {
 )]
 fn write_file(path: &Utf8Path, content: &[u8]) -> Result<()> {
     std::fs::write(path, content)?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resource install tests replace current symlinks directly"
+)]
+fn remove_file(path: &Utf8Path) -> Result<()> {
+    std::fs::remove_file(path)?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "resource install tests create current symlinks directly"
+)]
+fn symlink_dir(target: &str, link: &Utf8Path) -> Result<()> {
+    std::os::unix::fs::symlink(target, link)?;
 
     Ok(())
 }

--- a/crates/resources/tests/manifest_foundation.rs
+++ b/crates/resources/tests/manifest_foundation.rs
@@ -75,6 +75,12 @@ fn identity_types_reject_empty_values_and_bad_checksums() -> Result<()> {
     assert!(ResourceName::new("").is_err());
     assert!(TrackName::new("").is_err());
     assert!(ArtifactVersion::new("").is_err());
+    assert!(ResourceName::new(".").is_err());
+    assert!(ResourceName::new("..").is_err());
+    assert!(TrackName::new(".").is_err());
+    assert!(TrackName::new("..").is_err());
+    assert!(ArtifactVersion::new(".").is_err());
+    assert!(ArtifactVersion::new("..").is_err());
     assert!(Sha256Digest::new("not-a-sha").is_err());
     assert!(Sha256Digest::new("a".repeat(64)).is_ok());
 

--- a/crates/resources/tests/snapshots/artifact_cache_download__manifest_cache_fetches_latest_and_falls_back_to_cached_manifest-2.snap
+++ b/crates/resources/tests/snapshots/artifact_cache_download__manifest_cache_fetches_latest_and_falls_back_to_cached_manifest-2.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/resources/tests/artifact_cache_download.rs
+assertion_line: 35
 expression: cached.manifest()
 ---
 ArtifactManifest {
@@ -25,6 +26,12 @@ ArtifactManifest {
                     ),
                     artifacts: [
                         ManifestArtifact {
+                            resource_name: ResourceName(
+                                "redis",
+                            ),
+                            track: TrackName(
+                                "7.2",
+                            ),
                             artifact_version: ArtifactVersion(
                                 "7.2.5-pv1",
                             ),

--- a/crates/resources/tests/snapshots/artifact_install__artifact_installer_keeps_current_release_when_new_archive_fails_validation.snap
+++ b/crates/resources/tests/snapshots/artifact_install__artifact_installer_keeps_current_release_when_new_archive_fails_validation.snap
@@ -1,0 +1,19 @@
+---
+source: crates/resources/tests/artifact_install.rs
+expression: "(failed_install, read_link(&first_install.current_path())?,\nfirst_install.release_path().exists(),\nfirst_install.release_path().parent().map(|path|\nsorted_file_names(path)).transpose()?,)"
+---
+(
+    Err(
+        InvalidArtifactLayout {
+            resource: "redis",
+            reason: "missing required path `bin/redis-server`",
+        },
+    ),
+    "releases/7.2.5-pv1",
+    true,
+    Some(
+        [
+            "7.2.5-pv1",
+        ],
+    ),
+)

--- a/crates/resources/tests/snapshots/artifact_install__artifact_installer_unpacks_single_root_archive_and_updates_current_pointer.snap
+++ b/crates/resources/tests/snapshots/artifact_install__artifact_installer_unpacks_single_root_archive_and_updates_current_pointer.snap
@@ -1,0 +1,9 @@
+---
+source: crates/resources/tests/artifact_install.rs
+expression: "install_summary(&install, tempdir.path())?"
+---
+(
+    "resources/redis/7.2/releases/7.2.5-pv1",
+    "resources/redis/7.2/current",
+    "releases/7.2.5-pv1",
+)

--- a/crates/resources/tests/snapshots/manifest_foundation__manifest_parses_registry_backed_resources_tracks_and_artifacts.snap
+++ b/crates/resources/tests/snapshots/manifest_foundation__manifest_parses_registry_backed_resources_tracks_and_artifacts.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/resources/tests/manifest_foundation.rs
-assertion_line: 89
+assertion_line: 107
 expression: manifest
 ---
 ArtifactManifest {
@@ -26,6 +26,12 @@ ArtifactManifest {
                     ),
                     artifacts: [
                         ManifestArtifact {
+                            resource_name: ResourceName(
+                                "redis",
+                            ),
+                            track: TrackName(
+                                "7",
+                            ),
                             artifact_version: ArtifactVersion(
                                 "7.2.5-pv1",
                             ),
@@ -60,6 +66,12 @@ ArtifactManifest {
                     ),
                     artifacts: [
                         ManifestArtifact {
+                            resource_name: ResourceName(
+                                "composer",
+                            ),
+                            track: TrackName(
+                                "2",
+                            ),
                             artifact_version: ArtifactVersion(
                                 "2.8.0-pv1",
                             ),

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -318,7 +318,6 @@ impl Database {
             )
             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
             ON CONFLICT(resource_name, track) DO UPDATE SET
-                desired_state = excluded.desired_state,
                 installed_version = excluded.installed_version,
                 current_artifact_path = excluded.current_artifact_path,
                 updated_at = excluded.updated_at",

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::time::Duration;
 
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use rusqlite::{Connection, Transaction, TransactionBehavior, params};
 
 use crate::{PvPaths, StateError, fs, migrations};
@@ -97,6 +97,23 @@ pub struct ProjectConfigWatch {
     pub config_path: Utf8PathBuf,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ManagedResourceDesiredState {
+    Installed,
+    Removed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ManagedResourceTrackRecord {
+    pub resource_name: String,
+    pub track: String,
+    pub desired_state: ManagedResourceDesiredState,
+    pub installed_version: Option<String>,
+    pub current_artifact_path: Option<Utf8PathBuf>,
+    pub usage_count: i64,
+    pub updated_at: String,
+}
+
 struct JobRecordRow {
     id: String,
     kind: String,
@@ -113,6 +130,16 @@ struct PortAssignmentRow {
     owner_id: String,
     owner_track: String,
     port: u16,
+    updated_at: String,
+}
+
+struct ManagedResourceTrackRow {
+    resource_name: String,
+    track: String,
+    desired_state: String,
+    installed_version: Option<String>,
+    current_artifact_path: Option<String>,
+    usage_count: i64,
     updated_at: String,
 }
 
@@ -251,6 +278,77 @@ impl Database {
         }
 
         Ok(jobs)
+    }
+
+    pub fn record_managed_resource_track_desired(
+        &mut self,
+        resource_name: &str,
+        track: &str,
+        desired_state: ManagedResourceDesiredState,
+    ) -> Result<ManagedResourceTrackRecord, StateError> {
+        let updated_at = timestamp()?;
+        self.connection.execute(
+            "INSERT INTO managed_resource_tracks (resource_name, track, desired_state, updated_at)
+            VALUES (?1, ?2, ?3, ?4)
+            ON CONFLICT(resource_name, track) DO UPDATE SET
+                desired_state = excluded.desired_state,
+                updated_at = excluded.updated_at",
+            params![resource_name, track, desired_state.as_str(), updated_at],
+        )?;
+
+        self.managed_resource_track(resource_name, track)
+    }
+
+    pub fn record_managed_resource_track_installed(
+        &mut self,
+        resource_name: &str,
+        track: &str,
+        installed_version: &str,
+        current_artifact_path: &Utf8Path,
+    ) -> Result<ManagedResourceTrackRecord, StateError> {
+        let updated_at = timestamp()?;
+        self.connection.execute(
+            "INSERT INTO managed_resource_tracks (
+                resource_name,
+                track,
+                desired_state,
+                installed_version,
+                current_artifact_path,
+                updated_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            ON CONFLICT(resource_name, track) DO UPDATE SET
+                desired_state = excluded.desired_state,
+                installed_version = excluded.installed_version,
+                current_artifact_path = excluded.current_artifact_path,
+                updated_at = excluded.updated_at",
+            params![
+                resource_name,
+                track,
+                ManagedResourceDesiredState::Installed.as_str(),
+                installed_version,
+                current_artifact_path.as_str(),
+                updated_at,
+            ],
+        )?;
+
+        self.managed_resource_track(resource_name, track)
+    }
+
+    pub fn managed_resource_tracks(&self) -> Result<Vec<ManagedResourceTrackRecord>, StateError> {
+        let mut statement = self.connection.prepare(
+            "SELECT resource_name, track, desired_state, installed_version, current_artifact_path, usage_count, updated_at
+            FROM managed_resource_tracks
+            ORDER BY resource_name, track",
+        )?;
+        let rows = statement.query_map([], managed_resource_track_from_row)?;
+        let mut tracks = Vec::new();
+
+        for row in rows {
+            tracks.push(row?.into_record()?);
+        }
+
+        Ok(tracks)
     }
 
     pub fn assign_port(
@@ -404,6 +502,41 @@ impl Database {
         }
 
         Ok(tables)
+    }
+
+    fn managed_resource_track(
+        &self,
+        resource_name: &str,
+        track: &str,
+    ) -> Result<ManagedResourceTrackRecord, StateError> {
+        let mut statement = self.connection.prepare(
+            "SELECT resource_name, track, desired_state, installed_version, current_artifact_path, usage_count, updated_at
+            FROM managed_resource_tracks
+            WHERE resource_name = ?1 AND track = ?2",
+        )?;
+        let row = statement.query_row(
+            params![resource_name, track],
+            managed_resource_track_from_row,
+        )?;
+
+        row.into_record()
+    }
+}
+
+impl ManagedResourceDesiredState {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Installed => "installed",
+            Self::Removed => "removed",
+        }
+    }
+
+    fn from_database(desired_state: String) -> Result<Self, StateError> {
+        match desired_state.as_str() {
+            "installed" => Ok(Self::Installed),
+            "removed" => Ok(Self::Removed),
+            _ => Err(StateError::UnknownManagedResourceDesiredState { desired_state }),
+        }
     }
 }
 
@@ -611,6 +744,20 @@ impl PortAssignmentRow {
     }
 }
 
+impl ManagedResourceTrackRow {
+    fn into_record(self) -> Result<ManagedResourceTrackRecord, StateError> {
+        Ok(ManagedResourceTrackRecord {
+            resource_name: self.resource_name,
+            track: self.track,
+            desired_state: ManagedResourceDesiredState::from_database(self.desired_state)?,
+            installed_version: self.installed_version,
+            current_artifact_path: self.current_artifact_path.map(Utf8PathBuf::from),
+            usage_count: self.usage_count,
+            updated_at: self.updated_at,
+        })
+    }
+}
+
 impl PortIdentity {
     fn display_name(&self) -> String {
         describe_port_identity(self.owner_kind, &self.owner_id, &self.owner_track)
@@ -699,6 +846,20 @@ fn port_assignment_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PortAss
         owner_track: row.get(2)?,
         port: row.get(3)?,
         updated_at: row.get(4)?,
+    })
+}
+
+fn managed_resource_track_from_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<ManagedResourceTrackRow> {
+    Ok(ManagedResourceTrackRow {
+        resource_name: row.get(0)?,
+        track: row.get(1)?,
+        desired_state: row.get(2)?,
+        installed_version: row.get(3)?,
+        current_artifact_path: row.get(4)?,
+        usage_count: row.get(5)?,
+        updated_at: row.get(6)?,
     })
 }
 

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -286,6 +286,9 @@ impl Database {
         track: &str,
         desired_state: ManagedResourceDesiredState,
     ) -> Result<ManagedResourceTrackRecord, StateError> {
+        validate_managed_resource_identity("name", resource_name)?;
+        validate_managed_resource_identity("track", track)?;
+
         let updated_at = timestamp()?;
         self.connection.execute(
             "INSERT INTO managed_resource_tracks (resource_name, track, desired_state, updated_at)
@@ -306,6 +309,10 @@ impl Database {
         installed_version: &str,
         current_artifact_path: &Utf8Path,
     ) -> Result<ManagedResourceTrackRecord, StateError> {
+        validate_managed_resource_identity("name", resource_name)?;
+        validate_managed_resource_identity("track", track)?;
+        validate_managed_resource_identity("artifact version", installed_version)?;
+
         let updated_at = timestamp()?;
         self.connection.execute(
             "INSERT INTO managed_resource_tracks (
@@ -745,6 +752,12 @@ impl PortAssignmentRow {
 
 impl ManagedResourceTrackRow {
     fn into_record(self) -> Result<ManagedResourceTrackRecord, StateError> {
+        validate_managed_resource_identity("name", &self.resource_name)?;
+        validate_managed_resource_identity("track", &self.track)?;
+        if let Some(installed_version) = &self.installed_version {
+            validate_managed_resource_identity("artifact version", installed_version)?;
+        }
+
         Ok(ManagedResourceTrackRecord {
             resource_name: self.resource_name,
             track: self.track,
@@ -860,6 +873,24 @@ fn managed_resource_track_from_row(
         usage_count: row.get(5)?,
         updated_at: row.get(6)?,
     })
+}
+
+fn validate_managed_resource_identity(kind: &'static str, value: &str) -> Result<(), StateError> {
+    let is_valid = !value.is_empty()
+        && value != "."
+        && value != ".."
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'));
+
+    if is_valid {
+        Ok(())
+    } else {
+        Err(StateError::InvalidManagedResourceIdentity {
+            kind,
+            value: value.to_string(),
+        })
+    }
 }
 
 fn describe_port_identity(owner_kind: &str, owner_id: &str, owner_track: &str) -> String {

--- a/crates/state/src/error.rs
+++ b/crates/state/src/error.rs
@@ -51,6 +51,9 @@ pub enum StateError {
     #[error("unknown daemon job status `{status}`")]
     UnknownJobStatus { status: String },
 
+    #[error("unknown managed resource desired state `{desired_state}`")]
+    UnknownManagedResourceDesiredState { desired_state: String },
+
     #[error("daemon job `{id}` was not found")]
     JobNotFound { id: String },
 

--- a/crates/state/src/error.rs
+++ b/crates/state/src/error.rs
@@ -54,6 +54,9 @@ pub enum StateError {
     #[error("unknown managed resource desired state `{desired_state}`")]
     UnknownManagedResourceDesiredState { desired_state: String },
 
+    #[error("invalid managed resource {kind} `{value}`")]
+    InvalidManagedResourceIdentity { kind: &'static str, value: String },
+
     #[error("daemon job `{id}` was not found")]
     JobNotFound { id: String },
 

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -6,8 +6,8 @@ mod migrations;
 mod paths;
 
 pub use database::{
-    Database, DatabaseInspection, JobRecord, JobStatus, PortAssignment, PortOwner, PortRequest,
-    ProjectConfigWatch,
+    Database, DatabaseInspection, JobRecord, JobStatus, ManagedResourceDesiredState,
+    ManagedResourceTrackRecord, PortAssignment, PortOwner, PortRequest, ProjectConfigWatch,
 };
 pub use error::StateError;
 pub use paths::{PathSummaryEntry, PvPaths};

--- a/crates/state/tests/snapshots/state_foundation__managed_resource_tracks_record_desired_and_installed_state.snap
+++ b/crates/state/tests/snapshots/state_foundation__managed_resource_tracks_record_desired_and_installed_state.snap
@@ -1,0 +1,19 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: database.managed_resource_tracks()?
+---
+[
+    ManagedResourceTrackRecord {
+        resource_name: "redis",
+        track: "7.2",
+        desired_state: Installed,
+        installed_version: Some(
+            "7.2.5-pv1",
+        ),
+        current_artifact_path: Some(
+            "/Users/example/.pv/resources/redis/7.2/releases/7.2.5-pv1",
+        ),
+        usage_count: 0,
+        updated_at: "<timestamp>",
+    },
+]

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -386,6 +386,30 @@ fn managed_resource_tracks_record_desired_and_installed_state() -> Result<()> {
 }
 
 #[test]
+fn managed_resource_installed_update_preserves_removed_desired_state() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+
+    database.record_managed_resource_track_desired(
+        "redis",
+        "7.2",
+        ManagedResourceDesiredState::Removed,
+    )?;
+    let record = database.record_managed_resource_track_installed(
+        "redis",
+        "7.2",
+        "7.2.5-pv1",
+        Utf8Path::new("/Users/example/.pv/resources/redis/7.2/releases/7.2.5-pv1"),
+    )?;
+
+    assert_eq!(record.desired_state, ManagedResourceDesiredState::Removed);
+    assert_eq!(record.installed_version.as_deref(), Some("7.2.5-pv1"));
+
+    Ok(())
+}
+
+#[test]
 fn primary_project_hostname_rows_must_match_the_project() -> Result<()> {
     let tempdir = tempdir()?;
     let paths = PvPaths::for_home(tempdir.path().join("home"));

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -410,6 +410,103 @@ fn managed_resource_installed_update_preserves_removed_desired_state() -> Result
 }
 
 #[test]
+fn managed_resource_tracks_reject_unknown_desired_state_values() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+
+    state::testing::transaction(&mut database, |transaction| {
+        transaction.execute(
+            "INSERT INTO managed_resource_tracks (resource_name, track, desired_state, updated_at)
+            VALUES (?1, ?2, ?3, ?4)",
+            params!["redis", "7.2", "mystery", "2026-05-23T00:00:00Z"],
+        )?;
+
+        Ok(())
+    })?;
+    let result = database.managed_resource_tracks();
+
+    assert!(matches!(
+        result,
+        Err(StateError::UnknownManagedResourceDesiredState { desired_state })
+            if desired_state == "mystery"
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn managed_resource_track_writes_reject_invalid_identities() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+
+    let invalid_resource = database.record_managed_resource_track_desired(
+        ".",
+        "7.2",
+        ManagedResourceDesiredState::Installed,
+    );
+    assert!(matches!(
+        invalid_resource,
+        Err(StateError::InvalidManagedResourceIdentity { kind: "name", value })
+            if value == "."
+    ));
+
+    let invalid_track = database.record_managed_resource_track_desired(
+        "redis",
+        "..",
+        ManagedResourceDesiredState::Installed,
+    );
+    assert!(matches!(
+        invalid_track,
+        Err(StateError::InvalidManagedResourceIdentity { kind: "track", value })
+            if value == ".."
+    ));
+
+    let invalid_version = database.record_managed_resource_track_installed(
+        "redis",
+        "7.2",
+        "..",
+        Utf8Path::new("/Users/example/.pv/resources/redis/7.2/releases/7.2.5-pv1"),
+    );
+    assert!(matches!(
+        invalid_version,
+        Err(StateError::InvalidManagedResourceIdentity {
+            kind: "artifact version",
+            value
+        }) if value == ".."
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn managed_resource_tracks_reject_invalid_persisted_identities() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+
+    state::testing::transaction(&mut database, |transaction| {
+        transaction.execute(
+            "INSERT INTO managed_resource_tracks (resource_name, track, desired_state, installed_version, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![".", "7.2", "installed", "7.2.5-pv1", "2026-05-23T00:00:00Z"],
+        )?;
+
+        Ok(())
+    })?;
+    let result = database.managed_resource_tracks();
+
+    assert!(matches!(
+        result,
+        Err(StateError::InvalidManagedResourceIdentity { kind: "name", value })
+            if value == "."
+    ));
+
+    Ok(())
+}
+
+#[test]
 fn primary_project_hostname_rows_must_match_the_project() -> Result<()> {
     let tempdir = tempdir()?;
     let paths = PvPaths::for_home(tempdir.path().join("home"));

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -4,7 +4,9 @@ use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
 use rusqlite::{Connection, params};
 use state::testing::Migration;
-use state::{Database, JobStatus, PortOwner, PortRequest, PvPaths, StateError};
+use state::{
+    Database, JobStatus, ManagedResourceDesiredState, PortOwner, PortRequest, PvPaths, StateError,
+};
 
 #[test]
 fn paths_are_derived_from_an_injected_home() -> Result<()> {
@@ -353,6 +355,32 @@ fn resource_allocations_reject_duplicate_generated_names_per_resource_track() ->
         &database,
         "SELECT COUNT(*) FROM resource_allocations"
     )?);
+
+    Ok(())
+}
+
+#[test]
+fn managed_resource_tracks_record_desired_and_installed_state() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+
+    database.record_managed_resource_track_desired(
+        "redis",
+        "7.2",
+        ManagedResourceDesiredState::Installed,
+    )?;
+    database.record_managed_resource_track_installed(
+        "redis",
+        "7.2",
+        "7.2.5-pv1",
+        Utf8Path::new("/Users/example/.pv/resources/redis/7.2/releases/7.2.5-pv1"),
+    )?;
+
+    with_normalized_timestamps(|| {
+        assert_debug_snapshot!(database.managed_resource_tracks()?);
+        Ok::<(), anyhow::Error>(())
+    })?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add the resource adapter trait and artifact installer for single-root `.tar.gz` artifacts
- install artifacts under resource track releases, atomically update `current`, and retain current plus previous release
- expose managed-resource track state accessors for desired/installed state
- add fixture archive and state regression tests

Parallel downloads remain intentionally deferred from this PR.

## Test plan
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo nextest run --workspace --all-features --locked`
- `cargo insta test --check --test-runner nextest -p resources --unreferenced reject`
- `cargo insta test --check --test-runner nextest -p state --unreferenced reject`
- `cargo shear`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artifact installation pipeline with unpacking, validation hooks, atomic release switching, and release pruning.
  * Persistent managed-resource state with APIs to record desired state, installed details, and list tracks.
  * New public installer and adapter types exported for use.

* **Bug Fixes / Reliability**
  * Hardened archive/layout validation and improved filesystem/sync handling and error reporting.

* **Tests**
  * Expanded tests for installs, invalid/malicious archives, pruning and state persistence.

* **Behavioral Changes**
  * Identity validation now rejects "." and "..".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prvious/pv/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->