### PR TITLE
docs: clarify omitted resource version default

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -648,6 +648,8 @@ Install commands and Project config versions resolve to the latest artifact in t
 
 `latest` is accepted as a version alias that resolves to the manifest's default track for that Managed Resource. PV stores the resolved track, not `latest`, so existing Projects do not float when manifest defaults change later.
 
+If a Project config Managed Resource block omits `version`, PV treats it as the `latest` selector and resolves it to the manifest default concrete track before writing desired state. Existing Projects keep their internally stored concrete track when manifest defaults change later.
+
 PV does not rewrite Project config to replace `latest` with the resolved track. The resolved track is stored internally in `pv.db` and shown in status/list output.
 
 PV v1 supports track-based versions only. It does not support exact artifact pinning in Project config.

--- a/crates/daemon/tests/project_env_reconciliation.rs
+++ b/crates/daemon/tests/project_env_reconciliation.rs
@@ -750,6 +750,7 @@ async fn latest_resource_track_resolves_default_track_before_state_and_dotenv_wr
         "latest_resource_track_resolves_default_track_before_state_and_dotenv_writes",
         (
             lines,
+            read_project_config(&project)?,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
             database.resource_allocations(&project.id, "mysql")?,
@@ -785,6 +786,7 @@ async fn latest_resource_track_reuses_stored_track_when_manifest_default_changes
         (
             initial_lines,
             rerun_lines,
+            read_project_config(&project)?,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
             database.project_env_observed_state(&project.id)?,
@@ -815,6 +817,42 @@ async fn omitted_resource_track_resolves_manifest_default_track() -> Result<()> 
         "omitted_resource_track_resolves_manifest_default_track",
         (
             lines,
+            read_project_config(&project)?,
+            read_optional_dotenv(&project)?,
+            database.project_managed_resources(&project.id)?,
+            database.project_env_observed_state(&project.id)?,
+            latest_job(&database, &format!("project:{}", project.id))?,
+        ),
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn omitted_resource_track_reuses_stored_track_when_manifest_default_changes() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        "mysql:\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
+    )?;
+    seed_manifest(&paths, "8.0")?;
+    seed_mysql_resource_context(&paths)?;
+    let initial_lines = run_project_reconciliation(&paths, &project).await?;
+
+    seed_manifest(&paths, "8.4")?;
+    seed_mysql_resource_context_for_track(&paths, "8.4", "3406")?;
+    let rerun_lines = run_project_reconciliation(&paths, &project).await?;
+    let database = Database::open(&paths)?;
+
+    assert_with_normalized_timestamps(
+        "omitted_resource_track_reuses_stored_track_when_manifest_default_changes",
+        (
+            initial_lines,
+            rerun_lines,
+            read_project_config(&project)?,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
             database.project_env_observed_state(&project.id)?,
@@ -1039,6 +1077,10 @@ fn env_context(entries: &[(&str, &str)]) -> EnvContextValues {
         .iter()
         .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
         .collect::<BTreeMap<_, _>>()
+}
+
+fn read_project_config(project: &ProjectRecord) -> Result<String> {
+    state::fs::read_to_string(&project.config_path).map_err(Into::into)
 }
 
 fn read_dotenv(project: &ProjectRecord) -> Result<String> {

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__latest_resource_track_resolves_default_track_before_state_and_dotenv_writes.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__latest_resource_track_resolves_default_track_before_state_and_dotenv_writes.snap
@@ -33,6 +33,7 @@ expression: snapshot
             "type": String("job_completed"),
         },
     ],
+    "mysql:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n",
     Some(
         "# >>> PV MANAGED\nDB_HOST=127.0.0.1\n# <<< PV MANAGED\n",
     ),

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_resolves_manifest_default_track.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_resolves_manifest_default_track.snap
@@ -33,6 +33,7 @@ expression: snapshot
             "type": String("job_completed"),
         },
     ],
+    "mysql:\n  env:\n    DB_HOST: \"${host}\"\n",
     Some(
         "# >>> PV MANAGED\nDB_HOST=127.0.0.1\n# <<< PV MANAGED\n",
     ),

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_reuses_stored_track_when_manifest_default_changes.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_reuses_stored_track_when_manifest_default_changes.snap
@@ -63,7 +63,7 @@ expression: snapshot
             "type": String("job_completed"),
         },
     ],
-    "mysql:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
+    "mysql:\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
     Some(
         "# >>> PV MANAGED\nDB_HOST=127.0.0.1\nDB_PORT=3306\n# <<< PV MANAGED\n",
     ),


### PR DESCRIPTION
Summary
- add daemon integration coverage for omitted Project config Managed Resource version behavior
- prove omitted version keeps the stored concrete track when manifest defaults change
- document that omitted version uses the latest selector and resolves to the manifest default concrete track before state persistence

Verification
- cargo nextest run -p daemon --test project_env_reconciliation -E selector for omitted_resource_track_resolves_manifest_default_track, omitted_resource_track_reuses_stored_track_when_manifest_default_changes, latest_resource_track_resolves_default_track_before_state_and_dotenv_writes, latest_resource_track_reuses_stored_track_when_manifest_default_changes
- cargo fmt --all -- --check
- cargo clippy -p daemon --test project_env_reconciliation -- -D warnings
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation clarifying behavior when version fields are omitted in project configurations.

* **Tests**
  * Enhanced project environment reconciliation tests with expanded configuration snapshot coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->