### PR TITLE
fix(ci): authenticate artifact recipe GitHub downloads

### DIFF
--- a/.github/workflows/artifact-recipes.yml
+++ b/.github/workflows/artifact-recipes.yml
@@ -26,6 +26,9 @@ on:
           - darwin-arm64
           - darwin-amd64
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ inputs.platform == 'darwin-amd64' && 'macos-15-intel' || 'macos-14' }}
@@ -115,6 +118,7 @@ jobs:
           PV_ARTIFACT_RECORD_DIR: ${{ runner.temp }}/pv-records
           PV_COMMIT: ${{ github.sha }}
           PV_BUILD_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -eu
 


### PR DESCRIPTION
## Summary
- Pass the workflow token into the artifact recipe build step as `GITHUB_TOKEN`.
- Lets StaticPHP authenticate GitHub release API requests during PHP/FrankenPHP recipe builds.

## Test Plan
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/artifact-recipes.yml"); puts "yaml ok"'`
- `gh workflow run artifact-recipes.yml --ref fix/artifact-recipes-github-token -f resource=php -f track=8.4 -f platform=darwin-arm64`

Branch run `27113741441` got past the previous unauthenticated GitHub release API boundary, downloaded all 18 StaticPHP artifacts, built `php` and `frankenphp`, and passed PHP smoke tests. It still fails later on a separate FrankenPHP Mach-O rpath validation issue: `/usr/local/lib`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build artifact creation process with enhanced environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->