### PR TITLE
feat(release): add Redis artifact recipe

### DIFF
--- a/.github/workflows/artifact-recipes.yml
+++ b/.github/workflows/artifact-recipes.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       resource:
-        description: "Resource to build: all, php, composer"
+        description: "Resource to build: all, php, composer, redis"
         required: true
         default: "all"
         type: choice
@@ -12,6 +12,7 @@ on:
           - all
           - php
           - composer
+          - redis
       track:
         description: "Track to build: all, 8.2, 8.3, 8.4, 2"
         required: true
@@ -54,6 +55,7 @@ jobs:
             all:all | all:8.2 | all:8.3 | all:8.4) ;;
             php:all | php:8.2 | php:8.3 | php:8.4) ;;
             composer:all | composer:2) ;;
+            redis:all | redis:8.2) ;;
             *)
               printf '%s\n' "unsupported resource/track combination: $PV_RECIPE_RESOURCE/$PV_RECIPE_TRACK" >&2
               exit 1
@@ -95,6 +97,7 @@ jobs:
           cargo run -p pv-release -- generate-recipe-fixtures \
             --php release/artifacts/recipes/php/tracks.toml \
             --composer release/artifacts/recipes/composer/composer.toml \
+            --redis release/artifacts/recipes/redis/recipe.toml \
             --archives "$fixtures_dir/archives" \
             --records "$fixtures_dir/records" \
             --pv-commit "$(git rev-parse HEAD)" \
@@ -123,16 +126,21 @@ jobs:
 
           build_php_family=false
           build_composer=false
+          build_redis=false
           case "$PV_RECIPE_RESOURCE" in
             all)
               build_php_family=true
               build_composer=true
+              build_redis=true
               ;;
             php)
               build_php_family=true
               ;;
             composer)
               build_composer=true
+              ;;
+            redis)
+              build_redis=true
               ;;
           esac
 
@@ -162,6 +170,11 @@ jobs:
               PV_RECIPE_PLATFORM=any \
               PV_COMPOSER_SMOKE_PHP="$(command -v php)" \
               release/artifacts/recipes/composer/build.sh
+          fi
+
+          if [ "$build_redis" = true ]; then
+            PV_RECIPE_TRACK=8.2 \
+              release/artifacts/recipes/redis/build.sh
           fi
 
           rm -rf "$PV_ARTIFACT_OUT_DIR/sources" "$PV_ARTIFACT_OUT_DIR/work"
@@ -198,6 +211,7 @@ jobs:
               write_default_track php "$php_default_track"
               write_default_track frankenphp "$php_default_track"
               write_default_track composer 2
+              write_default_track redis 8.2
               ;;
             php)
               write_default_track php "$php_default_track"
@@ -205,6 +219,9 @@ jobs:
               ;;
             composer)
               write_default_track composer 2
+              ;;
+            redis)
+              write_default_track redis 8.2
               ;;
           esac
 

--- a/.github/workflows/artifact-recipes.yml
+++ b/.github/workflows/artifact-recipes.yml
@@ -62,7 +62,15 @@ jobs:
               ;;
           esac
 
-      - name: Install release tooling dependencies
+      - name: Install PHP runtime dependency
+        if: ${{ inputs.resource == 'all' || inputs.resource == 'php' || inputs.resource == 'composer' }}
+        run: |
+          set -eu
+          brew update
+          brew install php
+
+      - name: Install StaticPHP CLI
+        if: ${{ inputs.resource == 'all' || inputs.resource == 'php' }}
         run: |
           set -eu
           runner_architecture=$(uname -m)
@@ -75,8 +83,6 @@ jobs:
               ;;
           esac
 
-          brew update
-          brew install shellcheck php
           mkdir -p "${RUNNER_TEMP:?}/pv-tools"
           curl -L --fail --show-error --silent \
             --retry 3 --retry-delay 2 --retry-all-errors \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: cargo shear
 
       - name: Check artifact recipe scripts
-        run: shellcheck release/artifacts/recipes/common.sh release/artifacts/recipes/php/*.sh release/artifacts/recipes/composer/*.sh
+        run: shellcheck release/artifacts/recipes/common.sh release/artifacts/recipes/php/*.sh release/artifacts/recipes/composer/*.sh release/artifacts/recipes/redis/*.sh
 
       - name: Validate artifact recipe metadata and fixtures
         run: |
@@ -48,6 +48,7 @@ jobs:
           cargo run -p pv-release -- generate-recipe-fixtures \
             --php release/artifacts/recipes/php/tracks.toml \
             --composer release/artifacts/recipes/composer/composer.toml \
+            --redis release/artifacts/recipes/redis/recipe.toml \
             --archives /tmp/pv-recipe-fixtures/archives \
             --records /tmp/pv-recipe-fixtures/records \
             --pv-commit "$(git rev-parse HEAD)" \

--- a/crates/pv-release/src/cli.rs
+++ b/crates/pv-release/src/cli.rs
@@ -121,6 +121,8 @@ enum Command {
         #[arg(long)]
         composer: Option<Utf8PathBuf>,
         #[arg(long)]
+        redis: Option<Utf8PathBuf>,
+        #[arg(long)]
         resource: String,
         #[arg(long)]
         track: String,
@@ -243,6 +245,7 @@ pub fn run() -> anyhow::Result<()> {
         Command::PrintRecipeEnv {
             php,
             composer,
+            redis,
             resource,
             track,
             platform,
@@ -250,6 +253,7 @@ pub fn run() -> anyhow::Result<()> {
             let env = print_recipe_env(
                 php.as_deref(),
                 composer.as_deref(),
+                redis.as_deref(),
                 &resource,
                 &track,
                 &platform,
@@ -309,21 +313,33 @@ fn backing_recipe_paths(
 fn print_recipe_env(
     php: Option<&Utf8Path>,
     composer: Option<&Utf8Path>,
+    redis: Option<&Utf8Path>,
     resource: &str,
     track: &str,
     platform: &str,
 ) -> anyhow::Result<String> {
-    match (php, composer) {
-        (Some(php), None) => {
+    match (php, composer, redis) {
+        (Some(php), None, None) => {
             let context = format!("failed to print PHP recipe environment for `{php}`");
             crate::recipe::php_recipe_env(php, resource, track, platform).context(context)
         }
-        (None, Some(composer)) => {
+        (None, Some(composer), None) => {
             let context = format!("failed to print Composer recipe environment for `{composer}`");
             crate::recipe::composer_recipe_env(composer, resource, track, platform).context(context)
         }
-        (None, None) | (Some(_), Some(_)) => {
-            anyhow::bail!("print-recipe-env requires exactly one of --php or --composer")
+        (None, None, Some(redis)) => {
+            let context = format!("failed to print Redis recipe environment for `{redis}`");
+            crate::recipe::backing_recipe_env(
+                redis,
+                BackingRecipeKind::Redis,
+                resource,
+                track,
+                platform,
+            )
+            .context(context)
+        }
+        _ => {
+            anyhow::bail!("print-recipe-env requires exactly one of --php, --composer, or --redis")
         }
     }
 }
@@ -793,6 +809,7 @@ mod tests {
             Command::PrintRecipeEnv {
                 php,
                 composer,
+                redis,
                 resource,
                 track,
                 platform,
@@ -804,6 +821,7 @@ mod tests {
                         "release/artifacts/recipes/composer/composer.toml"
                     ))
                 );
+                assert_eq!(redis, None);
                 assert_eq!(resource, "composer");
                 assert_eq!(track, "2");
                 assert_eq!(platform, "any");
@@ -832,6 +850,7 @@ mod tests {
             Command::PrintRecipeEnv {
                 php,
                 composer,
+                redis,
                 resource,
                 track,
                 platform,
@@ -843,8 +862,50 @@ mod tests {
                     ))
                 );
                 assert_eq!(composer, None);
+                assert_eq!(redis, None);
                 assert_eq!(resource, "php");
                 assert_eq!(track, "8.4");
+                assert_eq!(platform, "darwin-arm64");
+                Ok(())
+            }
+            command => bail!("parsed unexpected command: {command:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_print_recipe_env_redis_arguments() -> anyhow::Result<()> {
+        let args = Args::try_parse_from([
+            "pv-release",
+            "print-recipe-env",
+            "--redis",
+            "release/artifacts/recipes/redis/recipe.toml",
+            "--resource",
+            "redis",
+            "--track",
+            "8.2",
+            "--platform",
+            "darwin-arm64",
+        ])?;
+
+        match args.command {
+            Command::PrintRecipeEnv {
+                php,
+                composer,
+                redis,
+                resource,
+                track,
+                platform,
+            } => {
+                assert_eq!(php, None);
+                assert_eq!(composer, None);
+                assert_eq!(
+                    redis,
+                    Some(Utf8PathBuf::from(
+                        "release/artifacts/recipes/redis/recipe.toml"
+                    ))
+                );
+                assert_eq!(resource, "redis");
+                assert_eq!(track, "8.2");
                 assert_eq!(platform, "darwin-arm64");
                 Ok(())
             }
@@ -856,13 +917,26 @@ mod tests {
     fn print_recipe_env_rejects_missing_or_multiple_metadata_paths() {
         let php = Utf8Path::new("release/artifacts/recipes/php/tracks.toml");
         let composer = Utf8Path::new("release/artifacts/recipes/composer/composer.toml");
+        let redis = Utf8Path::new("release/artifacts/recipes/redis/recipe.toml");
 
         assert!(
-            print_recipe_env(None, None, "php", "8.4", "darwin-arm64").is_err(),
+            print_recipe_env(None, None, None, "php", "8.4", "darwin-arm64").is_err(),
             "missing metadata path must be rejected"
         );
         assert!(
-            print_recipe_env(Some(php), Some(composer), "php", "8.4", "darwin-arm64").is_err(),
+            print_recipe_env(
+                Some(php),
+                Some(composer),
+                None,
+                "php",
+                "8.4",
+                "darwin-arm64"
+            )
+            .is_err(),
+            "multiple metadata paths must be rejected"
+        );
+        assert!(
+            print_recipe_env(Some(php), None, Some(redis), "redis", "8.2", "darwin-arm64").is_err(),
             "multiple metadata paths must be rejected"
         );
     }

--- a/crates/pv-release/src/cli.rs
+++ b/crates/pv-release/src/cli.rs
@@ -16,6 +16,10 @@ struct Args {
 }
 
 #[derive(Debug, Subcommand)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "pv-release parses CLI subcommands once at process startup"
+)]
 enum Command {
     GenerateManifest {
         #[arg(long)]
@@ -112,6 +116,10 @@ enum Command {
         minimum_pv_version: String,
         #[arg(long)]
         published_at: String,
+        #[arg(long = "license-file")]
+        license_files: Vec<String>,
+        #[arg(long = "notice-file")]
+        notice_files: Vec<String>,
         #[arg(long = "source-input", num_args = 3, value_names = ["NAME", "URL", "SHA256"])]
         source_inputs: Vec<String>,
     },
@@ -218,10 +226,14 @@ pub fn run() -> anyhow::Result<()> {
             build_run_id,
             minimum_pv_version,
             published_at,
+            license_files,
+            notice_files,
             source_inputs,
         } => {
             let context = format!("failed to write release record `{record}`");
             let source_inputs = parse_source_inputs(&source_inputs)?;
+            let license_files = default_legal_files(license_files, "LICENSE");
+            let notice_files = default_legal_files(notice_files, "NOTICE");
             crate::record_writer::write_release_record(&WriteReleaseRecordRequest {
                 record,
                 archive,
@@ -238,6 +250,8 @@ pub fn run() -> anyhow::Result<()> {
                 build_run_id,
                 minimum_pv_version,
                 published_at,
+                license_files,
+                notice_files,
                 source_inputs,
             })
             .context(context)
@@ -282,6 +296,14 @@ fn parse_source_inputs(values: &[String]) -> anyhow::Result<Vec<SourceInputReque
     }
 
     Ok(source_inputs)
+}
+
+fn default_legal_files(values: Vec<String>, default: &str) -> Vec<String> {
+    if values.is_empty() {
+        vec![default.to_string()]
+    } else {
+        values
+    }
 }
 
 fn backing_recipe_paths(
@@ -720,6 +742,12 @@ mod tests {
             "0.1.0",
             "--published-at",
             "2026-06-08T12:00:00Z",
+            "--license-file",
+            "LICENSE",
+            "--notice-file",
+            "NOTICE",
+            "--notice-file",
+            "THIRD-PARTY-NOTICES",
             "--source-input",
             "frankenphp",
             "https://github.com/php/frankenphp/archive/refs/tags/v1.12.3.tar.gz",
@@ -747,6 +775,8 @@ mod tests {
                 build_run_id,
                 minimum_pv_version,
                 published_at,
+                license_files,
+                notice_files,
                 source_inputs,
             } => {
                 assert_eq!(record, Utf8PathBuf::from("record.json"));
@@ -773,6 +803,8 @@ mod tests {
                 assert_eq!(build_run_id, "local-test");
                 assert_eq!(minimum_pv_version, "0.1.0");
                 assert_eq!(published_at, "2026-06-08T12:00:00Z");
+                assert_eq!(license_files, vec!["LICENSE"]);
+                assert_eq!(notice_files, vec!["NOTICE", "THIRD-PARTY-NOTICES"]);
                 assert_eq!(
                     source_inputs,
                     vec![

--- a/crates/pv-release/src/recipe.rs
+++ b/crates/pv-release/src/recipe.rs
@@ -173,6 +173,12 @@ struct RawRecipeHeader {
     notice_files: Vec<String>,
 }
 
+#[derive(Clone, Copy)]
+enum LegalFilePolicy {
+    ExactStandard,
+    StandardPlusAdditional,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawPhpSettings {
@@ -309,7 +315,8 @@ impl BackingRecipe {
         kind: BackingRecipeKind,
         raw: RawBackingRecipe,
     ) -> crate::Result<Self> {
-        let header = RecipeHeader::from_raw(path, raw.recipe)?;
+        let header =
+            RecipeHeader::from_raw(path, raw.recipe, LegalFilePolicy::StandardPlusAdditional)?;
         let resource = ResourceName::new(kind.resource_name())
             .map_err(|error| invalid_identity(path, "resource", error))?;
         validate_exact_resources(
@@ -458,7 +465,7 @@ impl PhpRecipe {
     }
 
     fn from_raw(path: &Utf8Path, raw: RawPhpRecipe) -> crate::Result<Self> {
-        let header = RecipeHeader::from_raw(path, raw.recipe)?;
+        let header = RecipeHeader::from_raw(path, raw.recipe, LegalFilePolicy::ExactStandard)?;
         validate_exact_resources(
             path,
             "PHP recipe",
@@ -492,7 +499,11 @@ impl PhpRecipe {
 }
 
 impl RecipeHeader {
-    fn from_raw(path: &Utf8Path, raw: RawRecipeHeader) -> crate::Result<Self> {
+    fn from_raw(
+        path: &Utf8Path,
+        raw: RawRecipeHeader,
+        legal_file_policy: LegalFilePolicy,
+    ) -> crate::Result<Self> {
         let resources = parse_resource_list(path, raw.resources)?;
         let default_track = TrackName::new(raw.default_track)
             .map_err(|error| invalid_identity(path, "default_track", error))?;
@@ -503,8 +514,16 @@ impl RecipeHeader {
             require_non_empty(path, "pv_build_revision", &raw.pv_build_revision)?.to_string();
         validate_relative_file_list(path, "license_files", &raw.license_files)?;
         validate_relative_file_list(path, "notice_files", &raw.notice_files)?;
-        validate_exact_file_list(path, "license_files", &raw.license_files, &["LICENSE"])?;
-        validate_exact_file_list(path, "notice_files", &raw.notice_files, &["NOTICE"])?;
+        match legal_file_policy {
+            LegalFilePolicy::ExactStandard => {
+                validate_exact_file_list(path, "license_files", &raw.license_files, &["LICENSE"])?;
+                validate_exact_file_list(path, "notice_files", &raw.notice_files, &["NOTICE"])?;
+            }
+            LegalFilePolicy::StandardPlusAdditional => {
+                validate_required_file(path, "license_files", &raw.license_files, "LICENSE")?;
+                validate_required_file(path, "notice_files", &raw.notice_files, "NOTICE")?;
+            }
+        }
 
         Ok(Self {
             resources,
@@ -633,7 +652,7 @@ impl ComposerRecipe {
     }
 
     fn from_raw(path: &Utf8Path, raw: RawComposerRecipe) -> crate::Result<Self> {
-        let header = RecipeHeader::from_raw(path, raw.recipe)?;
+        let header = RecipeHeader::from_raw(path, raw.recipe, LegalFilePolicy::ExactStandard)?;
         validate_exact_resources(path, "Composer recipe", &header.resources, &["composer"])?;
         validate_exact_platforms(path, "Composer recipe", &header.platforms, &["any"])?;
 
@@ -1404,6 +1423,19 @@ fn validate_exact_file_list(
                 .join(", ")
         ),
     ))
+}
+
+fn validate_required_file(
+    path: &Utf8Path,
+    field: &str,
+    values: &[String],
+    required: &str,
+) -> crate::Result<()> {
+    if values.iter().any(|value| value == required) {
+        return Ok(());
+    }
+
+    Err(invalid(path, format!("{field} must include `{required}`")))
 }
 
 fn relative_path_is_valid(value: &str) -> bool {

--- a/crates/pv-release/src/recipe.rs
+++ b/crates/pv-release/src/recipe.rs
@@ -727,6 +727,53 @@ pub fn composer_recipe_env(
     )
 }
 
+pub fn backing_recipe_env(
+    backing: &Utf8Path,
+    kind: BackingRecipeKind,
+    resource: &str,
+    track: &str,
+    platform: &str,
+) -> crate::Result<String> {
+    let recipe = BackingRecipe::load(backing, kind)?;
+    validate_backing_recipe_resource(&recipe, resource)?;
+    let track = validate_backing_recipe_track(&recipe, track)?;
+    let platform = validate_backing_recipe_platform(&recipe, platform)?;
+
+    let upstream_version = track.upstream_version();
+    let pv_build_revision = recipe.pv_build_revision();
+    let artifact_version = format!("{upstream_version}-{pv_build_revision}");
+    let source_url = track.source_url();
+    let source_sha256 = track.source_sha256().as_str();
+    let minimum_pv_version = recipe.minimum_pv_version().as_str();
+
+    shell_assignments(
+        recipe.path(),
+        &[
+            ("PV_RESOURCE", "resource", recipe.resource().as_str()),
+            ("PV_TRACK", "track", track.name().as_str()),
+            ("PV_PLATFORM", "platform", platform.as_str()),
+            ("PV_UPSTREAM_VERSION", "upstream_version", upstream_version),
+            (
+                "PV_ARTIFACT_VERSION",
+                "artifact_version",
+                artifact_version.as_str(),
+            ),
+            ("PV_SOURCE_URL", "source_url", source_url),
+            ("PV_SOURCE_SHA256", "source_sha256", source_sha256),
+            (
+                "PV_MINIMUM_PV_VERSION",
+                "minimum_pv_version",
+                minimum_pv_version,
+            ),
+            (
+                "PV_PV_BUILD_REVISION",
+                "pv_build_revision",
+                pv_build_revision,
+            ),
+        ],
+    )
+}
+
 pub fn php_recipe_env(
     php: &Utf8Path,
     resource: &str,
@@ -934,18 +981,93 @@ fn validate_composer_recipe_request(
     track: &str,
     platform: &str,
 ) -> crate::Result<()> {
-    validate_request_value(recipe.path(), "resource", resource, "composer")?;
-    validate_request_value(recipe.path(), "track", track, recipe.track().as_str())?;
     validate_request_value(
         recipe.path(),
+        "Composer recipe",
+        "resource",
+        resource,
+        "composer",
+    )?;
+    validate_request_value(
+        recipe.path(),
+        "Composer recipe",
+        "track",
+        track,
+        recipe.track().as_str(),
+    )?;
+    validate_request_value(
+        recipe.path(),
+        "Composer recipe",
         "platform",
         platform,
         recipe.platform().as_str(),
     )
 }
 
+fn validate_backing_recipe_resource(recipe: &BackingRecipe, resource: &str) -> crate::Result<()> {
+    validate_request_value(
+        recipe.path(),
+        recipe.kind().recipe_kind(),
+        "resource",
+        resource,
+        recipe.resource().as_str(),
+    )
+}
+
+fn validate_backing_recipe_track<'a>(
+    recipe: &'a BackingRecipe,
+    track: &str,
+) -> crate::Result<&'a BackingTrack> {
+    recipe
+        .tracks()
+        .iter()
+        .find(|candidate| candidate.name().as_str() == track)
+        .ok_or_else(|| {
+            let expected = recipe
+                .tracks()
+                .iter()
+                .map(|track| track.name().as_str())
+                .collect::<BTreeSet<_>>();
+            invalid(
+                recipe.path(),
+                format!(
+                    "{} track must be one of {}, got `{track}`",
+                    recipe.kind().recipe_kind(),
+                    format_expected_values(&expected)
+                ),
+            )
+        })
+}
+
+fn validate_backing_recipe_platform(
+    recipe: &BackingRecipe,
+    platform: &str,
+) -> crate::Result<ArtifactPlatform> {
+    recipe
+        .platforms()
+        .iter()
+        .copied()
+        .find(|candidate| candidate.as_str() == platform)
+        .ok_or_else(|| {
+            let expected = recipe
+                .platforms()
+                .iter()
+                .map(|platform| platform.as_str())
+                .collect::<BTreeSet<_>>();
+            invalid(
+                recipe.path(),
+                format!(
+                    "{} platform must be one of {}, got `{platform}`",
+                    recipe.kind().recipe_kind(),
+                    format_expected_values(&expected)
+                ),
+            )
+        })
+}
+
 fn validate_request_value(
     path: &Utf8Path,
+    recipe_kind: &str,
     field: &str,
     actual: &str,
     expected: &str,
@@ -955,7 +1077,7 @@ fn validate_request_value(
     } else {
         Err(invalid(
             path,
-            format!("Composer recipe {field} must be `{expected}`, got `{actual}`"),
+            format!("{recipe_kind} {field} must be `{expected}`, got `{actual}`"),
         ))
     }
 }

--- a/crates/pv-release/src/record_writer.rs
+++ b/crates/pv-release/src/record_writer.rs
@@ -21,6 +21,8 @@ pub struct WriteReleaseRecordRequest {
     pub build_run_id: String,
     pub minimum_pv_version: String,
     pub published_at: String,
+    pub license_files: Vec<String>,
+    pub notice_files: Vec<String>,
     pub source_inputs: Vec<SourceInputRequest>,
 }
 
@@ -44,8 +46,8 @@ struct ReleaseRecordJson<'a> {
     size: u64,
     published_at: &'a str,
     minimum_pv_version: &'a str,
-    license_files: [&'static str; 1],
-    notice_files: [&'static str; 1],
+    license_files: &'a [String],
+    notice_files: &'a [String],
     provenance: ProvenanceJson<'a>,
 }
 
@@ -90,8 +92,8 @@ pub fn write_release_record(request: &WriteReleaseRecordRequest) -> crate::Resul
         size,
         published_at: &request.published_at,
         minimum_pv_version: &request.minimum_pv_version,
-        license_files: ["LICENSE"],
-        notice_files: ["NOTICE"],
+        license_files: &request.license_files,
+        notice_files: &request.notice_files,
         provenance: ProvenanceJson {
             source_url: &request.source_url,
             source_sha256: &request.source_sha256,

--- a/crates/pv-release/tests/recipe_fixtures.rs
+++ b/crates/pv-release/tests/recipe_fixtures.rs
@@ -6,7 +6,7 @@ use insta::{assert_debug_snapshot, assert_snapshot};
 use pv_release::archive::validate_archive;
 use pv_release::fixture::generate_recipe_fixtures_with_backing;
 use pv_release::manifest::generate_manifest_file_with_defaults;
-use pv_release::recipe::BackingRecipeKind;
+use pv_release::recipe::{BackingRecipe, BackingRecipeKind};
 use pv_release::record::{ReleaseRecord, load_release_records};
 use resources::ArtifactManifest;
 use tar::Archive;
@@ -43,12 +43,19 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest() -> Result
     let manifest = tempdir.path().join("manifest.json");
     let php = workspace_root.join("release/artifacts/recipes/php/tracks.toml");
     let composer = workspace_root.join("release/artifacts/recipes/composer/composer.toml");
+    let redis = workspace_root.join("release/artifacts/recipes/redis/recipe.toml");
     let defaults = workspace_root.join("release/artifacts/default-tracks.toml");
 
     create_dir_all(&revocations)?;
-    pv_release::fixture::generate_recipe_fixtures(
+    let redis_recipe = BackingRecipe::load(&redis, BackingRecipeKind::Redis)?;
+    let Some(redis_track) = redis_recipe.tracks().first() else {
+        bail!("committed Redis recipe should define a track");
+    };
+    let redis_upstream_version = redis_track.upstream_version().to_string();
+    generate_recipe_fixtures_with_backing(
         &php,
         &composer,
+        &[(BackingRecipeKind::Redis, redis.clone())],
         &archives,
         &records,
         "0123456789abcdef0123456789abcdef01234567",
@@ -101,6 +108,18 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest() -> Result
             ArchiveRoot::new("php", "8.3", "darwin-arm64", "php-8.3.31-pv1-darwin-arm64"),
             ArchiveRoot::new("php", "8.4", "darwin-amd64", "php-8.4.20-pv1-darwin-amd64"),
             ArchiveRoot::new("php", "8.4", "darwin-arm64", "php-8.4.20-pv1-darwin-arm64"),
+            ArchiveRoot::new(
+                "redis",
+                "8.2",
+                "darwin-amd64",
+                &format!("redis-{redis_upstream_version}-pv1-darwin-amd64"),
+            ),
+            ArchiveRoot::new(
+                "redis",
+                "8.2",
+                "darwin-arm64",
+                &format!("redis-{redis_upstream_version}-pv1-darwin-arm64"),
+            ),
         ],
     );
     generate_manifest_file_with_defaults(

--- a/crates/pv-release/tests/recipe_metadata.rs
+++ b/crates/pv-release/tests/recipe_metadata.rs
@@ -58,6 +58,24 @@ fn backing_recipe_metadata_parses_common_shape() -> Result<()> {
 }
 
 #[test]
+fn backing_recipe_metadata_accepts_additional_legal_files() -> Result<()> {
+    let redis_with_third_party_notices = VALID_REDIS_TOML.replace(
+        "notice_files = [\"NOTICE\"]",
+        "notice_files = [\"NOTICE\", \"THIRD-PARTY-NOTICES\"]",
+    );
+
+    let recipe = BackingRecipe::from_toml(
+        Utf8Path::new("redis/recipe.toml"),
+        BackingRecipeKind::Redis,
+        &redis_with_third_party_notices,
+    )?;
+
+    assert_eq!(recipe.license_files(), ["LICENSE"]);
+    assert_eq!(recipe.notice_files(), ["NOTICE", "THIRD-PARTY-NOTICES"]);
+    Ok(())
+}
+
+#[test]
 fn committed_recipe_metadata_parses() -> Result<()> {
     let workspace_root = Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let php = PhpRecipe::load(&workspace_root.join("release/artifacts/recipes/php/tracks.toml"))?;

--- a/crates/pv-release/tests/recipe_metadata.rs
+++ b/crates/pv-release/tests/recipe_metadata.rs
@@ -5,8 +5,8 @@ use insta::{assert_debug_snapshot, assert_snapshot};
 use pv_release::ReleaseError;
 use pv_release::defaults::ManifestDefaults;
 use pv_release::recipe::{
-    BackingRecipe, BackingRecipeKind, ComposerRecipe, PhpRecipe, composer_recipe_env,
-    php_recipe_env,
+    BackingRecipe, BackingRecipeKind, ComposerRecipe, PhpRecipe, backing_recipe_env,
+    composer_recipe_env, php_recipe_env,
 };
 use resources::ResourceName;
 
@@ -64,6 +64,10 @@ fn committed_recipe_metadata_parses() -> Result<()> {
     let composer = ComposerRecipe::load(
         &workspace_root.join("release/artifacts/recipes/composer/composer.toml"),
     )?;
+    let redis = BackingRecipe::load(
+        &workspace_root.join("release/artifacts/recipes/redis/recipe.toml"),
+        BackingRecipeKind::Redis,
+    )?;
     let defaults =
         ManifestDefaults::load(&workspace_root.join("release/artifacts/default-tracks.toml"))?;
 
@@ -71,9 +75,13 @@ fn committed_recipe_metadata_parses() -> Result<()> {
     assert_eq!(php.tracks().len(), 3);
     assert_eq!(composer.track().as_str(), "2");
     assert_eq!(composer.platform().as_str(), "any");
+    assert_eq!(redis.default_track().as_str(), "8.2");
+    assert_eq!(redis.tracks().len(), 1);
+    assert_eq!(redis.payload_paths(), ["bin/redis-server", "bin/redis-cli"]);
     assert_default_track(&defaults, "php", "8.4")?;
     assert_default_track(&defaults, "frankenphp", "8.4")?;
     assert_default_track(&defaults, "composer", "2")?;
+    assert_default_track(&defaults, "redis", "8.2")?;
 
     Ok(())
 }
@@ -321,6 +329,24 @@ fn print_recipe_env_frankenphp() -> Result<()> {
             "PV_PHP_SOURCE_SHA256='a2def5d534d57c6a0236f2265de7537608af871900a4f7955eff463e9e38247d'",
         ]
     );
+    assert_snapshot!(env);
+    Ok(())
+}
+
+#[test]
+fn print_recipe_env_redis() -> Result<()> {
+    let tempdir = tempdir()?;
+    let redis = tempdir.path().join("recipe.toml");
+    write_file(&redis, VALID_REDIS_TOML)?;
+
+    let env = backing_recipe_env(
+        &redis,
+        BackingRecipeKind::Redis,
+        "redis",
+        "8.2",
+        "darwin-arm64",
+    )?;
+
     assert_snapshot!(env);
     Ok(())
 }

--- a/crates/pv-release/tests/record_writer.rs
+++ b/crates/pv-release/tests/record_writer.rs
@@ -37,6 +37,8 @@ fn release_record_writer_serializes_metadata_and_source_inputs() -> Result<()> {
         build_run_id: "run\"with\\escaping".to_string(),
         minimum_pv_version: "0.1.0".to_string(),
         published_at: "2026-06-08T12:00:00Z".to_string(),
+        license_files: vec!["LICENSE".to_string()],
+        notice_files: vec!["NOTICE".to_string()],
         source_inputs: vec![SourceInputRequest {
             name: "composer".to_string(),
             source_url:
@@ -53,6 +55,47 @@ fn release_record_writer_serializes_metadata_and_source_inputs() -> Result<()> {
     assert_eq!(parsed.provenance().build_run_id(), "run\"with\\escaping");
     assert_eq!(parsed.provenance().source_inputs().len(), 1);
     assert_snapshot!(json);
+    Ok(())
+}
+
+#[test]
+fn release_record_writer_serializes_custom_legal_files() -> Result<()> {
+    let tempdir = tempdir()?;
+    let archive = tempdir.path().join("redis-8.2.7-pv1-darwin-arm64.tar.gz");
+    let record = tempdir
+        .path()
+        .join("records/redis/8.2/8.2.7-pv1/darwin-arm64/redis-8.2.7-pv1-darwin-arm64.json");
+    write_file(&archive, b"artifact bytes")?;
+
+    write_release_record(&WriteReleaseRecordRequest {
+        record: record.clone(),
+        archive,
+        resource: "redis".to_string(),
+        track: "8.2".to_string(),
+        upstream_version: "8.2.7".to_string(),
+        pv_build_revision: "pv1".to_string(),
+        platform: "darwin-arm64".to_string(),
+        object_key:
+            "resources/redis/8.2/8.2.7-pv1/darwin-arm64/redis-8.2.7-pv1-darwin-arm64.tar.gz"
+                .to_string(),
+        source_url: "https://download.redis.io/releases/redis-8.2.7.tar.gz".to_string(),
+        source_sha256: "afaae66030c193b06720a714ba7a558136b82689027536e0e24f53908c18cbe9"
+            .to_string(),
+        recipe: "release/artifacts/recipes/redis/build.sh".to_string(),
+        pv_commit: "0123456789abcdef0123456789abcdef01234567".to_string(),
+        build_run_id: "local-test".to_string(),
+        minimum_pv_version: "0.1.0".to_string(),
+        published_at: "2026-06-08T12:00:00Z".to_string(),
+        license_files: vec!["LICENSE".to_string()],
+        notice_files: vec!["NOTICE".to_string(), "THIRD-PARTY-NOTICES".to_string()],
+        source_inputs: Vec::new(),
+    })?;
+
+    let json = read_to_string(&record)?;
+    let parsed = ReleaseRecord::from_json(&record, &json)?;
+
+    assert_eq!(parsed.license_files(), ["LICENSE"]);
+    assert_eq!(parsed.notice_files(), ["NOTICE", "THIRD-PARTY-NOTICES"]);
     Ok(())
 }
 

--- a/crates/pv-release/tests/smoke.rs
+++ b/crates/pv-release/tests/smoke.rs
@@ -385,6 +385,179 @@ fn composer_build_smoke_uses_platform_suffixed_archive_name() -> Result<()> {
 }
 
 #[test]
+fn redis_build_recipe_signs_binaries_and_requires_third_party_notices() -> Result<()> {
+    let run = run_redis_build_recipe_smoke(default_redis_build_recipe_options())?;
+
+    assert!(
+        run.output.status.success(),
+        "Redis build recipe failed: {}",
+        command_output_debug(&run.output)
+    );
+    assert!(
+        run.archive_exists,
+        "Redis archive was not written: {}",
+        command_output_debug(&run.output)
+    );
+    assert!(run.record_json.is_some(), "Redis record was not written");
+    assert_eq!(
+        run.validate_log,
+        "archive=redis-8.2.7-pv1-darwin-arm64.tar.gz record=redis-8.2.7-pv1-darwin-arm64.json smoke=smoke.sh\n"
+    );
+    assert_eq!(
+        run.codesign_log,
+        format!(
+            "argv=[--force][--sign][-][{}/work/redis-8.2.7-pv1-darwin-arm64/redis-8.2.7-pv1-darwin-arm64/bin/redis-server]\n\
+argv=[--verify][{}/work/redis-8.2.7-pv1-darwin-arm64/redis-8.2.7-pv1-darwin-arm64/bin/redis-server]\n\
+argv=[--force][--sign][-][{}/work/redis-8.2.7-pv1-darwin-arm64/redis-8.2.7-pv1-darwin-arm64/bin/redis-cli]\n\
+argv=[--verify][{}/work/redis-8.2.7-pv1-darwin-arm64/redis-8.2.7-pv1-darwin-arm64/bin/redis-cli]\n",
+            run.out_dir, run.out_dir, run.out_dir, run.out_dir
+        )
+    );
+
+    assert!(
+        run.archive_entries
+            .contains(&"redis-8.2.7-pv1-darwin-arm64/THIRD-PARTY-NOTICES".to_string()),
+        "Redis archive should contain third-party legal notices: {:?}",
+        run.archive_entries
+    );
+
+    let record_json = run
+        .record_json
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("Redis build recipe did not write a record"))?;
+    let record: Value = serde_json::from_str(record_json)?;
+    assert_eq!(record["license_files"], serde_json::json!(["LICENSE"]));
+    assert_eq!(
+        record["notice_files"],
+        serde_json::json!(["NOTICE", "THIRD-PARTY-NOTICES"])
+    );
+
+    Ok(())
+}
+
+#[test]
+fn redis_build_recipe_does_not_publish_outputs_before_archive_validation() -> Result<()> {
+    let run = run_redis_build_recipe_smoke(RedisBuildRecipeOptions {
+        validate_archive_failure: true,
+    })?;
+
+    assert!(
+        !run.output.status.success(),
+        "Redis build recipe unexpectedly succeeded: {}",
+        command_output_debug(&run.output)
+    );
+    assert!(
+        run.record_json.is_none(),
+        "Redis record should not be written before archive validation succeeds"
+    );
+    assert!(
+        !run.archive_exists,
+        "Redis archive should not be written before archive validation succeeds"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.output.stdout),
+        "",
+        "archive path should not be printed before validation succeeds"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn redis_smoke_prints_server_log_on_startup_failure() -> Result<()> {
+    let tempdir = tempdir()?;
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+    let command_bin = tempdir.path().join("commands");
+
+    create_dir_all(&artifact_bin)?;
+    create_dir_all(&command_bin)?;
+    write_executable(
+        &artifact_bin.join("redis-server"),
+        r#"#!/bin/sh
+set -eu
+printf '%s\n' 'redis startup exploded' >&2
+exit 71
+"#,
+    )?;
+    write_executable(
+        &artifact_bin.join("redis-cli"),
+        r#"#!/bin/sh
+set -eu
+exit 72
+"#,
+    )?;
+    write_executable(&command_bin.join("sleep"), "#!/bin/sh\nexit 0\n")?;
+
+    let output = StdCommand::new(redis_smoke_hook())
+        .arg(&artifact_root)
+        .env(
+            "PATH",
+            format!("{command_bin}:/usr/bin:/bin:/usr/sbin:/sbin"),
+        )
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "Redis smoke should fail: {}",
+        command_output_debug(&output)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("redis startup exploded"),
+        "Redis smoke should print redis-server output on failure: {stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn redis_smoke_kills_server_when_shutdown_fails() -> Result<()> {
+    let tempdir = tempdir()?;
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+    let command_bin = tempdir.path().join("commands");
+
+    create_dir_all(&artifact_bin)?;
+    create_dir_all(&command_bin)?;
+    write_executable(
+        &artifact_bin.join("redis-server"),
+        r#"#!/bin/sh
+set -eu
+exec /bin/sleep 5
+"#,
+    )?;
+    write_executable(
+        &artifact_bin.join("redis-cli"),
+        r#"#!/bin/sh
+set -eu
+exit 72
+"#,
+    )?;
+    write_executable(&command_bin.join("sleep"), "#!/bin/sh\nexit 0\n")?;
+    let started = Instant::now();
+    let output = StdCommand::new(redis_smoke_hook())
+        .arg(&artifact_root)
+        .env(
+            "PATH",
+            format!("{command_bin}:/usr/bin:/bin:/usr/sbin:/sbin"),
+        )
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "Redis smoke should fail when redis-cli never returns PONG: {}",
+        command_output_debug(&output)
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(4),
+        "Redis smoke should kill the server instead of waiting for it to exit"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn php_build_smoke_rejects_unexpected_macho_architecture() -> Result<()> {
     let run = run_php_build_recipe_smoke_with_options(BuildRecipeOptions {
         lipo_archs: "x86_64",
@@ -602,6 +775,16 @@ struct ComposerBuildRecipeRun {
     legacy_archive_exists: bool,
 }
 
+struct RedisBuildRecipeRun {
+    out_dir: String,
+    output: Output,
+    record_json: Option<String>,
+    validate_log: String,
+    codesign_log: String,
+    archive_entries: Vec<String>,
+    archive_exists: bool,
+}
+
 struct BuildRecipeOptions<'a> {
     lipo_archs: &'a str,
     macho_minos: &'a str,
@@ -610,6 +793,10 @@ struct BuildRecipeOptions<'a> {
     frankenphp_macho_libraries: &'a str,
     frankenphp_macho_rpaths: &'a str,
     validate_archive_failure_resource: &'a str,
+}
+
+struct RedisBuildRecipeOptions {
+    validate_archive_failure: bool,
 }
 
 fn php_smoke_hook() -> camino::Utf8PathBuf {
@@ -621,8 +808,98 @@ fn composer_smoke_hook() -> camino::Utf8PathBuf {
         .join("../../release/artifacts/recipes/composer/smoke.sh")
 }
 
+fn redis_smoke_hook() -> camino::Utf8PathBuf {
+    Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../release/artifacts/recipes/redis/smoke.sh")
+}
+
 fn run_php_build_recipe_smoke() -> Result<BuildRecipeRun> {
     run_php_build_recipe_smoke_with_options(default_build_recipe_options())
+}
+
+fn default_redis_build_recipe_options() -> RedisBuildRecipeOptions {
+    RedisBuildRecipeOptions {
+        validate_archive_failure: false,
+    }
+}
+
+fn run_redis_build_recipe_smoke(options: RedisBuildRecipeOptions) -> Result<RedisBuildRecipeRun> {
+    let tempdir = tempdir()?;
+    let fake_bin = tempdir.path().join("bin");
+    let out_dir = tempdir.path().join("out");
+    let record_dir = tempdir.path().join("records");
+    let source_archive = tempdir.path().join("redis-source.tar.gz");
+    let curl_log = tempdir.path().join("curl.log");
+    let validate_log = tempdir.path().join("validate.log");
+    let codesign_log = tempdir.path().join("codesign.log");
+
+    create_dir_all(&fake_bin)?;
+    write_redis_source_archive(&source_archive)?;
+    write_fake_redis_cargo(&fake_bin.join("cargo"))?;
+    write_fake_curl(&fake_bin.join("curl"))?;
+    write_fake_lipo(&fake_bin.join("lipo"))?;
+    write_fake_otool(&fake_bin.join("otool"))?;
+    write_fake_make(&fake_bin.join("make"))?;
+    write_fake_codesign(&fake_bin.join("codesign"))?;
+    write_fake_sysctl(&fake_bin.join("sysctl"))?;
+    write_fake_uname(&fake_bin.join("uname"))?;
+    write_file(&curl_log, "")?;
+    write_file(&validate_log, "")?;
+    write_file(&codesign_log, "")?;
+
+    let build_script = Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../release/artifacts/recipes/redis/build.sh");
+    let output = StdCommand::new(build_script)
+        .env("PATH", format!("{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"))
+        .env("PV_ARTIFACT_OUT_DIR", &out_dir)
+        .env("PV_ARTIFACT_RECORD_DIR", &record_dir)
+        .env("PV_BUILD_RUN_ID", "local-test")
+        .env("PV_COMMIT", "0123456789abcdef0123456789abcdef01234567")
+        .env("PV_RECIPE_PLATFORM", "darwin-arm64")
+        .env("PV_RECIPE_TRACK", "8.2")
+        .env("PV_TEST_CURL_LOG", &curl_log)
+        .env("PV_TEST_SOURCE_ARCHIVE", &source_archive)
+        .env("PV_TEST_SOURCE_SHA256", file_sha256(&source_archive)?)
+        .env(
+            "PV_TEST_VALIDATE_ARCHIVE_FAILURE",
+            if options.validate_archive_failure {
+                "1"
+            } else {
+                ""
+            },
+        )
+        .env("PV_TEST_VALIDATE_LOG", &validate_log)
+        .env("PV_TEST_CODESIGN_LOG", &codesign_log)
+        .env("PV_TEST_LIPO_ARCHS", "arm64")
+        .env("PV_TEST_MACHO_LIBRARIES", "")
+        .env("PV_TEST_MACHO_MINOS", "13.0")
+        .env("PV_TEST_MACHO_RPATHS", "")
+        .output()?;
+
+    let artifact_version = "8.2.7-pv1";
+    let artifact_basename = "redis-8.2.7-pv1-darwin-arm64";
+    let archive = out_dir.join(format!("{artifact_basename}.tar.gz"));
+    let archive_exists = path_exists(&archive);
+    let archive_entries = if archive_exists {
+        archive_entries(&archive)?
+    } else {
+        Vec::new()
+    };
+    let record = record_dir
+        .join("redis")
+        .join("8.2")
+        .join(artifact_version)
+        .join("darwin-arm64")
+        .join(format!("{artifact_basename}.json"));
+
+    Ok(RedisBuildRecipeRun {
+        out_dir: out_dir.to_string(),
+        output,
+        record_json: read_optional_file(&record)?,
+        validate_log: read_file(&validate_log)?,
+        codesign_log: read_file(&codesign_log)?,
+        archive_entries,
+        archive_exists,
+    })
 }
 
 fn run_composer_build_recipe_smoke() -> Result<ComposerBuildRecipeRun> {
@@ -1015,6 +1292,154 @@ fi
     )
 }
 
+fn write_fake_redis_cargo(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+json_array() {
+  first=true
+  printf '['
+  for value in "$@"; do
+    if [ "$first" = true ]; then
+      first=false
+    else
+      printf ', '
+    fi
+    printf '"%s"' "$value"
+  done
+  printf ']'
+}
+
+if [ "$#" -ge 5 ] && [ "$1" = "run" ] && [ "$2" = "-p" ] && [ "$3" = "pv-release" ] && [ "$4" = "--" ]; then
+  case "$5" in
+    print-recipe-env)
+      cat <<EOF
+PV_RESOURCE=redis
+PV_TRACK=$PV_RECIPE_TRACK
+PV_PLATFORM=$PV_RECIPE_PLATFORM
+PV_UPSTREAM_VERSION=8.2.7
+PV_ARTIFACT_VERSION=8.2.7-pv1
+PV_SOURCE_URL=https://sources.example.test/redis.tar.gz
+PV_SOURCE_SHA256=$PV_TEST_SOURCE_SHA256
+PV_PV_BUILD_REVISION=pv1
+PV_MINIMUM_PV_VERSION=0.1.0
+EOF
+      ;;
+    write-release-record)
+      record=
+      object_key=
+      source_url=
+      source_sha256=
+      recipe=
+      pv_commit=
+      build_run_id=
+      license_files=
+      notice_files=
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --record)
+            shift
+            record=${1:-}
+            ;;
+          --object-key)
+            shift
+            object_key=${1:-}
+            ;;
+          --source-url)
+            shift
+            source_url=${1:-}
+            ;;
+          --source-sha256)
+            shift
+            source_sha256=${1:-}
+            ;;
+          --recipe)
+            shift
+            recipe=${1:-}
+            ;;
+          --pv-commit)
+            shift
+            pv_commit=${1:-}
+            ;;
+          --build-run-id)
+            shift
+            build_run_id=${1:-}
+            ;;
+          --license-file)
+            shift
+            license_files="${license_files}${license_files:+
+}${1:-}"
+            ;;
+          --notice-file)
+            shift
+            notice_files="${notice_files}${notice_files:+
+}${1:-}"
+            ;;
+        esac
+        shift
+      done
+      [ -n "$license_files" ] || license_files=LICENSE
+      [ -n "$notice_files" ] || notice_files=NOTICE
+      set -- $license_files
+      license_json=$(json_array "$@")
+      set -- $notice_files
+      notice_json=$(json_array "$@")
+      mkdir -p "$(dirname "$record")"
+      {
+        printf '{\n'
+        printf '  "object_key": "%s",\n' "$object_key"
+        printf '  "license_files": %s,\n' "$license_json"
+        printf '  "notice_files": %s,\n' "$notice_json"
+        printf '  "provenance": {\n'
+        printf '    "source_url": "%s",\n' "$source_url"
+        printf '    "source_sha256": "%s",\n' "$source_sha256"
+        printf '    "recipe": "%s",\n' "$recipe"
+        printf '    "pv_commit": "%s",\n' "$pv_commit"
+        printf '    "build_run_id": "%s"\n' "$build_run_id"
+        printf '  }\n}\n'
+      } >"$record"
+      ;;
+    validate-archive)
+      archive=
+      record=
+      smoke_hook=
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --archive)
+            shift
+            archive=${1:-}
+            ;;
+          --record)
+            shift
+            record=${1:-}
+            ;;
+          --smoke-hook)
+            shift
+            smoke_hook=${1:-}
+            ;;
+        esac
+        shift
+      done
+      printf 'archive=%s record=%s smoke=%s\n' \
+        "${archive##*/}" \
+        "${record##*/}" \
+        "${smoke_hook##*/}" >>"$PV_TEST_VALIDATE_LOG"
+      if [ -n "$PV_TEST_VALIDATE_ARCHIVE_FAILURE" ]; then
+        printf 'validate-archive failed for %s\n' "${archive##*/}" >&2
+        exit 79
+      fi
+      ;;
+    *) exit 77 ;;
+  esac
+else
+  exit 77
+fi
+"#,
+    )
+}
+
 fn write_fake_composer_cargo(path: &Utf8Path) -> Result<()> {
     write_executable(
         path,
@@ -1272,6 +1697,67 @@ esac
     )
 }
 
+fn write_fake_make(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -C)
+      shift
+      cd "$1"
+      ;;
+  esac
+  shift
+done
+mkdir -p src
+printf '%s\n' '#!/bin/sh' >src/redis-server
+printf '%s\n' '#!/bin/sh' >src/redis-cli
+"#,
+    )
+}
+
+fn write_fake_codesign(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+printf 'argv=' >>"$PV_TEST_CODESIGN_LOG"
+for arg in "$@"; do
+  printf '[%s]' "$arg" >>"$PV_TEST_CODESIGN_LOG"
+done
+printf '\n' >>"$PV_TEST_CODESIGN_LOG"
+"#,
+    )
+}
+
+fn write_fake_sysctl(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+[ "${1:-}" = "-n" ] || exit 78
+[ "${2:-}" = "hw.ncpu" ] || exit 78
+printf '%s\n' 4
+"#,
+    )
+}
+
+fn write_fake_uname(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+case "${1:-}" in
+  -s) printf '%s\n' Darwin ;;
+  -m) printf '%s\n' arm64 ;;
+  *) exit 78 ;;
+esac
+"#,
+    )
+}
+
 #[expect(
     clippy::disallowed_types,
     reason = "release tooling tests create source tarball fixtures directly"
@@ -1291,6 +1777,99 @@ fn write_source_archive(path: &Utf8Path, top_level_dir: &str) -> Result<()> {
     let encoder = builder.into_inner()?;
     encoder.finish()?;
     Ok(())
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "release tooling tests create source tarball fixtures directly"
+)]
+fn write_redis_source_archive(path: &Utf8Path) -> Result<()> {
+    let file = std::fs::File::create(path)?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut builder = Builder::new(encoder);
+
+    append_archive_file(
+        &mut builder,
+        "redis-source/src/redis-server",
+        b"redis-server\n",
+    )?;
+    append_archive_file(&mut builder, "redis-source/src/redis-cli", b"redis-cli\n")?;
+    append_archive_file(
+        &mut builder,
+        "redis-source/deps/hiredis/COPYING",
+        b"hiredis license\n",
+    )?;
+    append_archive_file(
+        &mut builder,
+        "redis-source/deps/lua/COPYRIGHT",
+        b"lua license\n",
+    )?;
+    append_archive_file(
+        &mut builder,
+        "redis-source/deps/hdr_histogram/LICENSE.txt",
+        b"hdr histogram bsd license\n",
+    )?;
+    append_archive_file(
+        &mut builder,
+        "redis-source/deps/hdr_histogram/COPYING.txt",
+        b"hdr histogram cc0 license\n",
+    )?;
+    append_archive_file(
+        &mut builder,
+        "redis-source/deps/fpconv/LICENSE.txt",
+        b"fpconv license\n",
+    )?;
+    append_archive_file(
+        &mut builder,
+        "redis-source/deps/fast_float/README.md",
+        b"fast_float notice\n",
+    )?;
+    append_archive_file(
+        &mut builder,
+        "redis-source/deps/linenoise/README.markdown",
+        b"linenoise notice\n",
+    )?;
+    append_archive_file(
+        &mut builder,
+        "redis-source/deps/jemalloc/COPYING",
+        b"jemalloc license\n",
+    )?;
+
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+    Ok(())
+}
+
+fn append_archive_file<W: std::io::Write>(
+    builder: &mut Builder<W>,
+    path: &str,
+    content: &[u8],
+) -> Result<()> {
+    let mut header = Header::new_gnu();
+    header.set_path(path)?;
+    header.set_size(content.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder.append(&header, content)?;
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "release tooling tests inspect archive contents"
+)]
+fn archive_entries(path: &Utf8Path) -> Result<Vec<String>> {
+    let file = std::fs::File::open(path)?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    let mut entries = Vec::new();
+
+    for entry in archive.entries()? {
+        let entry = entry?;
+        entries.push(entry.path()?.to_string_lossy().into_owned());
+    }
+
+    Ok(entries)
 }
 
 #[expect(

--- a/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_archives_records_and_manifest.snap
+++ b/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_archives_records_and_manifest.snap
@@ -351,6 +351,51 @@ expression: manifest_json
           ]
         }
       ]
+    },
+    {
+      "name": "redis",
+      "default_track": "8.2",
+      "tracks": [
+        {
+          "name": "8.2",
+          "artifacts": [
+            {
+              "artifact_version": "8.2.7-pv1",
+              "upstream_version": "8.2.7",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-amd64",
+              "url": "https://artifacts.example.test/resources/redis/8.2/8.2.7-pv1/darwin-amd64/redis-8.2.7-pv1-darwin-amd64.tar.gz",
+              "sha256": "8a45f67e0e2839e3b5c2cc0f47a35580dae765356cf6f1f1ccc3df7ad0b069bd",
+              "size": 227,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://download.redis.io/releases/redis-8.2.7.tar.gz",
+                "source_sha256": "afaae66030c193b06720a714ba7a558136b82689027536e0e24f53908c18cbe9",
+                "recipe": "release/artifacts/recipes/redis/recipe.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            },
+            {
+              "artifact_version": "8.2.7-pv1",
+              "upstream_version": "8.2.7",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-arm64",
+              "url": "https://artifacts.example.test/resources/redis/8.2/8.2.7-pv1/darwin-arm64/redis-8.2.7-pv1-darwin-arm64.tar.gz",
+              "sha256": "62dd0ea0dc1415536837946b7d98dd06cee3df80c185e011446b6d2ea9080718",
+              "size": 228,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://download.redis.io/releases/redis-8.2.7.tar.gz",
+                "source_sha256": "afaae66030c193b06720a714ba7a558136b82689027536e0e24f53908c18cbe9",
+                "recipe": "release/artifacts/recipes/redis/recipe.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_archives_records_and_manifest.snap
+++ b/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_archives_records_and_manifest.snap
@@ -365,8 +365,8 @@ expression: manifest_json
               "pv_build_revision": "pv1",
               "platform": "darwin-amd64",
               "url": "https://artifacts.example.test/resources/redis/8.2/8.2.7-pv1/darwin-amd64/redis-8.2.7-pv1-darwin-amd64.tar.gz",
-              "sha256": "8a45f67e0e2839e3b5c2cc0f47a35580dae765356cf6f1f1ccc3df7ad0b069bd",
-              "size": 227,
+              "sha256": "8fc757b6ee863e1a1c069aa9187b14e7d773dba2c88e03f85ff4ba1bf2282704",
+              "size": 257,
               "published_at": "2026-01-01T00:00:00Z",
               "provenance": {
                 "source_url": "https://download.redis.io/releases/redis-8.2.7.tar.gz",
@@ -382,8 +382,8 @@ expression: manifest_json
               "pv_build_revision": "pv1",
               "platform": "darwin-arm64",
               "url": "https://artifacts.example.test/resources/redis/8.2/8.2.7-pv1/darwin-arm64/redis-8.2.7-pv1-darwin-arm64.tar.gz",
-              "sha256": "62dd0ea0dc1415536837946b7d98dd06cee3df80c185e011446b6d2ea9080718",
-              "size": 228,
+              "sha256": "e83cc8c46b28c11f2f993505f74335257d80d49e6e267548c40039b772c58a08",
+              "size": 257,
               "published_at": "2026-01-01T00:00:00Z",
               "provenance": {
                 "source_url": "https://download.redis.io/releases/redis-8.2.7.tar.gz",

--- a/crates/pv-release/tests/snapshots/recipe_metadata__print_recipe_env_redis.snap
+++ b/crates/pv-release/tests/snapshots/recipe_metadata__print_recipe_env_redis.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pv-release/tests/recipe_metadata.rs
+expression: env
+---
+PV_RESOURCE='redis'
+PV_TRACK='8.2'
+PV_PLATFORM='darwin-arm64'
+PV_UPSTREAM_VERSION='8.2.1'
+PV_ARTIFACT_VERSION='8.2.1-pv1'
+PV_SOURCE_URL='https://download.redis.io/releases/redis-8.2.1.tar.gz'
+PV_SOURCE_SHA256='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+PV_MINIMUM_PV_VERSION='0.1.0'
+PV_PV_BUILD_REVISION='pv1'

--- a/release/artifacts/default-tracks.toml
+++ b/release/artifacts/default-tracks.toml
@@ -9,3 +9,7 @@ default_track = "8.4"
 [[resource]]
 name = "composer"
 default_track = "2"
+
+[[resource]]
+name = "redis"
+default_track = "8.2"

--- a/release/artifacts/recipes/redis/LICENSE
+++ b/release/artifacts/recipes/redis/LICENSE
@@ -1,0 +1,1399 @@
+Starting with Redis 8, Redis Open Source is moving to a tri-licensing model with all new Redis code
+contributions governed by the updated Redis Software Grant and Contributor License Agreement.
+After this release, contributions are subject to your choice of: (a) the Redis Source Available License v2
+(RSALv2);or (b) the Server Side Public License v1 (SSPLv1); or (c) the GNU Affero General Public License v3 (AGPLv3).
+Redis Open Source 7.2 and prior releases remain subject to the BSDv3 clause license as referenced
+in the REDISCONTRIBUTIONS.txt file.
+
+The licensing structure for Redis 8.0 and subsequent releases is as follows:
+
+
+1. Redis Source Available License 2.0 (RSALv2) Agreement
+========================================================
+
+Last Update: December 30, 2023
+
+Acceptance
+----------
+
+This Agreement sets forth the terms and conditions on which the Licensor
+makes available the Software. By installing, downloading, accessing,
+Using, or distributing any of the Software, You agree to all of the
+terms and conditions of this Agreement.
+
+If You are receiving the Software on behalf of Your Company, You
+represent and warrant that You have the authority to agree to this
+Agreement on behalf of such entity.
+
+The Licensor reserves the right to update this Agreement from time to
+time.
+
+The terms below have the meanings set forth below for purposes of this
+Agreement:
+
+Definitions
+-----------
+
+Agreement: this Redis Source Available License 2.0 Agreement.
+
+Control: ownership, directly or indirectly, of substantially all the
+assets of an entity, or the power to direct its management and policies
+by vote, contract, or otherwise.
+
+License: the License as described in the License paragraph below.
+
+Licensor: the entity offering these terms, which includes Redis Ltd. on
+behalf of itself and its subsidiaries and affiliates worldwide.
+
+Modify, Modified, or Modification: copy from or adapt all or part of the
+work in a fashion requiring copyright permission other than making an
+exact copy. The resulting work is called a Modified version of the
+earlier work.
+
+Redis: the Redis software as described in redis.com redis.io.
+
+Software: certain Software components designed to work with Redis and
+provided to You under this Agreement.
+
+Trademark: the trademarks, service marks, and any other similar rights.
+
+Use: anything You do with the Software requiring one of Your Licenses.
+
+You: the recipient of the Software, the individual or entity on whose
+behalf You are agreeing to this Agreement.
+
+Your Company: any legal entity, sole proprietorship, or other kind of
+organization that You work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization.
+
+Your Licenses: means all the Licenses granted to You for the Software
+under this Agreement.
+
+License
+-------
+
+The Licensor grants You a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute,
+make available, and prepare derivative works of the Software, in each
+case subject to the limitations and conditions below.
+
+Limitations
+-----------
+
+You may not make the functionality of the Software or a Modified version
+available to third parties as a service or distribute the Software or a
+Modified version in a manner that makes the functionality of the
+Software available to third parties.
+
+Making the functionality of the Software or Modified version available
+to third parties includes, without limitation, enabling third parties to
+interact with the functionality of the Software or Modified version in
+distributed form or remotely through a computer network, offering a
+product or service, the value of which entirely or primarily derives
+from the value of the Software or Modified version, or offering a
+product or service that accomplishes for users the primary purpose of
+the Software or Modified version.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the Licensor in the Software. Any use of the Licensor's
+Trademarks is subject to applicable law.
+
+Patents
+-------
+
+The Licensor grants You a License, under any patent claims the Licensor
+can License, or becomes able to License, to make, have made, use, sell,
+offer for sale, import and have imported the Software, in each case
+subject to the limitations and conditions in this License. This License
+does not cover any patent claims that You cause to be infringed by
+Modifications or additions to the Software. If You or Your Company make
+any written claim that the Software infringes or contributes to
+infringement of any patent, your patent License for the Software granted
+under this Agreement ends immediately. If Your Company makes such a
+claim, your patent License ends immediately for work on behalf of Your
+Company.
+
+Notices
+-------
+
+You must ensure that anyone who gets a copy of any part of the Software
+from You also gets a copy of the terms and conditions in this Agreement.
+
+If You modify the Software, You must include in any Modified copies of
+the Software prominent notices stating that You have Modified the
+Software.
+
+No Other Rights
+---------------
+
+The terms and conditions of this Agreement do not imply any Licenses
+other than those expressly granted in this Agreement.
+
+Termination
+-----------
+
+If You Use the Software in violation of this Agreement, such Use is not
+Licensed, and Your Licenses will automatically terminate. If the
+Licensor provides You with a notice of your violation, and You cease all
+violations of this License no later than 30 days after You receive that
+notice, Your Licenses will be reinstated retroactively. However, if You
+violate this Agreement after such reinstatement, any additional
+violation of this Agreement will cause your Licenses to terminate
+automatically and permanently.
+
+No Liability
+------------
+
+As far as the law allows, the Software comes as is, without any
+warranty or condition, and the Licensor will not be liable to You for
+any damages arising out of this Agreement or the Use or nature of the
+Software, under any kind of legal claim.
+
+Governing Law and Jurisdiction
+------------------------------
+
+If You are located in Asia, Pacific, Americas, or other jurisdictions
+not listed below, the Agreement will be construed and enforced in all
+respects in accordance with the laws of the State of California, U.S.A.,
+without reference to its choice of law rules. The courts located in the
+County of Santa Clara, California, have exclusive jurisdiction for all
+purposes relating to this Agreement.
+
+If You are located in Israel, the Agreement will be construed and
+enforced in all respects in accordance with the laws of the State of
+Israel without reference to its choice of law rules. The courts located
+in the Central District of the State of Israel have exclusive
+jurisdiction for all purposes relating to this Agreement.
+
+If You are located in Europe, United Kingdom, Middle East or Africa, the
+Agreement will be construed and enforced in all respects in accordance
+with the laws of England and Wales without reference to its choice of
+law rules. The competent courts located in London, England, have
+exclusive jurisdiction for all purposes relating to this Agreement.
+
+
+
+2. Server Side Public License (SSPL)
+====================================
+
+                     Server Side Public License
+                     VERSION 1, OCTOBER 16, 2018
+
+                    Copyright (c) 2018 MongoDB, Inc.
+
+  Everyone is permitted to copy and distribute verbatim copies of this
+  license document, but changing it is not allowed.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to Server Side Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+  works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+  License.  Each licensee is addressed as "you". "Licensees" and
+  "recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work in
+  a fashion requiring copyright permission, other than the making of an
+  exact copy. The resulting work is called a "modified version" of the
+  earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based on
+  the Program.
+
+  To "propagate" a work means to do anything with it that, without
+  permission, would make you directly or secondarily liable for
+  infringement under applicable copyright law, except executing it on a
+  computer or modifying a private copy. Propagation includes copying,
+  distribution (with or without modification), making available to the
+  public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+  parties to make or receive copies. Mere interaction with a user through a
+  computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices" to the
+  extent that it includes a convenient and prominently visible feature that
+  (1) displays an appropriate copyright notice, and (2) tells the user that
+  there is no warranty for the work (except to the extent that warranties
+  are provided), that licensees may convey the work under this License, and
+  how to view a copy of this License. If the interface presents a list of
+  user commands or options, such as a menu, a prominent item in the list
+  meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work for
+  making modifications to it. "Object code" means any non-source form of a
+  work.
+
+  A "Standard Interface" means an interface that either is an official
+  standard defined by a recognized standards body, or, in the case of
+  interfaces specified for a particular programming language, one that is
+  widely used among developers working in that language.  The "System
+  Libraries" of an executable work include anything, other than the work as
+  a whole, that (a) is included in the normal form of packaging a Major
+  Component, but which is not part of that Major Component, and (b) serves
+  only to enable use of the work with that Major Component, or to implement
+  a Standard Interface for which an implementation is available to the
+  public in source code form. A "Major Component", in this context, means a
+  major essential component (kernel, window system, and so on) of the
+  specific operating system (if any) on which the executable work runs, or
+  a compiler used to produce the work, or an object code interpreter used
+  to run it.
+
+  The "Corresponding Source" for a work in object code form means all the
+  source code needed to generate, install, and (for an executable work) run
+  the object code and to modify the work, including scripts to control
+  those activities. However, it does not include the work's System
+  Libraries, or general-purpose tools or generally available free programs
+  which are used unmodified in performing those activities but which are
+  not part of the work. For example, Corresponding Source includes
+  interface definition files associated with source files for the work, and
+  the source code for shared libraries and dynamically linked subprograms
+  that the work is specifically designed to require, such as by intimate
+  data communication or control flow between those subprograms and other
+  parts of the work.
+
+  The Corresponding Source need not include anything that users can
+  regenerate automatically from other parts of the Corresponding Source.
+
+  The Corresponding Source for a work in source code form is that same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+  copyright on the Program, and are irrevocable provided the stated
+  conditions are met. This License explicitly affirms your unlimited
+  permission to run the unmodified Program, subject to section 13. The
+  output from running a covered work is covered by this License only if the
+  output, given its content, constitutes a covered work. This License
+  acknowledges your rights of fair use or other equivalent, as provided by
+  copyright law.  Subject to section 13, you may make, run and propagate
+  covered works that you do not convey, without conditions so long as your
+  license otherwise remains in force. You may convey covered works to
+  others for the sole purpose of having them make modifications exclusively
+  for you, or provide you with facilities for running those works, provided
+  that you comply with the terms of this License in conveying all
+  material for which you do not control copyright. Those thus making or
+  running the covered works for you must do so exclusively on your
+  behalf, under your direction and control, on terms that prohibit them
+  from making any copies of your copyrighted material outside their
+  relationship with you.
+
+  Conveying under any other circumstances is permitted solely under the
+  conditions stated below. Sublicensing is not allowed; section 10 makes it
+  unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+  measure under any applicable law fulfilling obligations under article 11
+  of the WIPO copyright treaty adopted on 20 December 1996, or similar laws
+  prohibiting or restricting circumvention of such measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+  circumvention of technological measures to the extent such circumvention is
+  effected by exercising rights under this License with respect to the
+  covered work, and you disclaim any intention to limit operation or
+  modification of the work as a means of enforcing, against the work's users,
+  your or third parties' legal rights to forbid circumvention of
+  technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+  receive it, in any medium, provided that you conspicuously and
+  appropriately publish on each copy an appropriate copyright notice; keep
+  intact all notices stating that this License and any non-permissive terms
+  added in accord with section 7 apply to the code; keep intact all notices
+  of the absence of any warranty; and give all recipients a copy of this
+  License along with the Program.  You may charge any price or no price for
+  each copy that you convey, and you may offer support or warranty
+  protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+  produce it from the Program, in the form of source code under the terms
+  of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified it,
+    and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is released
+    under this License and any conditions added under section 7. This
+    requirement modifies the requirement in section 4 to "keep intact all
+    notices".
+
+    c) You must license the entire work, as a whole, under this License to
+    anyone who comes into possession of a copy. This License will therefore
+    apply, along with any applicable section 7 additional terms, to the
+    whole of the work, and all its parts, regardless of how they are
+    packaged. This License gives no permission to license the work in any
+    other way, but it does not invalidate such permission if you have
+    separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your work
+    need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+  works, which are not by their nature extensions of the covered work, and
+  which are not combined with it such as to form a larger program, in or on
+  a volume of a storage or distribution medium, is called an "aggregate" if
+  the compilation and its resulting copyright are not used to limit the
+  access or legal rights of the compilation's users beyond what the
+  individual works permit. Inclusion of a covered work in an aggregate does
+  not cause this License to apply to the other parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms of
+  sections 4 and 5, provided that you also convey the machine-readable
+  Corresponding Source under the terms of this License, in one of these
+  ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium customarily
+    used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a written
+    offer, valid for at least three years and valid for as long as you
+    offer spare parts or customer support for that product model, to give
+    anyone who possesses the object code either (1) a copy of the
+    Corresponding Source for all the software in the product that is
+    covered by this License, on a durable physical medium customarily used
+    for software interchange, for a price no more than your reasonable cost
+    of physically performing this conveying of source, or (2) access to
+    copy the Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source. This alternative is
+    allowed only occasionally and noncommercially, and only if you received
+    the object code with such an offer, in accord with subsection 6b.
+
+    d) Convey the object code by offering access from a designated place
+    (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge. You need not require recipients to copy the
+    Corresponding Source along with the object code. If the place to copy
+    the object code is a network server, the Corresponding Source may be on
+    a different server (operated by you or a third party) that supports
+    equivalent copying facilities, provided you maintain clear directions
+    next to the object code saying where to find the Corresponding Source.
+    Regardless of what server hosts the Corresponding Source, you remain
+    obligated to ensure that it is available for as long as needed to
+    satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided you
+    inform other peers where the object code and Corresponding Source of
+    the work are being offered to the general public at no charge under
+    subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+  from the Corresponding Source as a System Library, need not be included
+  in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+  tangible personal property which is normally used for personal, family,
+  or household purposes, or (2) anything designed or sold for incorporation
+  into a dwelling. In determining whether a product is a consumer product,
+  doubtful cases shall be resolved in favor of coverage. For a particular
+  product received by a particular user, "normally used" refers to a
+  typical or common use of that class of product, regardless of the status
+  of the particular user or of the way in which the particular user
+  actually uses, or expects or is expected to use, the product. A product
+  is a consumer product regardless of whether the product has substantial
+  commercial, industrial or non-consumer uses, unless such uses represent
+  the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+  procedures, authorization keys, or other information required to install
+  and execute modified versions of a covered work in that User Product from
+  a modified version of its Corresponding Source. The information must
+  suffice to ensure that the continued functioning of the modified object
+  code is in no case prevented or interfered with solely because
+  modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+  specifically for use in, a User Product, and the conveying occurs as part
+  of a transaction in which the right of possession and use of the User
+  Product is transferred to the recipient in perpetuity or for a fixed term
+  (regardless of how the transaction is characterized), the Corresponding
+  Source conveyed under this section must be accompanied by the
+  Installation Information. But this requirement does not apply if neither
+  you nor any third party retains the ability to install modified object
+  code on the User Product (for example, the work has been installed in
+  ROM).
+
+  The requirement to provide Installation Information does not include a
+  requirement to continue to provide support service, warranty, or updates
+  for a work that has been modified or installed by the recipient, or for
+  the User Product in which it has been modified or installed. Access
+  to a network may be denied when the modification itself materially
+  and adversely affects the operation of the network or violates the
+  rules and protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided, in
+  accord with this section must be in a format that is publicly documented
+  (and with an implementation available to the public in source code form),
+  and must require no special password or key for unpacking, reading or
+  copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+  License by making exceptions from one or more of its conditions.
+  Additional permissions that are applicable to the entire Program shall be
+  treated as though they were included in this License, to the extent that
+  they are valid under applicable law. If additional permissions apply only
+  to part of the Program, that part may be used separately under those
+  permissions, but the entire Program remains governed by this License
+  without regard to the additional permissions.  When you convey a copy of
+  a covered work, you may at your option remove any additional permissions
+  from that copy, or from any part of it. (Additional permissions may be
+  written to require their own removal in certain cases when you modify the
+  work.) You may place additional permissions on material, added by you to
+  a covered work, for which you have or can give appropriate copyright
+  permission.
+
+  Notwithstanding any other provision of this License, for material you add
+  to a covered work, you may (if authorized by the copyright holders of
+  that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some trade
+    names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that material
+    by anyone who conveys the material (or modified versions of it) with
+    contractual assumptions of liability to the recipient, for any
+    liability that these contractual assumptions directly impose on those
+    licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+  restrictions" within the meaning of section 10. If the Program as you
+  received it, or any part of it, contains a notice stating that it is
+  governed by this License along with a term that is a further restriction,
+  you may remove that term. If a license document contains a further
+  restriction but permits relicensing or conveying under this License, you
+  may add to a covered work material governed by the terms of that license
+  document, provided that the further restriction does not survive such
+  relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you must
+  place, in the relevant source files, a statement of the additional terms
+  that apply to those files, or a notice indicating where to find the
+  applicable terms.  Additional terms, permissive or non-permissive, may be
+  stated in the form of a separately written license, or stated as
+  exceptions; the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+  provided under this License. Any attempt otherwise to propagate or modify
+  it is void, and will automatically terminate your rights under this
+  License (including any patent licenses granted under the third paragraph
+  of section 11).
+
+  However, if you cease all violation of this License, then your license
+  from a particular copyright holder is reinstated (a) provisionally,
+  unless and until the copyright holder explicitly and finally terminates
+  your license, and (b) permanently, if the copyright holder fails to
+  notify you of the violation by some reasonable means prior to 60 days
+  after the cessation.
+
+  Moreover, your license from a particular copyright holder is reinstated
+  permanently if the copyright holder notifies you of the violation by some
+  reasonable means, this is the first time you have received notice of
+  violation of this License (for any work) from that copyright holder, and
+  you cure the violation prior to 30 days after your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+  licenses of parties who have received copies or rights from you under
+  this License. If your rights have been terminated and not permanently
+  reinstated, you do not qualify to receive new licenses for the same
+  material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or run a
+  copy of the Program. Ancillary propagation of a covered work occurring
+  solely as a consequence of using peer-to-peer transmission to receive a
+  copy likewise does not require acceptance. However, nothing other than
+  this License grants you permission to propagate or modify any covered
+  work. These actions infringe copyright if you do not accept this License.
+  Therefore, by modifying or propagating a covered work, you indicate your
+  acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically receives
+  a license from the original licensors, to run, modify and propagate that
+  work, subject to this License. You are not responsible for enforcing
+  compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+  organization, or substantially all assets of one, or subdividing an
+  organization, or merging organizations. If propagation of a covered work
+  results from an entity transaction, each party to that transaction who
+  receives a copy of the work also receives whatever licenses to the work
+  the party's predecessor in interest had or could give under the previous
+  paragraph, plus a right to possession of the Corresponding Source of the
+  work from the predecessor in interest, if the predecessor has it or can
+  get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the rights
+  granted or affirmed under this License. For example, you may not impose a
+  license fee, royalty, or other charge for exercise of rights granted
+  under this License, and you may not initiate litigation (including a
+  cross-claim or counterclaim in a lawsuit) alleging that any patent claim
+  is infringed by making, using, selling, offering for sale, or importing
+  the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+  License of the Program or a work on which the Program is based. The work
+  thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims owned or
+  controlled by the contributor, whether already acquired or hereafter
+  acquired, that would be infringed by some manner, permitted by this
+  License, of making, using, or selling its contributor version, but do not
+  include claims that would be infringed only as a consequence of further
+  modification of the contributor version. For purposes of this definition,
+  "control" includes the right to grant patent sublicenses in a manner
+  consistent with the requirements of this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+  patent license under the contributor's essential patent claims, to make,
+  use, sell, offer for sale, import and otherwise run, modify and propagate
+  the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+  agreement or commitment, however denominated, not to enforce a patent
+  (such as an express permission to practice a patent or covenant not to
+  sue for patent infringement). To "grant" such a patent license to a party
+  means to make such an agreement or commitment not to enforce a patent
+  against the party.
+
+  If you convey a covered work, knowingly relying on a patent license, and
+  the Corresponding Source of the work is not available for anyone to copy,
+  free of charge and under the terms of this License, through a publicly
+  available network server or other readily accessible means, then you must
+  either (1) cause the Corresponding Source to be so available, or (2)
+  arrange to deprive yourself of the benefit of the patent license for this
+  particular work, or (3) arrange, in a manner consistent with the
+  requirements of this License, to extend the patent license to downstream
+  recipients. "Knowingly relying" means you have actual knowledge that, but
+  for the patent license, your conveying the covered work in a country, or
+  your recipient's use of the covered work in a country, would infringe
+  one or more identifiable patents in that country that you have reason
+  to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+  arrangement, you convey, or propagate by procuring conveyance of, a
+  covered work, and grant a patent license to some of the parties receiving
+  the covered work authorizing them to use, propagate, modify or convey a
+  specific copy of the covered work, then the patent license you grant is
+  automatically extended to all recipients of the covered work and works
+  based on it.
+
+  A patent license is "discriminatory" if it does not include within the
+  scope of its coverage, prohibits the exercise of, or is conditioned on
+  the non-exercise of one or more of the rights that are specifically
+  granted under this License. You may not convey a covered work if you are
+  a party to an arrangement with a third party that is in the business of
+  distributing software, under which you make payment to the third party
+  based on the extent of your activity of conveying the work, and under
+  which the third party grants, to any of the parties who would receive the
+  covered work from you, a discriminatory patent license (a) in connection
+  with copies of the covered work conveyed by you (or copies made from
+  those copies), or (b) primarily for and in connection with specific
+  products or compilations that contain the covered work, unless you
+  entered into that arrangement, or that patent license was granted, prior
+  to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting any
+  implied license or other defenses to infringement that may otherwise be
+  available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+  otherwise) that contradict the conditions of this License, they do not
+  excuse you from the conditions of this License. If you cannot use,
+  propagate or convey a covered work so as to satisfy simultaneously your
+  obligations under this License and any other pertinent obligations, then
+  as a consequence you may not use, propagate or convey it at all. For
+  example, if you agree to terms that obligate you to collect a royalty for
+  further conveying from those to whom you convey the Program, the only way
+  you could satisfy both those terms and this License would be to refrain
+  entirely from conveying the Program.
+
+  13. Offering the Program as a Service.
+
+  If you make the functionality of the Program or a modified version
+  available to third parties as a service, you must make the Service Source
+  Code available via network download to everyone at no charge, under the
+  terms of this License. Making the functionality of the Program or
+  modified version available to third parties as a service includes,
+  without limitation, enabling third parties to interact with the
+  functionality of the Program or modified version remotely through a
+  computer network, offering a service the value of which entirely or
+  primarily derives from the value of the Program or modified version, or
+  offering a service that accomplishes for users the primary purpose of the
+  Program or modified version.
+
+  "Service Source Code" means the Corresponding Source for the Program or
+  the modified version, and the Corresponding Source for all programs that
+  you use to make the Program or modified version available as a service,
+  including, without limitation, management software, user interfaces,
+  application program interfaces, automation software, monitoring software,
+  backup software, storage software and hosting software, all such that a
+  user could run an instance of the service using the Service Source Code
+  you make available.
+
+  14. Revised Versions of this License.
+
+  MongoDB, Inc. may publish revised and/or new versions of the Server Side
+  Public License from time to time. Such new versions will be similar in
+  spirit to the present version, but may differ in detail to address new
+  problems or concerns.
+
+  Each version is given a distinguishing version number. If the Program
+  specifies that a certain numbered version of the Server Side Public
+  License "or any later version" applies to it, you have the option of
+  following the terms and conditions either of that numbered version or of
+  any later version published by MongoDB, Inc. If the Program does not
+  specify a version number of the Server Side Public License, you may
+  choose any version ever published by MongoDB, Inc.
+
+  If the Program specifies that a proxy can decide which future versions of
+  the Server Side Public License can be used, that proxy's public statement
+  of acceptance of a version permanently authorizes you to choose that
+  version for the Program.
+
+  Later license versions may give you additional or different permissions.
+  However, no additional obligations are imposed on any author or copyright
+  holder as a result of your choosing to follow a later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+  APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+  HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+  OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+  PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+  IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+  ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+  WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+  THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING
+  ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF
+  THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO
+  LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU
+  OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+  PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided above
+  cannot be given local legal effect according to their terms, reviewing
+  courts shall apply local law that most closely approximates an absolute
+  waiver of all civil liability in connection with the Program, unless a
+  warranty or assumption of liability accompanies a copy of the Program in
+  return for a fee.
+
+                        END OF TERMS AND CONDITIONS
+
+
+3. GNU AFFERO GENERAL PUBLIC LICENSE, Version 3, 19 Nov 2007
+========================================================
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/release/artifacts/recipes/redis/NOTICE
+++ b/release/artifacts/recipes/redis/NOTICE
@@ -1,0 +1,31 @@
+Copyright (c) 2006-Present, Redis Ltd. and Contributors
+All rights reserved.
+
+Note: Continued Applicability of the BSD-3-Clause License
+
+Despite the shift to the dual-licensing model with version 7.4 (RSALv2 or SSPLv1) and
+the shift to a tri-license option with version 8.0 (RSALv2/SSPLv1/AGPLv3), portions of
+Redis Open Source remain available subject to the BSD-3-Clause License (BSD).
+See below for the full BSD license:
+
+Redistribution and use in source and binary forms, with or without modification, are permitted
+provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions
+and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+and the following disclaimer in the documentation and/or other materials provided with the
+distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/release/artifacts/recipes/redis/build.sh
+++ b/release/artifacts/recipes/redis/build.sh
@@ -16,6 +16,8 @@ REDIS_DEPLOYMENT_TARGET=13.0
 [ -n "$PLATFORM" ] || die "PV_RECIPE_PLATFORM is required"
 
 need cargo
+need cat
+need codesign
 need curl
 need awk
 need lipo
@@ -151,6 +153,38 @@ validate_macho_binary() {
   validate_macho_runtime_paths "$binary"
 }
 
+sign_macho_binary() {
+  binary=$1
+  codesign --force --sign - "$binary"
+  codesign --verify "$binary"
+}
+
+append_redis_legal_file() {
+  source_path=$1
+  label=$2
+
+  [ -f "$source_path" ] || die "missing Redis third-party legal file: $source_path"
+  printf '\n%s\n' "==== $label ===="
+  cat "$source_path"
+}
+
+write_third_party_notices() {
+  output=$1
+
+  {
+    printf '%s\n' "Third-party notices for Redis $PV_UPSTREAM_VERSION"
+    printf '%s\n' "Generated from legal files bundled in the Redis source archive."
+    append_redis_legal_file "$source_dir/deps/hiredis/COPYING" "deps/hiredis/COPYING"
+    append_redis_legal_file "$source_dir/deps/lua/COPYRIGHT" "deps/lua/COPYRIGHT"
+    append_redis_legal_file "$source_dir/deps/hdr_histogram/LICENSE.txt" "deps/hdr_histogram/LICENSE.txt"
+    append_redis_legal_file "$source_dir/deps/hdr_histogram/COPYING.txt" "deps/hdr_histogram/COPYING.txt"
+    append_redis_legal_file "$source_dir/deps/fpconv/LICENSE.txt" "deps/fpconv/LICENSE.txt"
+    append_redis_legal_file "$source_dir/deps/fast_float/README.md" "deps/fast_float/README.md"
+    append_redis_legal_file "$source_dir/deps/linenoise/README.markdown" "deps/linenoise/README.markdown"
+    append_redis_legal_file "$source_dir/deps/jemalloc/COPYING" "deps/jemalloc/COPYING"
+  } >"$output"
+}
+
 recipe_dir="$ROOT/release/artifacts/recipes/redis"
 env_file="$OUT_DIR/work/redis.env"
 mkdir -p "$(dirname "$env_file")"
@@ -167,9 +201,11 @@ work_dir="$OUT_DIR/work/$artifact_basename"
 source_archive="$OUT_DIR/sources/redis-$PV_UPSTREAM_VERSION.tar.gz"
 source_dir="$work_dir/source"
 root_dir="$work_dir/$artifact_basename"
-archive="$OUT_DIR/$artifact_basename.tar.gz"
+final_archive="$OUT_DIR/$artifact_basename.tar.gz"
+staged_archive="$work_dir/staged-archives/$artifact_basename.tar.gz"
 object_key=$(artifact_object_key redis "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
-record=$(artifact_record_path "$RECORD_DIR" redis "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+final_record=$(artifact_record_path "$RECORD_DIR" redis "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+staged_record="$work_dir/staged-records/redis/$PV_TRACK/$PV_ARTIFACT_VERSION/$PV_PLATFORM/$artifact_basename.json"
 
 rm -rf "$work_dir"
 mkdir -p "$OUT_DIR/sources" "$source_dir" "$root_dir/bin"
@@ -184,10 +220,17 @@ validate_macho_binary "$source_dir/src/redis-server"
 validate_macho_binary "$source_dir/src/redis-cli"
 cp "$source_dir/src/redis-server" "$root_dir/bin/redis-server"
 cp "$source_dir/src/redis-cli" "$root_dir/bin/redis-cli"
+sign_macho_binary "$root_dir/bin/redis-server"
+sign_macho_binary "$root_dir/bin/redis-cli"
 cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
 cp "$recipe_dir/NOTICE" "$root_dir/NOTICE"
-COPYFILE_DISABLE=1 tar -czf "$archive" -C "$work_dir" "$artifact_basename"
+write_third_party_notices "$root_dir/THIRD-PARTY-NOTICES"
+mkdir -p "$(dirname "$staged_archive")"
+COPYFILE_DISABLE=1 tar -czf "$staged_archive" -C "$work_dir" "$artifact_basename"
 
-write_record "$record" redis "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/redis/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
-cargo run -p pv-release -- validate-archive --archive "$archive" --record "$record" --smoke-hook "$recipe_dir/smoke.sh"
-printf '%s\n' "$archive"
+write_record "$staged_record" redis "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$staged_archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/redis/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION" --license-file LICENSE --notice-file NOTICE --notice-file THIRD-PARTY-NOTICES
+cargo run -p pv-release -- validate-archive --archive "$staged_archive" --record "$staged_record" --smoke-hook "$recipe_dir/smoke.sh"
+mkdir -p "$(dirname "$final_archive")" "$(dirname "$final_record")"
+mv "$staged_archive" "$final_archive"
+mv "$staged_record" "$final_record"
+printf '%s\n' "$final_archive"

--- a/release/artifacts/recipes/redis/build.sh
+++ b/release/artifacts/recipes/redis/build.sh
@@ -1,0 +1,193 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/../../../.." && pwd)
+# shellcheck source=/dev/null
+. "$ROOT/release/artifacts/recipes/common.sh"
+
+OUT_DIR=${PV_ARTIFACT_OUT_DIR:-"$ROOT/release/artifacts/out"}
+RECORD_DIR=${PV_ARTIFACT_RECORD_DIR:-"$ROOT/release/artifacts/records"}
+TRACK=${PV_RECIPE_TRACK:-8.2}
+PLATFORM=${PV_RECIPE_PLATFORM:-}
+PV_COMMIT=${PV_COMMIT:-}
+BUILD_RUN_ID=${PV_BUILD_RUN_ID:-local-redis}
+REDIS_DEPLOYMENT_TARGET=13.0
+
+[ -n "$PLATFORM" ] || die "PV_RECIPE_PLATFORM is required"
+
+need cargo
+need curl
+need awk
+need lipo
+need make
+need otool
+need shasum
+need sysctl
+need tar
+need uname
+
+if [ -z "$PV_COMMIT" ]; then
+  need git
+  PV_COMMIT=$(git -C "$ROOT" rev-parse HEAD)
+fi
+
+case "$PLATFORM:$(uname -s):$(uname -m)" in
+  darwin-arm64:Darwin:arm64 | darwin-amd64:Darwin:x86_64) ;;
+  *) die "Redis artifacts must be built on a native runner for $PLATFORM" ;;
+esac
+
+export MACOSX_DEPLOYMENT_TARGET="$REDIS_DEPLOYMENT_TARGET"
+
+expected_arch_for_platform() {
+  case "$1" in
+    darwin-arm64) printf '%s\n' arm64 ;;
+    darwin-amd64) printf '%s\n' x86_64 ;;
+    *) die "unsupported native Redis artifact platform: $1" ;;
+  esac
+}
+
+macho_minimum_os() {
+  otool -l "$1" | awk '
+    $1 == "cmd" && $2 == "LC_BUILD_VERSION" {
+      in_build_version = 1
+      in_version_min = 0
+      next
+    }
+    $1 == "cmd" && $2 == "LC_VERSION_MIN_MACOSX" {
+      in_build_version = 0
+      in_version_min = 1
+      next
+    }
+    $1 == "cmd" {
+      in_build_version = 0
+      in_version_min = 0
+      next
+    }
+    in_build_version && $1 == "minos" {
+      print $2
+      exit
+    }
+    in_version_min && $1 == "version" {
+      print $2
+      exit
+    }
+  '
+}
+
+version_lte() {
+  actual_version=$1
+  maximum_version=$2
+  awk -v actual="$actual_version" -v maximum="$maximum_version" '
+    BEGIN {
+      split(actual, actual_parts, ".")
+      split(maximum, maximum_parts, ".")
+      for (part_index = 1; part_index <= 3; part_index++) {
+        actual_part = actual_parts[part_index] == "" ? 0 : actual_parts[part_index] + 0
+        maximum_part = maximum_parts[part_index] == "" ? 0 : maximum_parts[part_index] + 0
+        if (actual_part < maximum_part) {
+          exit 0
+        }
+        if (actual_part > maximum_part) {
+          exit 1
+        }
+      }
+      exit 0
+    }
+  '
+}
+
+reject_unmanaged_macho_runtime_path() {
+  binary=$1
+  metadata_kind=$2
+  runtime_path=$3
+
+  case "$runtime_path" in
+    /usr/lib/* | /System/Library/* | @rpath/* | @loader_path/* | @executable_path/*)
+      ;;
+    *) die "$binary Mach-O $metadata_kind references unmanaged runtime path $runtime_path" ;;
+  esac
+}
+
+macho_rpaths() {
+  otool -l "$1" | awk '
+    $1 == "cmd" && $2 == "LC_RPATH" {
+      in_rpath = 1
+      next
+    }
+    $1 == "cmd" {
+      in_rpath = 0
+      next
+    }
+    in_rpath && $1 == "path" {
+      print $2
+      in_rpath = 0
+      next
+    }
+  '
+}
+
+validate_macho_runtime_paths() {
+  binary=$1
+  linked_libraries=$(otool -L "$binary")
+  printf '%s\n' "$linked_libraries" | awk 'NR > 1 && NF > 0 { print $1 }' | while IFS= read -r linked_library; do
+    reject_unmanaged_macho_runtime_path "$binary" "linked library" "$linked_library"
+  done
+
+  macho_rpaths "$binary" | while IFS= read -r macho_rpath; do
+    reject_unmanaged_macho_runtime_path "$binary" "rpath" "$macho_rpath"
+  done
+}
+
+validate_macho_binary() {
+  binary=$1
+  expected_arch=$(expected_arch_for_platform "$PV_PLATFORM")
+  binary_archs=$(lipo -archs "$binary")
+  [ "$binary_archs" = "$expected_arch" ] || die "$binary Mach-O architecture $binary_archs does not match expected $expected_arch for $PV_PLATFORM"
+
+  binary_minos=$(macho_minimum_os "$binary")
+  [ -n "$binary_minos" ] || die "$binary Mach-O minimum macOS version not found"
+  version_lte "$binary_minos" "$REDIS_DEPLOYMENT_TARGET" || die "$binary Mach-O minimum macOS $binary_minos is newer than deployment target $REDIS_DEPLOYMENT_TARGET"
+
+  validate_macho_runtime_paths "$binary"
+}
+
+recipe_dir="$ROOT/release/artifacts/recipes/redis"
+env_file="$OUT_DIR/work/redis.env"
+mkdir -p "$(dirname "$env_file")"
+cargo run -p pv-release -- print-recipe-env \
+  --redis "$recipe_dir/recipe.toml" \
+  --resource redis \
+  --track "$TRACK" \
+  --platform "$PLATFORM" >"$env_file"
+# shellcheck source=/dev/null
+. "$env_file"
+
+artifact_basename=$(artifact_basename redis "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+work_dir="$OUT_DIR/work/$artifact_basename"
+source_archive="$OUT_DIR/sources/redis-$PV_UPSTREAM_VERSION.tar.gz"
+source_dir="$work_dir/source"
+root_dir="$work_dir/$artifact_basename"
+archive="$OUT_DIR/$artifact_basename.tar.gz"
+object_key=$(artifact_object_key redis "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+record=$(artifact_record_path "$RECORD_DIR" redis "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+
+rm -rf "$work_dir"
+mkdir -p "$OUT_DIR/sources" "$source_dir" "$root_dir/bin"
+curl -L --fail --show-error --silent \
+  --retry 3 --retry-delay 2 --retry-all-errors \
+  --connect-timeout 20 --max-time 600 \
+  "$PV_SOURCE_URL" -o "$source_archive"
+require_sha256 "$source_archive" "$PV_SOURCE_SHA256"
+tar -xzf "$source_archive" -C "$source_dir" --strip-components 1
+make -C "$source_dir" BUILD_TLS=no -j"$(sysctl -n hw.ncpu)"
+validate_macho_binary "$source_dir/src/redis-server"
+validate_macho_binary "$source_dir/src/redis-cli"
+cp "$source_dir/src/redis-server" "$root_dir/bin/redis-server"
+cp "$source_dir/src/redis-cli" "$root_dir/bin/redis-cli"
+cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
+cp "$recipe_dir/NOTICE" "$root_dir/NOTICE"
+COPYFILE_DISABLE=1 tar -czf "$archive" -C "$work_dir" "$artifact_basename"
+
+write_record "$record" redis "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/redis/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
+cargo run -p pv-release -- validate-archive --archive "$archive" --record "$record" --smoke-hook "$recipe_dir/smoke.sh"
+printf '%s\n' "$archive"

--- a/release/artifacts/recipes/redis/recipe.toml
+++ b/release/artifacts/recipes/redis/recipe.toml
@@ -1,0 +1,17 @@
+[recipe]
+resources = ["redis"]
+default_track = "8.2"
+platforms = ["darwin-arm64", "darwin-amd64"]
+minimum_pv_version = "0.1.0"
+pv_build_revision = "pv1"
+license_files = ["LICENSE"]
+notice_files = ["NOTICE"]
+
+[artifact]
+payload_paths = ["bin/redis-server", "bin/redis-cli"]
+
+[[tracks]]
+name = "8.2"
+upstream_version = "8.2.7"
+source_url = "https://download.redis.io/releases/redis-8.2.7.tar.gz"
+source_sha256 = "afaae66030c193b06720a714ba7a558136b82689027536e0e24f53908c18cbe9"

--- a/release/artifacts/recipes/redis/recipe.toml
+++ b/release/artifacts/recipes/redis/recipe.toml
@@ -5,7 +5,7 @@ platforms = ["darwin-arm64", "darwin-amd64"]
 minimum_pv_version = "0.1.0"
 pv_build_revision = "pv1"
 license_files = ["LICENSE"]
-notice_files = ["NOTICE"]
+notice_files = ["NOTICE", "THIRD-PARTY-NOTICES"]
 
 [artifact]
 payload_paths = ["bin/redis-server", "bin/redis-cli"]

--- a/release/artifacts/recipes/redis/smoke.sh
+++ b/release/artifacts/recipes/redis/smoke.sh
@@ -5,6 +5,7 @@ artifact_root=$1
 redis_server="$artifact_root/bin/redis-server"
 redis_cli="$artifact_root/bin/redis-cli"
 pid=
+log_file=
 
 need() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -23,11 +24,24 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
 PY
 }
 
+print_server_log() {
+  if [ -n "$log_file" ] && [ -s "$log_file" ]; then
+    printf '%s\n' "redis-server output:" >&2
+    sed 's/^/  /' "$log_file" >&2
+  fi
+}
+
 # Invoked by the EXIT trap below.
 # shellcheck disable=SC2329
 cleanup() {
   if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
-    "$redis_cli" -h 127.0.0.1 -p "$port" shutdown nosave >/dev/null 2>&1 || true
+    if ! "$redis_cli" -h 127.0.0.1 -p "$port" shutdown nosave >/dev/null 2>&1; then
+      kill "$pid" 2>/dev/null || true
+      sleep 0.1
+      if kill -0 "$pid" 2>/dev/null; then
+        kill -KILL "$pid" 2>/dev/null || true
+      fi
+    fi
     wait "$pid" 2>/dev/null || true
   fi
   rm -rf "$data_dir"
@@ -44,8 +58,11 @@ cleanup() {
 
 need mktemp
 need python3
+need sed
+need sleep
 
 data_dir=$(mktemp -d "${TMPDIR:-/tmp}/pv-redis-smoke.XXXXXX")
+log_file="$data_dir/redis-server.log"
 port=$(available_port)
 trap cleanup 0
 
@@ -55,7 +72,7 @@ trap cleanup 0
   --dir "$data_dir" \
   --save "" \
   --appendonly no \
-  --daemonize no >/dev/null 2>&1 &
+  --daemonize no >"$log_file" 2>&1 &
 pid=$!
 
 for _ in 1 2 3 4 5 6 7 8 9 10; do
@@ -66,8 +83,16 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
     pid=
     exit 0
   fi
+  if ! kill -0 "$pid" 2>/dev/null; then
+    printf '%s\n' "Redis smoke failed: redis-server exited before accepting connections" >&2
+    print_server_log
+    wait "$pid" 2>/dev/null || true
+    pid=
+    exit 43
+  fi
   sleep 1
 done
 
 printf '%s\n' "Redis smoke failed: redis-cli ping did not return PONG" >&2
+print_server_log
 exit 43

--- a/release/artifacts/recipes/redis/smoke.sh
+++ b/release/artifacts/recipes/redis/smoke.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -eu
+
+artifact_root=$1
+redis_server="$artifact_root/bin/redis-server"
+redis_cli="$artifact_root/bin/redis-cli"
+pid=
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf '%s\n' "missing required command: $1" >&2
+    exit 42
+  }
+}
+
+available_port() {
+  python3 - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+}
+
+# Invoked by the EXIT trap below.
+# shellcheck disable=SC2329
+cleanup() {
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    "$redis_cli" -h 127.0.0.1 -p "$port" shutdown nosave >/dev/null 2>&1 || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  rm -rf "$data_dir"
+}
+
+[ -x "$redis_server" ] || {
+  printf '%s\n' "missing executable bin/redis-server in $artifact_root" >&2
+  exit 42
+}
+[ -x "$redis_cli" ] || {
+  printf '%s\n' "missing executable bin/redis-cli in $artifact_root" >&2
+  exit 42
+}
+
+need mktemp
+need python3
+
+data_dir=$(mktemp -d "${TMPDIR:-/tmp}/pv-redis-smoke.XXXXXX")
+port=$(available_port)
+trap cleanup 0
+
+"$redis_server" \
+  --bind 127.0.0.1 \
+  --port "$port" \
+  --dir "$data_dir" \
+  --save "" \
+  --appendonly no \
+  --daemonize no >/dev/null 2>&1 &
+pid=$!
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if response=$("$redis_cli" -h 127.0.0.1 -p "$port" ping 2>/dev/null) &&
+    [ "$response" = "PONG" ]; then
+    "$redis_cli" -h 127.0.0.1 -p "$port" shutdown nosave >/dev/null
+    wait "$pid"
+    pid=
+    exit 0
+  fi
+  sleep 1
+done
+
+printf '%s\n' "Redis smoke failed: redis-cli ping did not return PONG" >&2
+exit 43


### PR DESCRIPTION
## Summary
- Adds the Redis backing artifact recipe for default track `8.2`.
- Builds, packages, records, and smoke-validates Redis artifacts for the native macOS recipe matrix.
- Adds Redis metadata, legal files, fixture coverage, and default-track integration.

## Stack
2/5. Base: `feat/pr25-publication-foundation-stack`. Next: `feat/pr25-mailpit-rustfs-recipes-stack`.

## Test Plan
- `cargo nextest run -p pv-release --locked` (90/90 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all --check`
- `actionlint .github/workflows/artifact-publication.yml .github/workflows/artifact-recipes.yml .github/workflows/ci.yml`
- `shellcheck release/artifacts/recipes/common.sh release/artifacts/recipes/php/*.sh release/artifacts/recipes/composer/*.sh release/artifacts/recipes/redis/*.sh release/artifacts/recipes/mysql/*.sh release/artifacts/recipes/postgres/*.sh release/artifacts/recipes/mailpit/*.sh release/artifacts/recipes/rustfs/*.sh`
- `git diff --check`
- no pending `.snap.new`; no conflict markers

## Remaining Release Evidence
Draft until native Artifact Recipes and R2 publication verification are recorded under Solo todo 72.