### PR TITLE
docs: record omitted resource version verification

### DIFF
--- a/docs/adr/0013-omitted-resource-version-verification.md
+++ b/docs/adr/0013-omitted-resource-version-verification.md
@@ -1,0 +1,55 @@
+# ADR 0013: Omitted Resource Version Verification
+
+## Status
+
+Accepted
+
+## Context
+
+Project config Managed Resource blocks can omit `version`. PV needed focused
+verification that omitted versions use the same contract as explicit `latest`:
+they resolve to the artifact manifest default concrete track before desired
+state is written, and existing Projects keep their stored concrete track when a
+manifest default changes later.
+
+Related reviewed PRs:
+
+- Test/docs coverage: https://github.com/prvious/pv/pull/247
+- Repair coverage: https://github.com/prvious/pv/pull/248
+
+## Decision
+
+PV treats an omitted Project config Managed Resource `version` as the `latest`
+selector. `latest` resolves to the Managed Resource manifest `default_track`.
+Reconciliation persists only the resolved concrete track. Project config is not
+rewritten, and existing Project state does not float when manifest defaults
+change.
+
+The responsibility split remains:
+
+- `config` parses omitted resource versions as `ResourceConfig.track: None`.
+- `daemon` resolves omitted and explicit `latest` selectors before state writes.
+- `resources` owns manifest default-track selection.
+- `state` rejects reserved alias tracks such as `latest`.
+
+## Verification
+
+Final focused verification ran against the reviewed omitted-version coverage
+branch:
+
+```shell
+cargo nextest run -p daemon --test project_env_reconciliation -E 'test(omitted_resource_track_resolves_manifest_default_track) or test(omitted_resource_track_reuses_stored_track_when_manifest_default_changes) or test(latest_resource_track_resolves_default_track_before_state_and_dotenv_writes) or test(latest_resource_track_reuses_stored_track_when_manifest_default_changes)'
+cargo nextest run -p state -E 'test(resource_state_apis_reject_latest_tracks)'
+git diff --check
+cargo fmt --all -- --check
+```
+
+Results:
+
+- Daemon focused nextest: 4 run, 4 passed, 18 skipped.
+- State focused nextest: 1 run, 1 passed, 51 skipped.
+- `git diff --check`: exit 0.
+- `cargo fmt --all -- --check`: exit 0.
+
+Solo scoped TODOs for `feature-omitted-resource-version` were verified with
+owner and scope tags during the review handoff.


### PR DESCRIPTION
Summary
- add ADR 0013 recording the omitted Managed Resource version verification handoff
- link the reviewed test/docs and repair PRs
- capture the final focused verification commands and results

Verification
- cargo nextest run -p daemon --test project_env_reconciliation -E selector for omitted/default, omitted/non-floating, and explicit latest tests: 4 run, 4 passed
- cargo nextest run -p state -E test(resource_state_apis_reject_latest_tracks): 1 run, 1 passed
- git diff --check
- cargo fmt --all -- --check
- git diff --cached --check before commit

Notes
- This PR is docs-only and records the plan 13 verification handoff. The implementation payloads are in PR #247 and PR #248.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation explaining how omitted resource versions are handled in Project configuration. Omitted versions default to the latest selector, which resolves to the Managed Resource manifest's default track. The documentation clarifies that reconciliation preserves the resolved concrete track without modifying Project configuration or affecting existing state when manifest defaults change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->