### PR TITLE
feat(release): add Mailpit and RustFS artifact recipes

### DIFF
--- a/.github/workflows/artifact-recipes.yml
+++ b/.github/workflows/artifact-recipes.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       resource:
-        description: "Resource to build: all, php, composer, redis"
+        description: "Resource to build: all, php, composer, redis, mailpit, rustfs"
         required: true
         default: "all"
         type: choice
@@ -13,8 +13,10 @@ on:
           - php
           - composer
           - redis
+          - mailpit
+          - rustfs
       track:
-        description: "Track to build: all, 8.2, 8.3, 8.4, 2"
+        description: "Track to build: all, 8.2, 8.3, 8.4, 2, 1"
         required: true
         default: "all"
         type: string
@@ -56,6 +58,8 @@ jobs:
             php:all | php:8.2 | php:8.3 | php:8.4) ;;
             composer:all | composer:2) ;;
             redis:all | redis:8.2) ;;
+            mailpit:all | mailpit:1) ;;
+            rustfs:all | rustfs:1) ;;
             *)
               printf '%s\n' "unsupported resource/track combination: $PV_RECIPE_RESOURCE/$PV_RECIPE_TRACK" >&2
               exit 1
@@ -104,6 +108,8 @@ jobs:
             --php release/artifacts/recipes/php/tracks.toml \
             --composer release/artifacts/recipes/composer/composer.toml \
             --redis release/artifacts/recipes/redis/recipe.toml \
+            --mailpit release/artifacts/recipes/mailpit/recipe.toml \
+            --rustfs release/artifacts/recipes/rustfs/recipe.toml \
             --archives "$fixtures_dir/archives" \
             --records "$fixtures_dir/records" \
             --pv-commit "$(git rev-parse HEAD)" \
@@ -133,11 +139,15 @@ jobs:
           build_php_family=false
           build_composer=false
           build_redis=false
+          build_mailpit=false
+          build_rustfs=false
           case "$PV_RECIPE_RESOURCE" in
             all)
               build_php_family=true
               build_composer=true
               build_redis=true
+              build_mailpit=true
+              build_rustfs=true
               ;;
             php)
               build_php_family=true
@@ -147,6 +157,12 @@ jobs:
               ;;
             redis)
               build_redis=true
+              ;;
+            mailpit)
+              build_mailpit=true
+              ;;
+            rustfs)
+              build_rustfs=true
               ;;
           esac
 
@@ -181,6 +197,16 @@ jobs:
           if [ "$build_redis" = true ]; then
             PV_RECIPE_TRACK=8.2 \
               release/artifacts/recipes/redis/build.sh
+          fi
+
+          if [ "$build_mailpit" = true ]; then
+            PV_RECIPE_TRACK=1 \
+              release/artifacts/recipes/mailpit/build.sh
+          fi
+
+          if [ "$build_rustfs" = true ]; then
+            PV_RECIPE_TRACK=1 \
+              release/artifacts/recipes/rustfs/build.sh
           fi
 
           rm -rf "$PV_ARTIFACT_OUT_DIR/sources" "$PV_ARTIFACT_OUT_DIR/work"
@@ -218,6 +244,8 @@ jobs:
               write_default_track frankenphp "$php_default_track"
               write_default_track composer 2
               write_default_track redis 8.2
+              write_default_track mailpit 1
+              write_default_track rustfs 1
               ;;
             php)
               write_default_track php "$php_default_track"
@@ -228,6 +256,12 @@ jobs:
               ;;
             redis)
               write_default_track redis 8.2
+              ;;
+            mailpit)
+              write_default_track mailpit 1
+              ;;
+            rustfs)
+              write_default_track rustfs 1
               ;;
           esac
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: cargo shear
 
       - name: Check artifact recipe scripts
-        run: shellcheck release/artifacts/recipes/common.sh release/artifacts/recipes/php/*.sh release/artifacts/recipes/composer/*.sh release/artifacts/recipes/redis/*.sh
+        run: shellcheck release/artifacts/recipes/common.sh release/artifacts/recipes/php/*.sh release/artifacts/recipes/composer/*.sh release/artifacts/recipes/redis/*.sh release/artifacts/recipes/mailpit/*.sh release/artifacts/recipes/rustfs/*.sh
 
       - name: Validate artifact recipe metadata and fixtures
         run: |
@@ -49,6 +49,8 @@ jobs:
             --php release/artifacts/recipes/php/tracks.toml \
             --composer release/artifacts/recipes/composer/composer.toml \
             --redis release/artifacts/recipes/redis/recipe.toml \
+            --mailpit release/artifacts/recipes/mailpit/recipe.toml \
+            --rustfs release/artifacts/recipes/rustfs/recipe.toml \
             --archives /tmp/pv-recipe-fixtures/archives \
             --records /tmp/pv-recipe-fixtures/records \
             --pv-commit "$(git rev-parse HEAD)" \

--- a/crates/pv-release/src/cli.rs
+++ b/crates/pv-release/src/cli.rs
@@ -271,11 +271,13 @@ pub fn run() -> anyhow::Result<()> {
             platform,
         } => {
             let env = print_recipe_env(
-                php.as_deref(),
-                composer.as_deref(),
-                redis.as_deref(),
-                mailpit.as_deref(),
-                rustfs.as_deref(),
+                RecipeEnvPaths {
+                    php: php.as_deref(),
+                    composer: composer.as_deref(),
+                    redis: redis.as_deref(),
+                    mailpit: mailpit.as_deref(),
+                    rustfs: rustfs.as_deref(),
+                },
                 &resource,
                 &track,
                 &platform,
@@ -286,6 +288,15 @@ pub fn run() -> anyhow::Result<()> {
                 .context("failed to write recipe environment to stdout")
         }
     }
+}
+
+#[derive(Default)]
+struct RecipeEnvPaths<'a> {
+    php: Option<&'a Utf8Path>,
+    composer: Option<&'a Utf8Path>,
+    redis: Option<&'a Utf8Path>,
+    mailpit: Option<&'a Utf8Path>,
+    rustfs: Option<&'a Utf8Path>,
 }
 
 fn parse_source_inputs(values: &[String]) -> anyhow::Result<Vec<SourceInputRequest>> {
@@ -341,16 +352,18 @@ fn backing_recipe_paths(
 }
 
 fn print_recipe_env(
-    php: Option<&Utf8Path>,
-    composer: Option<&Utf8Path>,
-    redis: Option<&Utf8Path>,
-    mailpit: Option<&Utf8Path>,
-    rustfs: Option<&Utf8Path>,
+    paths: RecipeEnvPaths<'_>,
     resource: &str,
     track: &str,
     platform: &str,
 ) -> anyhow::Result<String> {
-    match (php, composer, redis, mailpit, rustfs) {
+    match (
+        paths.php,
+        paths.composer,
+        paths.redis,
+        paths.mailpit,
+        paths.rustfs,
+    ) {
         (Some(php), None, None, None, None) => {
             let context = format!("failed to print PHP recipe environment for `{php}`");
             crate::recipe::php_recipe_env(php, resource, track, platform).context(context)
@@ -1085,16 +1098,16 @@ mod tests {
         let mailpit = Utf8Path::new("release/artifacts/recipes/mailpit/recipe.toml");
 
         assert!(
-            print_recipe_env(None, None, None, None, None, "php", "8.4", "darwin-arm64").is_err(),
+            print_recipe_env(RecipeEnvPaths::default(), "php", "8.4", "darwin-arm64").is_err(),
             "missing metadata path must be rejected"
         );
         assert!(
             print_recipe_env(
-                Some(php),
-                Some(composer),
-                None,
-                None,
-                None,
+                RecipeEnvPaths {
+                    php: Some(php),
+                    composer: Some(composer),
+                    ..RecipeEnvPaths::default()
+                },
                 "php",
                 "8.4",
                 "darwin-arm64"
@@ -1104,11 +1117,11 @@ mod tests {
         );
         assert!(
             print_recipe_env(
-                Some(php),
-                None,
-                Some(redis),
-                None,
-                None,
+                RecipeEnvPaths {
+                    php: Some(php),
+                    redis: Some(redis),
+                    ..RecipeEnvPaths::default()
+                },
                 "redis",
                 "8.2",
                 "darwin-arm64"
@@ -1118,11 +1131,11 @@ mod tests {
         );
         assert!(
             print_recipe_env(
-                None,
-                None,
-                Some(redis),
-                Some(mailpit),
-                None,
+                RecipeEnvPaths {
+                    redis: Some(redis),
+                    mailpit: Some(mailpit),
+                    ..RecipeEnvPaths::default()
+                },
                 "redis",
                 "8.2",
                 "darwin-arm64"

--- a/crates/pv-release/src/cli.rs
+++ b/crates/pv-release/src/cli.rs
@@ -131,6 +131,10 @@ enum Command {
         #[arg(long)]
         redis: Option<Utf8PathBuf>,
         #[arg(long)]
+        mailpit: Option<Utf8PathBuf>,
+        #[arg(long)]
+        rustfs: Option<Utf8PathBuf>,
+        #[arg(long)]
         resource: String,
         #[arg(long)]
         track: String,
@@ -260,6 +264,8 @@ pub fn run() -> anyhow::Result<()> {
             php,
             composer,
             redis,
+            mailpit,
+            rustfs,
             resource,
             track,
             platform,
@@ -268,6 +274,8 @@ pub fn run() -> anyhow::Result<()> {
                 php.as_deref(),
                 composer.as_deref(),
                 redis.as_deref(),
+                mailpit.as_deref(),
+                rustfs.as_deref(),
                 &resource,
                 &track,
                 &platform,
@@ -336,20 +344,22 @@ fn print_recipe_env(
     php: Option<&Utf8Path>,
     composer: Option<&Utf8Path>,
     redis: Option<&Utf8Path>,
+    mailpit: Option<&Utf8Path>,
+    rustfs: Option<&Utf8Path>,
     resource: &str,
     track: &str,
     platform: &str,
 ) -> anyhow::Result<String> {
-    match (php, composer, redis) {
-        (Some(php), None, None) => {
+    match (php, composer, redis, mailpit, rustfs) {
+        (Some(php), None, None, None, None) => {
             let context = format!("failed to print PHP recipe environment for `{php}`");
             crate::recipe::php_recipe_env(php, resource, track, platform).context(context)
         }
-        (None, Some(composer), None) => {
+        (None, Some(composer), None, None, None) => {
             let context = format!("failed to print Composer recipe environment for `{composer}`");
             crate::recipe::composer_recipe_env(composer, resource, track, platform).context(context)
         }
-        (None, None, Some(redis)) => {
+        (None, None, Some(redis), None, None) => {
             let context = format!("failed to print Redis recipe environment for `{redis}`");
             crate::recipe::backing_recipe_env(
                 redis,
@@ -360,9 +370,29 @@ fn print_recipe_env(
             )
             .context(context)
         }
-        _ => {
-            anyhow::bail!("print-recipe-env requires exactly one of --php, --composer, or --redis")
+        (None, None, None, Some(mailpit), None) => {
+            let context = format!("failed to print Mailpit recipe environment for `{mailpit}`");
+            crate::recipe::backing_recipe_env(
+                mailpit,
+                BackingRecipeKind::Mailpit,
+                resource,
+                track,
+                platform,
+            )
+            .context(context)
         }
+        (None, None, None, None, Some(rustfs)) => {
+            let context = format!("failed to print RustFS recipe environment for `{rustfs}`");
+            crate::recipe::backing_recipe_env(
+                rustfs,
+                BackingRecipeKind::Rustfs,
+                resource,
+                track,
+                platform,
+            )
+            .context(context)
+        }
+        _ => anyhow::bail!("print-recipe-env requires exactly one recipe metadata path"),
     }
 }
 
@@ -842,6 +872,8 @@ mod tests {
                 php,
                 composer,
                 redis,
+                mailpit,
+                rustfs,
                 resource,
                 track,
                 platform,
@@ -854,6 +886,8 @@ mod tests {
                     ))
                 );
                 assert_eq!(redis, None);
+                assert_eq!(mailpit, None);
+                assert_eq!(rustfs, None);
                 assert_eq!(resource, "composer");
                 assert_eq!(track, "2");
                 assert_eq!(platform, "any");
@@ -883,6 +917,8 @@ mod tests {
                 php,
                 composer,
                 redis,
+                mailpit,
+                rustfs,
                 resource,
                 track,
                 platform,
@@ -895,6 +931,8 @@ mod tests {
                 );
                 assert_eq!(composer, None);
                 assert_eq!(redis, None);
+                assert_eq!(mailpit, None);
+                assert_eq!(rustfs, None);
                 assert_eq!(resource, "php");
                 assert_eq!(track, "8.4");
                 assert_eq!(platform, "darwin-arm64");
@@ -924,6 +962,8 @@ mod tests {
                 php,
                 composer,
                 redis,
+                mailpit,
+                rustfs,
                 resource,
                 track,
                 platform,
@@ -936,8 +976,100 @@ mod tests {
                         "release/artifacts/recipes/redis/recipe.toml"
                     ))
                 );
+                assert_eq!(mailpit, None);
+                assert_eq!(rustfs, None);
                 assert_eq!(resource, "redis");
                 assert_eq!(track, "8.2");
+                assert_eq!(platform, "darwin-arm64");
+                Ok(())
+            }
+            command => bail!("parsed unexpected command: {command:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_print_recipe_env_mailpit_arguments() -> anyhow::Result<()> {
+        let args = Args::try_parse_from([
+            "pv-release",
+            "print-recipe-env",
+            "--mailpit",
+            "release/artifacts/recipes/mailpit/recipe.toml",
+            "--resource",
+            "mailpit",
+            "--track",
+            "1",
+            "--platform",
+            "darwin-arm64",
+        ])?;
+
+        match args.command {
+            Command::PrintRecipeEnv {
+                php,
+                composer,
+                redis,
+                mailpit,
+                rustfs,
+                resource,
+                track,
+                platform,
+            } => {
+                assert_eq!(php, None);
+                assert_eq!(composer, None);
+                assert_eq!(redis, None);
+                assert_eq!(
+                    mailpit,
+                    Some(Utf8PathBuf::from(
+                        "release/artifacts/recipes/mailpit/recipe.toml"
+                    ))
+                );
+                assert_eq!(rustfs, None);
+                assert_eq!(resource, "mailpit");
+                assert_eq!(track, "1");
+                assert_eq!(platform, "darwin-arm64");
+                Ok(())
+            }
+            command => bail!("parsed unexpected command: {command:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_print_recipe_env_rustfs_arguments() -> anyhow::Result<()> {
+        let args = Args::try_parse_from([
+            "pv-release",
+            "print-recipe-env",
+            "--rustfs",
+            "release/artifacts/recipes/rustfs/recipe.toml",
+            "--resource",
+            "rustfs",
+            "--track",
+            "1",
+            "--platform",
+            "darwin-arm64",
+        ])?;
+
+        match args.command {
+            Command::PrintRecipeEnv {
+                php,
+                composer,
+                redis,
+                mailpit,
+                rustfs,
+                resource,
+                track,
+                platform,
+            } => {
+                assert_eq!(php, None);
+                assert_eq!(composer, None);
+                assert_eq!(redis, None);
+                assert_eq!(mailpit, None);
+                assert_eq!(
+                    rustfs,
+                    Some(Utf8PathBuf::from(
+                        "release/artifacts/recipes/rustfs/recipe.toml"
+                    ))
+                );
+                assert_eq!(resource, "rustfs");
+                assert_eq!(track, "1");
                 assert_eq!(platform, "darwin-arm64");
                 Ok(())
             }
@@ -950,15 +1082,18 @@ mod tests {
         let php = Utf8Path::new("release/artifacts/recipes/php/tracks.toml");
         let composer = Utf8Path::new("release/artifacts/recipes/composer/composer.toml");
         let redis = Utf8Path::new("release/artifacts/recipes/redis/recipe.toml");
+        let mailpit = Utf8Path::new("release/artifacts/recipes/mailpit/recipe.toml");
 
         assert!(
-            print_recipe_env(None, None, None, "php", "8.4", "darwin-arm64").is_err(),
+            print_recipe_env(None, None, None, None, None, "php", "8.4", "darwin-arm64").is_err(),
             "missing metadata path must be rejected"
         );
         assert!(
             print_recipe_env(
                 Some(php),
                 Some(composer),
+                None,
+                None,
                 None,
                 "php",
                 "8.4",
@@ -968,7 +1103,31 @@ mod tests {
             "multiple metadata paths must be rejected"
         );
         assert!(
-            print_recipe_env(Some(php), None, Some(redis), "redis", "8.2", "darwin-arm64").is_err(),
+            print_recipe_env(
+                Some(php),
+                None,
+                Some(redis),
+                None,
+                None,
+                "redis",
+                "8.2",
+                "darwin-arm64"
+            )
+            .is_err(),
+            "multiple metadata paths must be rejected"
+        );
+        assert!(
+            print_recipe_env(
+                None,
+                None,
+                Some(redis),
+                Some(mailpit),
+                None,
+                "redis",
+                "8.2",
+                "darwin-arm64"
+            )
+            .is_err(),
             "multiple metadata paths must be rejected"
         );
     }

--- a/crates/pv-release/src/fixture.rs
+++ b/crates/pv-release/src/fixture.rs
@@ -216,6 +216,7 @@ fn write_backing_fixture(
         .iter()
         .map(String::as_str)
         .collect::<Vec<_>>();
+    let source = track.source_for_platform(recipe.path(), platform)?;
     let artifact = FixtureArtifact {
         resource: recipe.resource().as_str(),
         track: track.name().as_str(),
@@ -223,8 +224,8 @@ fn write_backing_fixture(
         pv_build_revision,
         platform,
         payload_paths,
-        source_url: track.source_url(),
-        source_sha256: track.source_sha256().as_str(),
+        source_url: source.source_url(),
+        source_sha256: source.source_sha256().as_str(),
         source_inputs: Vec::new(),
         recipe: &recipe_path,
         minimum_pv_version: recipe.minimum_pv_version().as_str(),

--- a/crates/pv-release/src/recipe.rs
+++ b/crates/pv-release/src/recipe.rs
@@ -389,14 +389,6 @@ impl BackingTrack {
         &self.upstream_version
     }
 
-    pub fn source_url(&self) -> &str {
-        &self.sources[0].source_url
-    }
-
-    pub fn source_sha256(&self) -> &Sha256Digest {
-        &self.sources[0].source_sha256
-    }
-
     pub fn source_for_platform(
         &self,
         path: &Utf8Path,

--- a/crates/pv-release/src/recipe.rs
+++ b/crates/pv-release/src/recipe.rs
@@ -71,6 +71,12 @@ pub struct BackingArtifact {
 pub struct BackingTrack {
     name: TrackName,
     upstream_version: String,
+    sources: Vec<BackingSource>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BackingSource {
+    platform: Option<ArtifactPlatform>,
     source_url: String,
     source_sha256: Sha256Digest,
 }
@@ -224,6 +230,16 @@ struct RawBackingArtifact {
 struct RawBackingTrack {
     name: String,
     upstream_version: String,
+    source_url: Option<String>,
+    source_sha256: Option<String>,
+    #[serde(default)]
+    sources: Vec<RawBackingSource>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawBackingSource {
+    platform: String,
     source_url: String,
     source_sha256: String,
 }
@@ -333,7 +349,7 @@ impl BackingRecipe {
         )?;
 
         let artifact = BackingArtifact::from_raw(path, raw.artifact)?;
-        let tracks = parse_backing_tracks(path, raw.tracks)?;
+        let tracks = parse_backing_tracks(path, &header.platforms, raw.tracks)?;
         validate_default_track_exists(
             path,
             &header.default_track,
@@ -374,6 +390,55 @@ impl BackingTrack {
     }
 
     pub fn source_url(&self) -> &str {
+        &self.sources[0].source_url
+    }
+
+    pub fn source_sha256(&self) -> &Sha256Digest {
+        &self.sources[0].source_sha256
+    }
+
+    pub fn source_for_platform(
+        &self,
+        path: &Utf8Path,
+        platform: ArtifactPlatform,
+    ) -> crate::Result<&BackingSource> {
+        self.sources
+            .iter()
+            .find(|source| match source.platform {
+                Some(candidate) => candidate == platform,
+                None => true,
+            })
+            .ok_or_else(|| {
+                invalid(
+                    path,
+                    format!(
+                        "backing recipe track `{}` has no source for platform `{platform}`",
+                        self.name
+                    ),
+                )
+            })
+    }
+
+    fn from_raw(
+        path: &Utf8Path,
+        name: TrackName,
+        platforms: &[ArtifactPlatform],
+        raw: RawBackingTrack,
+    ) -> crate::Result<Self> {
+        let upstream_version =
+            require_non_empty(path, "upstream_version", &raw.upstream_version)?.to_string();
+        let sources = parse_backing_sources(path, platforms, raw)?;
+
+        Ok(Self {
+            name,
+            upstream_version,
+            sources,
+        })
+    }
+}
+
+impl BackingSource {
+    pub fn source_url(&self) -> &str {
         &self.source_url
     }
 
@@ -381,18 +446,24 @@ impl BackingTrack {
         &self.source_sha256
     }
 
-    fn from_raw(path: &Utf8Path, name: TrackName, raw: RawBackingTrack) -> crate::Result<Self> {
-        let upstream_version =
-            require_non_empty(path, "upstream_version", &raw.upstream_version)?.to_string();
-        let source_url = parse_https_url(path, "source_url", raw.source_url)?;
-        let source_sha256 = Sha256Digest::new(raw.source_sha256)
-            .map_err(|error| invalid_identity(path, "source_sha256", error))?;
-
+    fn common(path: &Utf8Path, source_url: String, source_sha256: String) -> crate::Result<Self> {
         Ok(Self {
-            name,
-            upstream_version,
-            source_url,
-            source_sha256,
+            platform: None,
+            source_url: parse_https_url(path, "source_url", source_url)?,
+            source_sha256: Sha256Digest::new(source_sha256)
+                .map_err(|error| invalid_identity(path, "source_sha256", error))?,
+        })
+    }
+
+    fn platform_specific(path: &Utf8Path, raw: RawBackingSource) -> crate::Result<Self> {
+        Ok(Self {
+            platform: Some(
+                ArtifactPlatform::new(&raw.platform)
+                    .map_err(|error| invalid_identity(path, "sources.platform", error))?,
+            ),
+            source_url: parse_https_url(path, "sources.source_url", raw.source_url)?,
+            source_sha256: Sha256Digest::new(raw.source_sha256)
+                .map_err(|error| invalid_identity(path, "sources.source_sha256", error))?,
         })
     }
 }
@@ -702,28 +773,38 @@ impl ComposerTrack {
     }
 }
 
-pub fn composer_recipe_env(
-    composer: &Utf8Path,
+pub fn backing_recipe_env(
+    recipe: &Utf8Path,
+    kind: BackingRecipeKind,
     resource: &str,
     track: &str,
     platform: &str,
 ) -> crate::Result<String> {
-    let recipe = ComposerRecipe::load(composer)?;
-    validate_composer_recipe_request(&recipe, resource, track, platform)?;
+    let recipe = BackingRecipe::load(recipe, kind)?;
+    let track = validate_backing_recipe_track(&recipe, track)?;
+    let platform = validate_backing_recipe_platform(&recipe, platform)?;
+    validate_request_value(
+        recipe.path(),
+        kind.recipe_kind(),
+        "resource",
+        resource,
+        recipe.resource().as_str(),
+    )?;
 
-    let upstream_version = recipe.upstream_version();
+    let source = track.source_for_platform(recipe.path(), platform)?;
+    let upstream_version = track.upstream_version();
     let pv_build_revision = recipe.pv_build_revision();
     let artifact_version = format!("{upstream_version}-{pv_build_revision}");
-    let source_url = recipe.source_url();
-    let source_sha256 = recipe.source_sha256().as_str();
+    let source_url = source.source_url();
+    let source_sha256 = source.source_sha256().as_str();
     let minimum_pv_version = recipe.minimum_pv_version().as_str();
 
     shell_assignments(
         recipe.path(),
         &[
-            ("PV_RESOURCE", "resource", "composer"),
-            ("PV_TRACK", "track", "2"),
-            ("PV_PLATFORM", "platform", "any"),
+            ("PV_RESOURCE", "resource", recipe.resource().as_str()),
+            ("PV_TRACK", "track", track.name().as_str()),
+            ("PV_PLATFORM", "platform", platform.as_str()),
             ("PV_UPSTREAM_VERSION", "upstream_version", upstream_version),
             (
                 "PV_ARTIFACT_VERSION",
@@ -746,31 +827,28 @@ pub fn composer_recipe_env(
     )
 }
 
-pub fn backing_recipe_env(
-    backing: &Utf8Path,
-    kind: BackingRecipeKind,
+pub fn composer_recipe_env(
+    composer: &Utf8Path,
     resource: &str,
     track: &str,
     platform: &str,
 ) -> crate::Result<String> {
-    let recipe = BackingRecipe::load(backing, kind)?;
-    validate_backing_recipe_resource(&recipe, resource)?;
-    let track = validate_backing_recipe_track(&recipe, track)?;
-    let platform = validate_backing_recipe_platform(&recipe, platform)?;
+    let recipe = ComposerRecipe::load(composer)?;
+    validate_composer_recipe_request(&recipe, resource, track, platform)?;
 
-    let upstream_version = track.upstream_version();
+    let upstream_version = recipe.upstream_version();
     let pv_build_revision = recipe.pv_build_revision();
     let artifact_version = format!("{upstream_version}-{pv_build_revision}");
-    let source_url = track.source_url();
-    let source_sha256 = track.source_sha256().as_str();
+    let source_url = recipe.source_url();
+    let source_sha256 = recipe.source_sha256().as_str();
     let minimum_pv_version = recipe.minimum_pv_version().as_str();
 
     shell_assignments(
         recipe.path(),
         &[
-            ("PV_RESOURCE", "resource", recipe.resource().as_str()),
-            ("PV_TRACK", "track", track.name().as_str()),
-            ("PV_PLATFORM", "platform", platform.as_str()),
+            ("PV_RESOURCE", "resource", "composer"),
+            ("PV_TRACK", "track", "2"),
+            ("PV_PLATFORM", "platform", "any"),
             ("PV_UPSTREAM_VERSION", "upstream_version", upstream_version),
             (
                 "PV_ARTIFACT_VERSION",
@@ -1023,16 +1101,6 @@ fn validate_composer_recipe_request(
     )
 }
 
-fn validate_backing_recipe_resource(recipe: &BackingRecipe, resource: &str) -> crate::Result<()> {
-    validate_request_value(
-        recipe.path(),
-        recipe.kind().recipe_kind(),
-        "resource",
-        resource,
-        recipe.resource().as_str(),
-    )
-}
-
 fn validate_backing_recipe_track<'a>(
     recipe: &'a BackingRecipe,
     track: &str,
@@ -1165,6 +1233,7 @@ fn parse_php_tracks(path: &Utf8Path, values: Vec<RawPhpTrack>) -> crate::Result<
 
 fn parse_backing_tracks(
     path: &Utf8Path,
+    platforms: &[ArtifactPlatform],
     values: Vec<RawBackingTrack>,
 ) -> crate::Result<Vec<BackingTrack>> {
     let mut names = Vec::with_capacity(values.len());
@@ -1180,11 +1249,71 @@ fn parse_backing_tracks(
 
     let mut tracks = Vec::with_capacity(values.len());
     for (name, value) in names.into_iter().zip(values) {
-        let track = BackingTrack::from_raw(path, name, value)?;
+        let track = BackingTrack::from_raw(path, name, platforms, value)?;
         tracks.push(track);
     }
 
     Ok(tracks)
+}
+
+fn parse_backing_sources(
+    path: &Utf8Path,
+    platforms: &[ArtifactPlatform],
+    raw: RawBackingTrack,
+) -> crate::Result<Vec<BackingSource>> {
+    match (raw.source_url, raw.source_sha256, raw.sources.is_empty()) {
+        (Some(source_url), Some(source_sha256), true) => Ok(vec![BackingSource::common(
+            path,
+            source_url,
+            source_sha256,
+        )?]),
+        (None, None, false) => {
+            let mut sources = Vec::with_capacity(raw.sources.len());
+            let mut seen = BTreeSet::new();
+            for raw_source in raw.sources {
+                let source = BackingSource::platform_specific(path, raw_source)?;
+                let Some(platform) = source.platform else {
+                    return Err(invalid(path, "backing source platform is required"));
+                };
+                if !platforms.contains(&platform) {
+                    return Err(invalid(
+                        path,
+                        format!("sources.platform `{platform}` is not listed in recipe.platforms"),
+                    ));
+                }
+                if !seen.insert(platform) {
+                    return Err(invalid(
+                        path,
+                        format!("duplicate source for platform `{platform}`"),
+                    ));
+                }
+                sources.push(source);
+            }
+
+            for platform in platforms {
+                if !seen.contains(platform) {
+                    return Err(invalid(
+                        path,
+                        format!("missing source for platform `{platform}`"),
+                    ));
+                }
+            }
+
+            Ok(sources)
+        }
+        (Some(_), None, _) | (None, Some(_), _) => Err(invalid(
+            path,
+            "source_url and source_sha256 must be provided together",
+        )),
+        (Some(_), Some(_), false) => Err(invalid(
+            path,
+            "track-level source_url/source_sha256 cannot be combined with sources",
+        )),
+        (None, None, true) => Err(invalid(
+            path,
+            "backing recipe track must define source_url/source_sha256 or sources",
+        )),
+    }
 }
 
 fn validate_exact_resources(

--- a/crates/pv-release/tests/recipe_fixtures.rs
+++ b/crates/pv-release/tests/recipe_fixtures.rs
@@ -44,6 +44,8 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest() -> Result
     let php = workspace_root.join("release/artifacts/recipes/php/tracks.toml");
     let composer = workspace_root.join("release/artifacts/recipes/composer/composer.toml");
     let redis = workspace_root.join("release/artifacts/recipes/redis/recipe.toml");
+    let mailpit = workspace_root.join("release/artifacts/recipes/mailpit/recipe.toml");
+    let rustfs = workspace_root.join("release/artifacts/recipes/rustfs/recipe.toml");
     let defaults = workspace_root.join("release/artifacts/default-tracks.toml");
 
     create_dir_all(&revocations)?;
@@ -55,7 +57,11 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest() -> Result
     generate_recipe_fixtures_with_backing(
         &php,
         &composer,
-        &[(BackingRecipeKind::Redis, redis.clone())],
+        &[
+            (BackingRecipeKind::Redis, redis.clone()),
+            (BackingRecipeKind::Mailpit, mailpit),
+            (BackingRecipeKind::Rustfs, rustfs),
+        ],
         &archives,
         &records,
         "0123456789abcdef0123456789abcdef01234567",
@@ -102,6 +108,18 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest() -> Result
                 "darwin-arm64",
                 "frankenphp-8.4.20-frankenphp1.12.3-pv1-darwin-arm64",
             ),
+            ArchiveRoot::new(
+                "mailpit",
+                "1",
+                "darwin-amd64",
+                "mailpit-1.30.1-pv1-darwin-amd64",
+            ),
+            ArchiveRoot::new(
+                "mailpit",
+                "1",
+                "darwin-arm64",
+                "mailpit-1.30.1-pv1-darwin-arm64",
+            ),
             ArchiveRoot::new("php", "8.2", "darwin-amd64", "php-8.2.31-pv1-darwin-amd64"),
             ArchiveRoot::new("php", "8.2", "darwin-arm64", "php-8.2.31-pv1-darwin-arm64"),
             ArchiveRoot::new("php", "8.3", "darwin-amd64", "php-8.3.31-pv1-darwin-amd64"),
@@ -119,6 +137,18 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest() -> Result
                 "8.2",
                 "darwin-arm64",
                 &format!("redis-{redis_upstream_version}-pv1-darwin-arm64"),
+            ),
+            ArchiveRoot::new(
+                "rustfs",
+                "1",
+                "darwin-amd64",
+                "rustfs-1.0.0-beta.7-pv1-darwin-amd64",
+            ),
+            ArchiveRoot::new(
+                "rustfs",
+                "1",
+                "darwin-arm64",
+                "rustfs-1.0.0-beta.7-pv1-darwin-arm64",
             ),
         ],
     );
@@ -148,6 +178,8 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest_with_backin
     let manifest = tempdir.path().join("manifest.json");
     let php = workspace_root.join("release/artifacts/recipes/php/tracks.toml");
     let composer = workspace_root.join("release/artifacts/recipes/composer/composer.toml");
+    let mailpit = workspace_root.join("release/artifacts/recipes/mailpit/recipe.toml");
+    let rustfs = workspace_root.join("release/artifacts/recipes/rustfs/recipe.toml");
     let defaults = workspace_root.join("release/artifacts/default-tracks.toml");
     let redis = tempdir
         .path()
@@ -158,7 +190,11 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest_with_backin
     generate_recipe_fixtures_with_backing(
         &php,
         &composer,
-        &[(BackingRecipeKind::Redis, redis.clone())],
+        &[
+            (BackingRecipeKind::Redis, redis.clone()),
+            (BackingRecipeKind::Mailpit, mailpit),
+            (BackingRecipeKind::Rustfs, rustfs),
+        ],
         &archives,
         &records,
         "0123456789abcdef0123456789abcdef01234567",
@@ -168,6 +204,55 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest_with_backin
     let mut backing_summaries = load_release_records(&records)?
         .iter()
         .filter(|record| record.resource().as_str() == "redis")
+        .map(|record| backing_fixture_summary(&archives, &records, record))
+        .collect::<Result<Vec<_>>>()?;
+    backing_summaries.sort();
+    assert_debug_snapshot!(backing_summaries);
+
+    generate_manifest_file_with_defaults(
+        &records,
+        &revocations,
+        Some(&defaults),
+        &manifest,
+        "https://artifacts.example.test",
+    )?;
+    let manifest_json = read_to_string(&manifest)?;
+    ArtifactManifest::parse(&manifest_json)?;
+
+    Ok(())
+}
+
+#[test]
+fn recipe_fixture_generation_validates_committed_mailpit_and_rustfs_recipes() -> Result<()> {
+    let workspace_root = Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let tempdir = tempdir()?;
+    let archives = tempdir.path().join("archives");
+    let records = tempdir.path().join("records");
+    let revocations = tempdir.path().join("revocations");
+    let manifest = tempdir.path().join("manifest.json");
+    let php = workspace_root.join("release/artifacts/recipes/php/tracks.toml");
+    let composer = workspace_root.join("release/artifacts/recipes/composer/composer.toml");
+    let mailpit = workspace_root.join("release/artifacts/recipes/mailpit/recipe.toml");
+    let rustfs = workspace_root.join("release/artifacts/recipes/rustfs/recipe.toml");
+    let defaults = workspace_root.join("release/artifacts/default-tracks.toml");
+
+    create_dir_all(&revocations)?;
+    generate_recipe_fixtures_with_backing(
+        &php,
+        &composer,
+        &[
+            (BackingRecipeKind::Mailpit, mailpit),
+            (BackingRecipeKind::Rustfs, rustfs),
+        ],
+        &archives,
+        &records,
+        "0123456789abcdef0123456789abcdef01234567",
+        "local-test",
+    )?;
+
+    let mut backing_summaries = load_release_records(&records)?
+        .iter()
+        .filter(|record| matches!(record.resource().as_str(), "mailpit" | "rustfs"))
         .map(|record| backing_fixture_summary(&archives, &records, record))
         .collect::<Result<Vec<_>>>()?;
     backing_summaries.sort();

--- a/crates/pv-release/tests/recipe_fixtures.rs
+++ b/crates/pv-release/tests/recipe_fixtures.rs
@@ -234,9 +234,10 @@ fn recipe_fixture_generation_validates_committed_mailpit_and_rustfs_recipes() ->
     let composer = workspace_root.join("release/artifacts/recipes/composer/composer.toml");
     let mailpit = workspace_root.join("release/artifacts/recipes/mailpit/recipe.toml");
     let rustfs = workspace_root.join("release/artifacts/recipes/rustfs/recipe.toml");
-    let defaults = workspace_root.join("release/artifacts/default-tracks.toml");
+    let defaults = tempdir.path().join("default-tracks.toml");
 
     create_dir_all(&revocations)?;
+    write_file(&defaults, MAILPIT_RUSTFS_FIXTURE_DEFAULTS)?;
     generate_recipe_fixtures_with_backing(
         &php,
         &composer,
@@ -418,4 +419,26 @@ name = "8.2"
 upstream_version = "8.2.1"
 source_url = "https://download.redis.io/releases/redis-8.2.1.tar.gz"
 source_sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+"#;
+
+const MAILPIT_RUSTFS_FIXTURE_DEFAULTS: &str = r#"
+[[resource]]
+name = "php"
+default_track = "8.4"
+
+[[resource]]
+name = "frankenphp"
+default_track = "8.4"
+
+[[resource]]
+name = "composer"
+default_track = "2"
+
+[[resource]]
+name = "mailpit"
+default_track = "1"
+
+[[resource]]
+name = "rustfs"
+default_track = "1"
 "#;

--- a/crates/pv-release/tests/recipe_metadata.rs
+++ b/crates/pv-release/tests/recipe_metadata.rs
@@ -8,7 +8,7 @@ use pv_release::recipe::{
     BackingRecipe, BackingRecipeKind, ComposerRecipe, PhpRecipe, backing_recipe_env,
     composer_recipe_env, php_recipe_env,
 };
-use resources::ResourceName;
+use resources::{ArtifactPlatform, ResourceName};
 
 #[test]
 fn recipe_metadata_parses_php_tracks_and_composer() -> Result<()> {
@@ -31,6 +31,22 @@ fn backing_recipe_metadata_parses_common_shape() -> Result<()> {
         BackingRecipeKind::Redis,
         VALID_REDIS_TOML,
     )?;
+    let track_sources = recipe
+        .tracks()
+        .iter()
+        .map(|track| {
+            let source = track.source_for_platform(
+                Utf8Path::new("redis/recipe.toml"),
+                ArtifactPlatform::DarwinArm64,
+            )?;
+            Ok((
+                track.name().as_str(),
+                track.upstream_version(),
+                source.source_url(),
+                source.source_sha256().as_str(),
+            ))
+        })
+        .collect::<pv_release::Result<Vec<_>>>()?;
 
     assert_debug_snapshot!((
         recipe.kind(),
@@ -41,16 +57,7 @@ fn backing_recipe_metadata_parses_common_shape() -> Result<()> {
             .iter()
             .map(|platform| platform.as_str())
             .collect::<Vec<_>>(),
-        recipe
-            .tracks()
-            .iter()
-            .map(|track| (
-                track.name().as_str(),
-                track.upstream_version(),
-                track.source_url(),
-                track.source_sha256().as_str(),
-            ))
-            .collect::<Vec<_>>(),
+        track_sources,
         recipe.payload_paths(),
     ));
 
@@ -144,6 +151,23 @@ fn backing_recipe_metadata_rejects_invalid_shapes() -> Result<()> {
         "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "bad",
     );
+    let missing_platform_source = VALID_MAILPIT_TOML.replace(
+        r#"
+[[tracks.sources]]
+platform = "darwin-amd64"
+source_url = "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-amd64.tar.gz"
+source_sha256 = "a2d7df1b34967e51604b42136260789b75a45233a03c9dc773b98024e1390974"
+"#,
+        "",
+    );
+    let duplicate_platform_source =
+        VALID_MAILPIT_TOML.replace("platform = \"darwin-amd64\"", "platform = \"darwin-arm64\"");
+    let unsupported_platform_source =
+        VALID_MAILPIT_TOML.replace("platform = \"darwin-amd64\"", "platform = \"any\"");
+    let mixed_common_and_platform_sources = VALID_MAILPIT_TOML.replace(
+        "upstream_version = \"1.30.1\"\n\n[[tracks.sources]]",
+        "upstream_version = \"1.30.1\"\nsource_url = \"https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-arm64.tar.gz\"\nsource_sha256 = \"1cce392a19a6093fcc859aeb87d9999671fed9a0a7a1c227a7f7df6307741be2\"\n\n[[tracks.sources]]",
+    );
 
     assert_debug_snapshot!((
         BackingRecipe::from_toml(
@@ -180,6 +204,26 @@ fn backing_recipe_metadata_rejects_invalid_shapes() -> Result<()> {
             Utf8Path::new("bad-source-sha256.toml"),
             BackingRecipeKind::Redis,
             &bad_source_sha256,
+        ),
+        BackingRecipe::from_toml(
+            Utf8Path::new("missing-platform-source.toml"),
+            BackingRecipeKind::Mailpit,
+            &missing_platform_source,
+        ),
+        BackingRecipe::from_toml(
+            Utf8Path::new("duplicate-platform-source.toml"),
+            BackingRecipeKind::Mailpit,
+            &duplicate_platform_source,
+        ),
+        BackingRecipe::from_toml(
+            Utf8Path::new("unsupported-platform-source.toml"),
+            BackingRecipeKind::Mailpit,
+            &unsupported_platform_source,
+        ),
+        BackingRecipe::from_toml(
+            Utf8Path::new("mixed-common-and-platform-sources.toml"),
+            BackingRecipeKind::Mailpit,
+            &mixed_common_and_platform_sources,
         ),
     ));
 
@@ -395,6 +439,23 @@ fn print_backing_recipe_env_mailpit() -> Result<()> {
         "mailpit",
         "1",
         "darwin-arm64",
+    )?;
+
+    assert_snapshot!(env);
+    Ok(())
+}
+
+#[test]
+fn print_backing_recipe_env_rustfs() -> Result<()> {
+    let workspace_root = Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let rustfs = workspace_root.join("release/artifacts/recipes/rustfs/recipe.toml");
+
+    let env = backing_recipe_env(
+        &rustfs,
+        BackingRecipeKind::Rustfs,
+        "rustfs",
+        "1",
+        "darwin-amd64",
     )?;
 
     assert_snapshot!(env);

--- a/crates/pv-release/tests/recipe_metadata.rs
+++ b/crates/pv-release/tests/recipe_metadata.rs
@@ -86,6 +86,14 @@ fn committed_recipe_metadata_parses() -> Result<()> {
         &workspace_root.join("release/artifacts/recipes/redis/recipe.toml"),
         BackingRecipeKind::Redis,
     )?;
+    let mailpit = BackingRecipe::load(
+        &workspace_root.join("release/artifacts/recipes/mailpit/recipe.toml"),
+        BackingRecipeKind::Mailpit,
+    )?;
+    let rustfs = BackingRecipe::load(
+        &workspace_root.join("release/artifacts/recipes/rustfs/recipe.toml"),
+        BackingRecipeKind::Rustfs,
+    )?;
     let defaults =
         ManifestDefaults::load(&workspace_root.join("release/artifacts/default-tracks.toml"))?;
 
@@ -96,10 +104,16 @@ fn committed_recipe_metadata_parses() -> Result<()> {
     assert_eq!(redis.default_track().as_str(), "8.2");
     assert_eq!(redis.tracks().len(), 1);
     assert_eq!(redis.payload_paths(), ["bin/redis-server", "bin/redis-cli"]);
+    assert_eq!(mailpit.default_track().as_str(), "1");
+    assert_eq!(mailpit.payload_paths(), ["bin/mailpit"]);
+    assert_eq!(rustfs.default_track().as_str(), "1");
+    assert_eq!(rustfs.payload_paths(), ["bin/rustfs"]);
     assert_default_track(&defaults, "php", "8.4")?;
     assert_default_track(&defaults, "frankenphp", "8.4")?;
     assert_default_track(&defaults, "composer", "2")?;
     assert_default_track(&defaults, "redis", "8.2")?;
+    assert_default_track(&defaults, "mailpit", "1")?;
+    assert_default_track(&defaults, "rustfs", "1")?;
 
     Ok(())
 }
@@ -370,6 +384,24 @@ fn print_recipe_env_redis() -> Result<()> {
 }
 
 #[test]
+fn print_backing_recipe_env_mailpit() -> Result<()> {
+    let tempdir = tempdir()?;
+    let mailpit = tempdir.path().join("recipe.toml");
+    write_file(&mailpit, VALID_MAILPIT_TOML)?;
+
+    let env = backing_recipe_env(
+        &mailpit,
+        BackingRecipeKind::Mailpit,
+        "mailpit",
+        "1",
+        "darwin-arm64",
+    )?;
+
+    assert_snapshot!(env);
+    Ok(())
+}
+
+#[test]
 fn print_composer_recipe_env_quotes_shell_values() -> Result<()> {
     let tempdir = tempdir()?;
     let composer = tempdir.path().join("composer.toml");
@@ -498,4 +530,32 @@ name = "8.2"
 upstream_version = "8.2.1"
 source_url = "https://download.redis.io/releases/redis-8.2.1.tar.gz"
 source_sha256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+"#;
+
+const VALID_MAILPIT_TOML: &str = r#"
+[recipe]
+resources = ["mailpit"]
+default_track = "1"
+platforms = ["darwin-arm64", "darwin-amd64"]
+minimum_pv_version = "0.1.0"
+pv_build_revision = "pv1"
+license_files = ["LICENSE"]
+notice_files = ["NOTICE"]
+
+[artifact]
+payload_paths = ["bin/mailpit"]
+
+[[tracks]]
+name = "1"
+upstream_version = "1.30.1"
+
+[[tracks.sources]]
+platform = "darwin-arm64"
+source_url = "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-arm64.tar.gz"
+source_sha256 = "1cce392a19a6093fcc859aeb87d9999671fed9a0a7a1c227a7f7df6307741be2"
+
+[[tracks.sources]]
+platform = "darwin-amd64"
+source_url = "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-amd64.tar.gz"
+source_sha256 = "a2d7df1b34967e51604b42136260789b75a45233a03c9dc773b98024e1390974"
 "#;

--- a/crates/pv-release/tests/smoke.rs
+++ b/crates/pv-release/tests/smoke.rs
@@ -550,8 +550,231 @@ exit 72
         command_output_debug(&output)
     );
     assert!(
-        started.elapsed() < Duration::from_secs(4),
+        started.elapsed() < Duration::from_secs(5),
         "Redis smoke should kill the server instead of waiting for it to exit"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mailpit_smoke_rejects_prefix_version_match() -> Result<()> {
+    let tempdir = tempdir()?;
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+    let command_bin = tempdir.path().join("commands");
+
+    create_dir_all(&artifact_bin)?;
+    create_dir_all(&command_bin)?;
+    write_fake_mailpit(&artifact_bin.join("mailpit"))?;
+    write_fake_success_curl(&command_bin.join("curl"))?;
+
+    let output = StdCommand::new(mailpit_smoke_hook())
+        .arg(&artifact_root)
+        .env(
+            "PATH",
+            format!("{command_bin}:/usr/bin:/bin:/usr/sbin:/sbin"),
+        )
+        .env("PV_TEST_MAILPIT_VERSION_OUTPUT", "Mailpit v1.30.10")
+        .env("PV_UPSTREAM_VERSION", "1.30.1")
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "Mailpit smoke should reject prefix version matches: {}",
+        command_output_debug(&output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("Mailpit version mismatch"),
+        "Mailpit smoke should report the exact version mismatch: {}",
+        command_output_debug(&output)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mailpit_smoke_fails_when_server_does_not_stop() -> Result<()> {
+    let tempdir = tempdir()?;
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+    let command_bin = tempdir.path().join("commands");
+
+    create_dir_all(&artifact_bin)?;
+    create_dir_all(&command_bin)?;
+    write_fake_mailpit(&artifact_bin.join("mailpit"))?;
+    write_fake_success_curl(&command_bin.join("curl"))?;
+
+    let started = Instant::now();
+    let output = StdCommand::new(mailpit_smoke_hook())
+        .arg(&artifact_root)
+        .env(
+            "PATH",
+            format!("{command_bin}:/usr/bin:/bin:/usr/sbin:/sbin"),
+        )
+        .env("PV_TEST_MAILPIT_IGNORE_TERM", "1")
+        .env("PV_TEST_MAILPIT_SLEEP_SECONDS", "3")
+        .env("PV_TEST_MAILPIT_VERSION_OUTPUT", "Mailpit v1.30.1")
+        .env("PV_UPSTREAM_VERSION", "1.30.1")
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "Mailpit smoke should fail when the server ignores shutdown: {}",
+        command_output_debug(&output)
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(3),
+        "Mailpit smoke should use a bounded shutdown wait"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rustfs_smoke_rejects_prefix_version_match() -> Result<()> {
+    let tempdir = tempdir()?;
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+
+    create_dir_all(&artifact_bin)?;
+    write_fake_rustfs(&artifact_bin.join("rustfs"))?;
+
+    let output = StdCommand::new(rustfs_smoke_hook())
+        .arg(&artifact_root)
+        .env("PV_TEST_RUSTFS_VERSION_OUTPUT", "rustfs 1.0.0-beta.70")
+        .env("PV_UPSTREAM_VERSION", "1.0.0-beta.7")
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "RustFS smoke should reject prefix version matches: {}",
+        command_output_debug(&output)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("RustFS version mismatch"),
+        "RustFS smoke should report the exact version mismatch: {}",
+        command_output_debug(&output)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rustfs_smoke_uses_explicit_loopback_console_port() -> Result<()> {
+    let tempdir = tempdir()?;
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+    let rustfs_log = tempdir.path().join("rustfs.log");
+
+    create_dir_all(&artifact_bin)?;
+    write_fake_rustfs(&artifact_bin.join("rustfs"))?;
+    write_file(&rustfs_log, "")?;
+
+    let output = StdCommand::new(rustfs_smoke_hook())
+        .arg(&artifact_root)
+        .env("PV_TEST_RUSTFS_LOG", &rustfs_log)
+        .env("PV_TEST_RUSTFS_REQUIRE_CONSOLE_ADDRESS", "1")
+        .env("PV_TEST_RUSTFS_VERSION_OUTPUT", "rustfs 1.0.0-beta.7")
+        .env("PV_UPSTREAM_VERSION", "1.0.0-beta.7")
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "RustFS smoke should pass an explicit loopback console port: {}",
+        command_output_debug(&output)
+    );
+    let rustfs_log = read_file(&rustfs_log)?;
+    assert!(
+        rustfs_log.contains("console=127.0.0.1:"),
+        "RustFS smoke should not leave the console on the default wildcard listener: {rustfs_log}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rustfs_smoke_fails_when_server_does_not_stop() -> Result<()> {
+    let tempdir = tempdir()?;
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+
+    create_dir_all(&artifact_bin)?;
+    write_fake_rustfs(&artifact_bin.join("rustfs"))?;
+
+    let started = Instant::now();
+    let output = StdCommand::new(rustfs_smoke_hook())
+        .arg(&artifact_root)
+        .env("PV_TEST_RUSTFS_IGNORE_TERM", "1")
+        .env("PV_TEST_RUSTFS_SLEEP_SECONDS", "3")
+        .env("PV_TEST_RUSTFS_VERSION_OUTPUT", "rustfs 1.0.0-beta.7")
+        .env("PV_UPSTREAM_VERSION", "1.0.0-beta.7")
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "RustFS smoke should fail when the server ignores shutdown: {}",
+        command_output_debug(&output)
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(3),
+        "RustFS smoke should use a bounded shutdown wait"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mailpit_build_recipe_rejects_unexpected_macho_architecture() -> Result<()> {
+    let run = run_mailpit_build_recipe_smoke(BackingBuildRecipeOptions {
+        lipo_archs: "x86_64",
+        ..default_backing_build_recipe_options()
+    })?;
+
+    assert!(
+        !run.output.status.success(),
+        "Mailpit build recipe unexpectedly succeeded: {}",
+        command_output_debug(&run.output)
+    );
+    assert!(
+        !run.archive_exists,
+        "Mailpit archive should not be written before Mach-O validation succeeds"
+    );
+    assert!(
+        run.record_json.is_none(),
+        "Mailpit record should not be written before Mach-O validation succeeds"
+    );
+    assert_eq!(
+        run.validate_log, "",
+        "archive validation should not run before Mach-O validation succeeds"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rustfs_build_recipe_rejects_newer_macho_minimum_os() -> Result<()> {
+    let run = run_rustfs_build_recipe_smoke(BackingBuildRecipeOptions {
+        macho_minos: "14.0",
+        ..default_backing_build_recipe_options()
+    })?;
+
+    assert!(
+        !run.output.status.success(),
+        "RustFS build recipe unexpectedly succeeded: {}",
+        command_output_debug(&run.output)
+    );
+    assert!(
+        !run.archive_exists,
+        "RustFS archive should not be written before Mach-O validation succeeds"
+    );
+    assert!(
+        run.record_json.is_none(),
+        "RustFS record should not be written before Mach-O validation succeeds"
+    );
+    assert_eq!(
+        run.validate_log, "",
+        "archive validation should not run before Mach-O validation succeeds"
     );
 
     Ok(())
@@ -785,6 +1008,13 @@ struct RedisBuildRecipeRun {
     archive_exists: bool,
 }
 
+struct BackingBuildRecipeRun {
+    output: Output,
+    record_json: Option<String>,
+    validate_log: String,
+    archive_exists: bool,
+}
+
 struct BuildRecipeOptions<'a> {
     lipo_archs: &'a str,
     macho_minos: &'a str,
@@ -799,6 +1029,13 @@ struct RedisBuildRecipeOptions {
     validate_archive_failure: bool,
 }
 
+struct BackingBuildRecipeOptions<'a> {
+    lipo_archs: &'a str,
+    macho_minos: &'a str,
+    macho_libraries: &'a str,
+    macho_rpaths: &'a str,
+}
+
 fn php_smoke_hook() -> camino::Utf8PathBuf {
     Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../release/artifacts/recipes/php/smoke.sh")
 }
@@ -810,6 +1047,16 @@ fn composer_smoke_hook() -> camino::Utf8PathBuf {
 
 fn redis_smoke_hook() -> camino::Utf8PathBuf {
     Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../release/artifacts/recipes/redis/smoke.sh")
+}
+
+fn mailpit_smoke_hook() -> camino::Utf8PathBuf {
+    Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../release/artifacts/recipes/mailpit/smoke.sh")
+}
+
+fn rustfs_smoke_hook() -> camino::Utf8PathBuf {
+    Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../release/artifacts/recipes/rustfs/smoke.sh")
 }
 
 fn run_php_build_recipe_smoke() -> Result<BuildRecipeRun> {
@@ -899,6 +1146,104 @@ fn run_redis_build_recipe_smoke(options: RedisBuildRecipeOptions) -> Result<Redi
         codesign_log: read_file(&codesign_log)?,
         archive_entries,
         archive_exists,
+    })
+}
+
+fn default_backing_build_recipe_options() -> BackingBuildRecipeOptions<'static> {
+    BackingBuildRecipeOptions {
+        lipo_archs: "arm64",
+        macho_minos: "13.0",
+        macho_libraries: "",
+        macho_rpaths: "",
+    }
+}
+
+fn run_mailpit_build_recipe_smoke(
+    options: BackingBuildRecipeOptions<'_>,
+) -> Result<BackingBuildRecipeRun> {
+    run_backing_build_recipe_smoke("mailpit", "1.30.1", "mailpit", "tar.gz", options)
+}
+
+fn run_rustfs_build_recipe_smoke(
+    options: BackingBuildRecipeOptions<'_>,
+) -> Result<BackingBuildRecipeRun> {
+    run_backing_build_recipe_smoke("rustfs", "1.0.0-beta.7", "rustfs", "zip", options)
+}
+
+fn run_backing_build_recipe_smoke(
+    resource: &str,
+    upstream_version: &str,
+    binary_name: &str,
+    source_extension: &str,
+    options: BackingBuildRecipeOptions<'_>,
+) -> Result<BackingBuildRecipeRun> {
+    let tempdir = tempdir()?;
+    let fake_bin = tempdir.path().join("bin");
+    let out_dir = tempdir.path().join("out");
+    let record_dir = tempdir.path().join("records");
+    let source_archive = tempdir
+        .path()
+        .join(format!("{resource}-source.{source_extension}"));
+    let curl_log = tempdir.path().join("curl.log");
+    let validate_log = tempdir.path().join("validate.log");
+    let codesign_log = tempdir.path().join("codesign.log");
+
+    create_dir_all(&fake_bin)?;
+    match source_extension {
+        "tar.gz" => write_single_binary_source_archive(&source_archive, binary_name)?,
+        "zip" => write_file(&source_archive, "zip fixture\n")?,
+        _ => anyhow::bail!("unsupported source extension: {source_extension}"),
+    }
+    write_fake_backing_cargo(&fake_bin.join("cargo"))?;
+    write_fake_curl(&fake_bin.join("curl"))?;
+    write_fake_lipo(&fake_bin.join("lipo"))?;
+    write_fake_otool(&fake_bin.join("otool"))?;
+    write_fake_codesign(&fake_bin.join("codesign"))?;
+    write_fake_unzip(&fake_bin.join("unzip"))?;
+    write_file(&curl_log, "")?;
+    write_file(&validate_log, "")?;
+    write_file(&codesign_log, "")?;
+
+    let build_script = Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join(format!(
+        "../../release/artifacts/recipes/{resource}/build.sh"
+    ));
+    let output = StdCommand::new(build_script)
+        .env("PATH", format!("{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"))
+        .env("PV_ARTIFACT_OUT_DIR", &out_dir)
+        .env("PV_ARTIFACT_RECORD_DIR", &record_dir)
+        .env("PV_BUILD_RUN_ID", "local-test")
+        .env("PV_COMMIT", "0123456789abcdef0123456789abcdef01234567")
+        .env("PV_RECIPE_PLATFORM", "darwin-arm64")
+        .env("PV_RECIPE_TRACK", "1")
+        .env("PV_TEST_BINARY_NAME", binary_name)
+        .env("PV_TEST_CURL_LOG", &curl_log)
+        .env("PV_TEST_CODESIGN_LOG", &codesign_log)
+        .env("PV_TEST_RESOURCE", resource)
+        .env("PV_TEST_SOURCE_ARCHIVE", &source_archive)
+        .env("PV_TEST_SOURCE_SHA256", file_sha256(&source_archive)?)
+        .env("PV_TEST_UPSTREAM_VERSION", upstream_version)
+        .env("PV_TEST_VALIDATE_LOG", &validate_log)
+        .env("PV_TEST_LIPO_ARCHS", options.lipo_archs)
+        .env("PV_TEST_MACHO_LIBRARIES", options.macho_libraries)
+        .env("PV_TEST_MACHO_MINOS", options.macho_minos)
+        .env("PV_TEST_MACHO_RPATHS", options.macho_rpaths)
+        .output()?;
+
+    let artifact_version = format!("{upstream_version}-pv1");
+    let artifact_basename = format!("{resource}-{artifact_version}-darwin-arm64");
+    let archive = out_dir.join(format!("{artifact_basename}.tar.gz"));
+    let record = record_dir
+        .join(resource)
+        .join("1")
+        .join(&artifact_version)
+        .join("darwin-arm64")
+        .join(format!("{artifact_basename}.json"));
+
+    Ok(BackingBuildRecipeRun {
+        output,
+        record_json: read_optional_file(&record)?,
+        validate_log: read_file(&validate_log)?,
+        archive_exists: path_exists(&archive),
     })
 }
 
@@ -1440,6 +1785,117 @@ fi
     )
 }
 
+fn write_fake_backing_cargo(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+if [ "$#" -ge 5 ] && [ "$1" = "run" ] && [ "$2" = "-p" ] && [ "$3" = "pv-release" ] && [ "$4" = "--" ]; then
+  case "$5" in
+    print-recipe-env)
+      cat <<EOF
+PV_RESOURCE=$PV_TEST_RESOURCE
+PV_TRACK=$PV_RECIPE_TRACK
+PV_PLATFORM=$PV_RECIPE_PLATFORM
+PV_UPSTREAM_VERSION=$PV_TEST_UPSTREAM_VERSION
+PV_ARTIFACT_VERSION=$PV_TEST_UPSTREAM_VERSION-pv1
+PV_SOURCE_URL=https://sources.example.test/$PV_TEST_RESOURCE
+PV_SOURCE_SHA256=$PV_TEST_SOURCE_SHA256
+PV_PV_BUILD_REVISION=pv1
+PV_MINIMUM_PV_VERSION=0.1.0
+EOF
+      ;;
+    write-release-record)
+      record=
+      object_key=
+      source_url=
+      source_sha256=
+      recipe=
+      pv_commit=
+      build_run_id=
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --record)
+            shift
+            record=${1:-}
+            ;;
+          --object-key)
+            shift
+            object_key=${1:-}
+            ;;
+          --source-url)
+            shift
+            source_url=${1:-}
+            ;;
+          --source-sha256)
+            shift
+            source_sha256=${1:-}
+            ;;
+          --recipe)
+            shift
+            recipe=${1:-}
+            ;;
+          --pv-commit)
+            shift
+            pv_commit=${1:-}
+            ;;
+          --build-run-id)
+            shift
+            build_run_id=${1:-}
+            ;;
+        esac
+        shift
+      done
+      mkdir -p "$(dirname "$record")"
+      cat >"$record" <<EOF
+{
+  "object_key": "$object_key",
+  "provenance": {
+    "source_url": "$source_url",
+    "source_sha256": "$source_sha256",
+    "recipe": "$recipe",
+    "pv_commit": "$pv_commit",
+    "build_run_id": "$build_run_id"
+  }
+}
+EOF
+      ;;
+    validate-archive)
+      archive=
+      record=
+      smoke_hook=
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --archive)
+            shift
+            archive=${1:-}
+            ;;
+          --record)
+            shift
+            record=${1:-}
+            ;;
+          --smoke-hook)
+            shift
+            smoke_hook=${1:-}
+            ;;
+        esac
+        shift
+      done
+      printf 'archive=%s record=%s smoke=%s\n' \
+        "${archive##*/}" \
+        "${record##*/}" \
+        "${smoke_hook##*/}" >>"$PV_TEST_VALIDATE_LOG"
+      ;;
+    *) exit 77 ;;
+  esac
+else
+  exit 77
+fi
+"#,
+    )
+}
+
 fn write_fake_composer_cargo(path: &Utf8Path) -> Result<()> {
     write_executable(
         path,
@@ -1588,6 +2044,167 @@ case "$url" in
     cp "$PV_TEST_SOURCE_ARCHIVE" "$output"
     ;;
 esac
+"#,
+    )
+}
+
+fn write_fake_success_curl(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+exit 0
+"#,
+    )
+}
+
+fn write_fake_mailpit(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+case "${1:-}" in
+  version)
+    printf '%s\n' "${PV_TEST_MAILPIT_VERSION_OUTPUT:-Mailpit v1.30.1}"
+    exit 0
+    ;;
+esac
+
+smtp=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --smtp)
+      shift
+      smtp=${1:-}
+      ;;
+  esac
+  shift
+done
+
+[ -n "$smtp" ] || exit 78
+smtp_port=${smtp##*:}
+export PV_TEST_MAILPIT_SMTP_PORT=$smtp_port
+exec python3 - <<'PY'
+import os
+import signal
+import socket
+import time
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", int(os.environ["PV_TEST_MAILPIT_SMTP_PORT"])))
+sock.listen(1)
+
+if os.environ.get("PV_TEST_MAILPIT_IGNORE_TERM"):
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+time.sleep(float(os.environ.get("PV_TEST_MAILPIT_SLEEP_SECONDS", "60")))
+PY
+"#,
+    )
+}
+
+fn write_fake_rustfs(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+case "${1:-}" in
+  --version)
+    printf '%s\n' "${PV_TEST_RUSTFS_VERSION_OUTPUT:-rustfs 1.0.0-beta.7}"
+    exit 0
+    ;;
+  server)
+    shift
+    ;;
+  *)
+    exit 78
+    ;;
+esac
+
+address=
+console_address=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --address)
+      shift
+      address=${1:-}
+      ;;
+    --console-address)
+      shift
+      console_address=${1:-}
+      ;;
+    --access-key | --secret-key)
+      shift
+      ;;
+  esac
+  shift
+done
+
+[ -n "$address" ] || exit 78
+if [ -n "${PV_TEST_RUSTFS_REQUIRE_CONSOLE_ADDRESS:-}" ]; then
+  case "$console_address" in
+    127.0.0.1:*) ;;
+    *) exit 73 ;;
+  esac
+fi
+if [ -n "${PV_TEST_RUSTFS_LOG:-}" ]; then
+  printf 'address=%s console=%s\n' "$address" "$console_address" >>"$PV_TEST_RUSTFS_LOG"
+fi
+
+export PV_TEST_RUSTFS_ADDRESS=$address
+export PV_TEST_RUSTFS_CONSOLE_ADDRESS=$console_address
+exec python3 - <<'PY'
+import http.server
+import os
+import signal
+import socket
+import threading
+import time
+
+bucket_names = set()
+
+def split_address(address):
+    host, port = address.rsplit(":", 1)
+    return host, int(port)
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = "\n".join(sorted(bucket_names)).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_PUT(self):
+        bucket_names.add(self.path.strip("/"))
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, _format, *_args):
+        pass
+
+api_host, api_port = split_address(os.environ["PV_TEST_RUSTFS_ADDRESS"])
+server = http.server.HTTPServer((api_host, api_port), Handler)
+threading.Thread(target=server.serve_forever, daemon=True).start()
+
+console_address = os.environ.get("PV_TEST_RUSTFS_CONSOLE_ADDRESS")
+console_socket = None
+if console_address:
+    console_host, console_port = split_address(console_address)
+    console_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    console_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    console_socket.bind((console_host, console_port))
+    console_socket.listen(1)
+
+if os.environ.get("PV_TEST_RUSTFS_IGNORE_TERM"):
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+
+time.sleep(float(os.environ.get("PV_TEST_RUSTFS_SLEEP_SECONDS", "60")))
+PY
 "#,
     )
 }
@@ -1758,6 +2375,30 @@ esac
     )
 }
 
+fn write_fake_unzip(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+destination=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -d)
+      shift
+      destination=${1:-}
+      ;;
+  esac
+  shift
+done
+
+[ -n "$destination" ] || exit 78
+mkdir -p "$destination"
+printf '%s\n' '#!/bin/sh' >"$destination/$PV_TEST_BINARY_NAME"
+"#,
+    )
+}
+
 #[expect(
     clippy::disallowed_types,
     reason = "release tooling tests create source tarball fixtures directly"
@@ -1773,6 +2414,21 @@ fn write_source_archive(path: &Utf8Path, top_level_dir: &str) -> Result<()> {
     header.set_mode(0o644);
     header.set_cksum();
     builder.append(&header, content as &[u8])?;
+
+    let encoder = builder.into_inner()?;
+    encoder.finish()?;
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "release tooling tests create source tarball fixtures directly"
+)]
+fn write_single_binary_source_archive(path: &Utf8Path, binary_name: &str) -> Result<()> {
+    let file = std::fs::File::create(path)?;
+    let encoder = GzEncoder::new(file, Compression::default());
+    let mut builder = Builder::new(encoder);
+    append_archive_file(&mut builder, binary_name, b"#!/bin/sh\n")?;
 
     let encoder = builder.into_inner()?;
     encoder.finish()?;

--- a/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_archives_records_and_manifest.snap
+++ b/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_archives_records_and_manifest.snap
@@ -230,6 +230,51 @@ expression: manifest_json
       ]
     },
     {
+      "name": "mailpit",
+      "default_track": "1",
+      "tracks": [
+        {
+          "name": "1",
+          "artifacts": [
+            {
+              "artifact_version": "1.30.1-pv1",
+              "upstream_version": "1.30.1",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-amd64",
+              "url": "https://artifacts.example.test/resources/mailpit/1/1.30.1-pv1/darwin-amd64/mailpit-1.30.1-pv1-darwin-amd64.tar.gz",
+              "sha256": "a7b6c28c03b048f9714dde22c4cc14363feb64701ea022e229dfdd9c74e742cd",
+              "size": 206,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-amd64.tar.gz",
+                "source_sha256": "a2d7df1b34967e51604b42136260789b75a45233a03c9dc773b98024e1390974",
+                "recipe": "release/artifacts/recipes/mailpit/recipe.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            },
+            {
+              "artifact_version": "1.30.1-pv1",
+              "upstream_version": "1.30.1",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-arm64",
+              "url": "https://artifacts.example.test/resources/mailpit/1/1.30.1-pv1/darwin-arm64/mailpit-1.30.1-pv1-darwin-arm64.tar.gz",
+              "sha256": "6af5a3450ef66fbadca29ffda5eedd46d7fcb56b71bb14d743162c8df9082317",
+              "size": 207,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-arm64.tar.gz",
+                "source_sha256": "1cce392a19a6093fcc859aeb87d9999671fed9a0a7a1c227a7f7df6307741be2",
+                "recipe": "release/artifacts/recipes/mailpit/recipe.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "php",
       "default_track": "8.4",
       "tracks": [
@@ -389,6 +434,51 @@ expression: manifest_json
                 "source_url": "https://download.redis.io/releases/redis-8.2.7.tar.gz",
                 "source_sha256": "afaae66030c193b06720a714ba7a558136b82689027536e0e24f53908c18cbe9",
                 "recipe": "release/artifacts/recipes/redis/recipe.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "rustfs",
+      "default_track": "1",
+      "tracks": [
+        {
+          "name": "1",
+          "artifacts": [
+            {
+              "artifact_version": "1.0.0-beta.7-pv1",
+              "upstream_version": "1.0.0-beta.7",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-amd64",
+              "url": "https://artifacts.example.test/resources/rustfs/1/1.0.0-beta.7-pv1/darwin-amd64/rustfs-1.0.0-beta.7-pv1-darwin-amd64.tar.gz",
+              "sha256": "b69111036ba23e7afdbb88f3705f6ed6242e63eaf4191e37cab1b596f53760de",
+              "size": 208,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://github.com/rustfs/rustfs/releases/download/1.0.0-beta.7/rustfs-macos-x86_64-v1.0.0-beta.7.zip",
+                "source_sha256": "b45cd47c3b3c903ab31b2b6d936be474d5ee64527a40271e7817dd6c961d5387",
+                "recipe": "release/artifacts/recipes/rustfs/recipe.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            },
+            {
+              "artifact_version": "1.0.0-beta.7-pv1",
+              "upstream_version": "1.0.0-beta.7",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-arm64",
+              "url": "https://artifacts.example.test/resources/rustfs/1/1.0.0-beta.7-pv1/darwin-arm64/rustfs-1.0.0-beta.7-pv1-darwin-arm64.tar.gz",
+              "sha256": "375fd10cb182f9d0a7781a7805f58ab73b5a901c490936c671a34eeedd39bea7",
+              "size": 207,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://github.com/rustfs/rustfs/releases/download/1.0.0-beta.7/rustfs-macos-aarch64-v1.0.0-beta.7.zip",
+                "source_sha256": "8ff8db2068db450b22c4dbaa86b7abcf35110307f8e036aa83db387f540a2b53",
+                "recipe": "release/artifacts/recipes/rustfs/recipe.toml",
                 "pv_commit": "0123456789abcdef0123456789abcdef01234567",
                 "build_run_id": "local-test"
               }

--- a/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_committed_mailpit_and_rustfs_recipes.snap
+++ b/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_committed_mailpit_and_rustfs_recipes.snap
@@ -1,0 +1,70 @@
+---
+source: crates/pv-release/tests/recipe_fixtures.rs
+expression: backing_summaries
+---
+[
+    BackingFixtureSummary {
+        track: "1",
+        upstream_version: "1.0.0-beta.7",
+        artifact_version: "1.0.0-beta.7-pv1",
+        platform: "darwin-amd64",
+        object_key: "resources/rustfs/1/1.0.0-beta.7-pv1/darwin-amd64/rustfs-1.0.0-beta.7-pv1-darwin-amd64.tar.gz",
+        record_key: "resources/rustfs/1/1.0.0-beta.7-pv1/darwin-amd64/rustfs-1.0.0-beta.7-pv1-darwin-amd64.json",
+        source_url: "https://github.com/rustfs/rustfs/releases/download/1.0.0-beta.7/rustfs-macos-x86_64-v1.0.0-beta.7.zip",
+        source_sha256: "b45cd47c3b3c903ab31b2b6d936be474d5ee64527a40271e7817dd6c961d5387",
+        recipe: "release/artifacts/recipes/rustfs/recipe.toml",
+        archive_entries: [
+            "rustfs-1.0.0-beta.7-pv1-darwin-amd64/LICENSE",
+            "rustfs-1.0.0-beta.7-pv1-darwin-amd64/NOTICE",
+            "rustfs-1.0.0-beta.7-pv1-darwin-amd64/bin/rustfs",
+        ],
+    },
+    BackingFixtureSummary {
+        track: "1",
+        upstream_version: "1.0.0-beta.7",
+        artifact_version: "1.0.0-beta.7-pv1",
+        platform: "darwin-arm64",
+        object_key: "resources/rustfs/1/1.0.0-beta.7-pv1/darwin-arm64/rustfs-1.0.0-beta.7-pv1-darwin-arm64.tar.gz",
+        record_key: "resources/rustfs/1/1.0.0-beta.7-pv1/darwin-arm64/rustfs-1.0.0-beta.7-pv1-darwin-arm64.json",
+        source_url: "https://github.com/rustfs/rustfs/releases/download/1.0.0-beta.7/rustfs-macos-aarch64-v1.0.0-beta.7.zip",
+        source_sha256: "8ff8db2068db450b22c4dbaa86b7abcf35110307f8e036aa83db387f540a2b53",
+        recipe: "release/artifacts/recipes/rustfs/recipe.toml",
+        archive_entries: [
+            "rustfs-1.0.0-beta.7-pv1-darwin-arm64/LICENSE",
+            "rustfs-1.0.0-beta.7-pv1-darwin-arm64/NOTICE",
+            "rustfs-1.0.0-beta.7-pv1-darwin-arm64/bin/rustfs",
+        ],
+    },
+    BackingFixtureSummary {
+        track: "1",
+        upstream_version: "1.30.1",
+        artifact_version: "1.30.1-pv1",
+        platform: "darwin-amd64",
+        object_key: "resources/mailpit/1/1.30.1-pv1/darwin-amd64/mailpit-1.30.1-pv1-darwin-amd64.tar.gz",
+        record_key: "resources/mailpit/1/1.30.1-pv1/darwin-amd64/mailpit-1.30.1-pv1-darwin-amd64.json",
+        source_url: "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-amd64.tar.gz",
+        source_sha256: "a2d7df1b34967e51604b42136260789b75a45233a03c9dc773b98024e1390974",
+        recipe: "release/artifacts/recipes/mailpit/recipe.toml",
+        archive_entries: [
+            "mailpit-1.30.1-pv1-darwin-amd64/LICENSE",
+            "mailpit-1.30.1-pv1-darwin-amd64/NOTICE",
+            "mailpit-1.30.1-pv1-darwin-amd64/bin/mailpit",
+        ],
+    },
+    BackingFixtureSummary {
+        track: "1",
+        upstream_version: "1.30.1",
+        artifact_version: "1.30.1-pv1",
+        platform: "darwin-arm64",
+        object_key: "resources/mailpit/1/1.30.1-pv1/darwin-arm64/mailpit-1.30.1-pv1-darwin-arm64.tar.gz",
+        record_key: "resources/mailpit/1/1.30.1-pv1/darwin-arm64/mailpit-1.30.1-pv1-darwin-arm64.json",
+        source_url: "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-arm64.tar.gz",
+        source_sha256: "1cce392a19a6093fcc859aeb87d9999671fed9a0a7a1c227a7f7df6307741be2",
+        recipe: "release/artifacts/recipes/mailpit/recipe.toml",
+        archive_entries: [
+            "mailpit-1.30.1-pv1-darwin-arm64/LICENSE",
+            "mailpit-1.30.1-pv1-darwin-arm64/NOTICE",
+            "mailpit-1.30.1-pv1-darwin-arm64/bin/mailpit",
+        ],
+    },
+]

--- a/crates/pv-release/tests/snapshots/recipe_metadata__backing_recipe_metadata_rejects_invalid_shapes.snap
+++ b/crates/pv-release/tests/snapshots/recipe_metadata__backing_recipe_metadata_rejects_invalid_shapes.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/pv-release/tests/recipe_metadata.rs
-expression: "(BackingRecipe::from_toml(Utf8Path::new(\"wrong-resource.toml\"),\nBackingRecipeKind::Redis, &wrong_resource,),\nBackingRecipe::from_toml(Utf8Path::new(\"missing-platform.toml\"),\nBackingRecipeKind::Redis, &missing_platform,),\nBackingRecipe::from_toml(Utf8Path::new(\"missing-default-track.toml\"),\nBackingRecipeKind::Redis, &missing_default_track,),\nBackingRecipe::from_toml(Utf8Path::new(\"empty-payload-paths.toml\"),\nBackingRecipeKind::Redis, &empty_payload_paths,),\nBackingRecipe::from_toml(Utf8Path::new(\"unsafe-payload-path.toml\"),\nBackingRecipeKind::Redis, &unsafe_payload_path,),\nBackingRecipe::from_toml(Utf8Path::new(\"insecure-source-url.toml\"),\nBackingRecipeKind::Redis, &insecure_source_url,),\nBackingRecipe::from_toml(Utf8Path::new(\"bad-source-sha256.toml\"),\nBackingRecipeKind::Redis, &bad_source_sha256,),)"
+expression: "(BackingRecipe::from_toml(Utf8Path::new(\"wrong-resource.toml\"),\nBackingRecipeKind::Redis, &wrong_resource,),\nBackingRecipe::from_toml(Utf8Path::new(\"missing-platform.toml\"),\nBackingRecipeKind::Redis, &missing_platform,),\nBackingRecipe::from_toml(Utf8Path::new(\"missing-default-track.toml\"),\nBackingRecipeKind::Redis, &missing_default_track,),\nBackingRecipe::from_toml(Utf8Path::new(\"empty-payload-paths.toml\"),\nBackingRecipeKind::Redis, &empty_payload_paths,),\nBackingRecipe::from_toml(Utf8Path::new(\"unsafe-payload-path.toml\"),\nBackingRecipeKind::Redis, &unsafe_payload_path,),\nBackingRecipe::from_toml(Utf8Path::new(\"insecure-source-url.toml\"),\nBackingRecipeKind::Redis, &insecure_source_url,),\nBackingRecipe::from_toml(Utf8Path::new(\"bad-source-sha256.toml\"),\nBackingRecipeKind::Redis, &bad_source_sha256,),\nBackingRecipe::from_toml(Utf8Path::new(\"missing-platform-source.toml\"),\nBackingRecipeKind::Mailpit, &missing_platform_source,),\nBackingRecipe::from_toml(Utf8Path::new(\"duplicate-platform-source.toml\"),\nBackingRecipeKind::Mailpit, &duplicate_platform_source,),\nBackingRecipe::from_toml(Utf8Path::new(\"unsupported-platform-source.toml\"),\nBackingRecipeKind::Mailpit, &unsupported_platform_source,),\nBackingRecipe::from_toml(Utf8Path::new(\"mixed-common-and-platform-sources.toml\"),\nBackingRecipeKind::Mailpit, &mixed_common_and_platform_sources,),)"
 ---
 (
     Err(
@@ -43,6 +43,30 @@ expression: "(BackingRecipe::from_toml(Utf8Path::new(\"wrong-resource.toml\"),\n
         InvalidRecipeMetadata {
             path: "bad-source-sha256.toml",
             reason: "invalid source_sha256: invalid sha256 `bad`",
+        },
+    ),
+    Err(
+        InvalidRecipeMetadata {
+            path: "missing-platform-source.toml",
+            reason: "missing source for platform `darwin-amd64`",
+        },
+    ),
+    Err(
+        InvalidRecipeMetadata {
+            path: "duplicate-platform-source.toml",
+            reason: "duplicate source for platform `darwin-arm64`",
+        },
+    ),
+    Err(
+        InvalidRecipeMetadata {
+            path: "unsupported-platform-source.toml",
+            reason: "sources.platform `any` is not listed in recipe.platforms",
+        },
+    ),
+    Err(
+        InvalidRecipeMetadata {
+            path: "mixed-common-and-platform-sources.toml",
+            reason: "track-level source_url/source_sha256 cannot be combined with sources",
         },
     ),
 )

--- a/crates/pv-release/tests/snapshots/recipe_metadata__print_backing_recipe_env_mailpit.snap
+++ b/crates/pv-release/tests/snapshots/recipe_metadata__print_backing_recipe_env_mailpit.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pv-release/tests/recipe_metadata.rs
+expression: env
+---
+PV_RESOURCE='mailpit'
+PV_TRACK='1'
+PV_PLATFORM='darwin-arm64'
+PV_UPSTREAM_VERSION='1.30.1'
+PV_ARTIFACT_VERSION='1.30.1-pv1'
+PV_SOURCE_URL='https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-arm64.tar.gz'
+PV_SOURCE_SHA256='1cce392a19a6093fcc859aeb87d9999671fed9a0a7a1c227a7f7df6307741be2'
+PV_MINIMUM_PV_VERSION='0.1.0'
+PV_PV_BUILD_REVISION='pv1'

--- a/crates/pv-release/tests/snapshots/recipe_metadata__print_backing_recipe_env_rustfs.snap
+++ b/crates/pv-release/tests/snapshots/recipe_metadata__print_backing_recipe_env_rustfs.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pv-release/tests/recipe_metadata.rs
+expression: env
+---
+PV_RESOURCE='rustfs'
+PV_TRACK='1'
+PV_PLATFORM='darwin-amd64'
+PV_UPSTREAM_VERSION='1.0.0-beta.7'
+PV_ARTIFACT_VERSION='1.0.0-beta.7-pv1'
+PV_SOURCE_URL='https://github.com/rustfs/rustfs/releases/download/1.0.0-beta.7/rustfs-macos-x86_64-v1.0.0-beta.7.zip'
+PV_SOURCE_SHA256='b45cd47c3b3c903ab31b2b6d936be474d5ee64527a40271e7817dd6c961d5387'
+PV_MINIMUM_PV_VERSION='0.1.0'
+PV_PV_BUILD_REVISION='pv1'

--- a/release/artifacts/default-tracks.toml
+++ b/release/artifacts/default-tracks.toml
@@ -13,3 +13,11 @@ default_track = "2"
 [[resource]]
 name = "redis"
 default_track = "8.2"
+
+[[resource]]
+name = "mailpit"
+default_track = "1"
+
+[[resource]]
+name = "rustfs"
+default_track = "1"

--- a/release/artifacts/recipes/common.sh
+++ b/release/artifacts/recipes/common.sh
@@ -21,6 +21,127 @@ require_sha256() {
   [ "$actual" = "$expected" ] || die "$file checksum mismatch: expected $expected, got $actual"
 }
 
+expected_arch_for_platform() {
+  case "$1" in
+    darwin-arm64) printf '%s\n' arm64 ;;
+    darwin-amd64) printf '%s\n' x86_64 ;;
+    *) die "unsupported native artifact platform: $1" ;;
+  esac
+}
+
+macho_minimum_os() {
+  otool -l "$1" | awk '
+    $1 == "cmd" && $2 == "LC_BUILD_VERSION" {
+      in_build_version = 1
+      in_version_min = 0
+      next
+    }
+    $1 == "cmd" && $2 == "LC_VERSION_MIN_MACOSX" {
+      in_build_version = 0
+      in_version_min = 1
+      next
+    }
+    $1 == "cmd" {
+      in_build_version = 0
+      in_version_min = 0
+      next
+    }
+    in_build_version && $1 == "minos" {
+      print $2
+      exit
+    }
+    in_version_min && $1 == "version" {
+      print $2
+      exit
+    }
+  '
+}
+
+version_lte() {
+  actual_version=$1
+  maximum_version=$2
+  awk -v actual="$actual_version" -v maximum="$maximum_version" '
+    BEGIN {
+      split(actual, actual_parts, ".")
+      split(maximum, maximum_parts, ".")
+      for (part_index = 1; part_index <= 3; part_index++) {
+        actual_part = actual_parts[part_index] == "" ? 0 : actual_parts[part_index] + 0
+        maximum_part = maximum_parts[part_index] == "" ? 0 : maximum_parts[part_index] + 0
+        if (actual_part < maximum_part) {
+          exit 0
+        }
+        if (actual_part > maximum_part) {
+          exit 1
+        }
+      }
+      exit 0
+    }
+  '
+}
+
+reject_unmanaged_macho_runtime_path() {
+  binary=$1
+  metadata_kind=$2
+  runtime_path=$3
+
+  case "$runtime_path" in
+    /usr/lib/* | /System/Library/* | @rpath/* | @loader_path/* | @executable_path/*)
+      ;;
+    *) die "$binary Mach-O $metadata_kind references unmanaged runtime path $runtime_path" ;;
+  esac
+}
+
+macho_rpaths() {
+  otool -l "$1" | awk '
+    $1 == "cmd" && $2 == "LC_RPATH" {
+      in_rpath = 1
+      next
+    }
+    $1 == "cmd" {
+      in_rpath = 0
+      next
+    }
+    in_rpath && $1 == "path" {
+      print $2
+      in_rpath = 0
+      next
+    }
+  '
+}
+
+validate_macho_runtime_paths() {
+  binary=$1
+  linked_libraries=$(otool -L "$binary")
+  printf '%s\n' "$linked_libraries" | awk 'NR > 1 && NF > 0 { print $1 }' | while IFS= read -r linked_library; do
+    reject_unmanaged_macho_runtime_path "$binary" "linked library" "$linked_library"
+  done
+
+  macho_rpaths "$binary" | while IFS= read -r macho_rpath; do
+    reject_unmanaged_macho_runtime_path "$binary" "rpath" "$macho_rpath"
+  done
+}
+
+validate_macho_binary() {
+  binary=$1
+  platform=$2
+  deployment_target=$3
+  expected_arch=$(expected_arch_for_platform "$platform")
+  binary_archs=$(lipo -archs "$binary")
+  [ "$binary_archs" = "$expected_arch" ] || die "$binary Mach-O architecture $binary_archs does not match expected $expected_arch for $platform"
+
+  binary_minos=$(macho_minimum_os "$binary")
+  [ -n "$binary_minos" ] || die "$binary Mach-O minimum macOS version not found"
+  version_lte "$binary_minos" "$deployment_target" || die "$binary Mach-O minimum macOS $binary_minos is newer than deployment target $deployment_target"
+
+  validate_macho_runtime_paths "$binary"
+}
+
+sign_macho_binary() {
+  binary=$1
+  codesign --force --sign - "$binary"
+  codesign --verify "$binary"
+}
+
 artifact_basename() {
   resource=$1
   artifact_version=$2

--- a/release/artifacts/recipes/mailpit/LICENSE
+++ b/release/artifacts/recipes/mailpit/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+Copyright (c) 2022-Now() Ralph Slooten
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/release/artifacts/recipes/mailpit/NOTICE
+++ b/release/artifacts/recipes/mailpit/NOTICE
@@ -1,0 +1,8 @@
+PV packages upstream Mailpit 1.30.1 binaries from:
+https://github.com/axllent/mailpit/releases/tag/v1.30.1
+
+Upstream Mailpit source for this artifact is tracked at:
+https://github.com/axllent/mailpit/tree/v1.30.1
+
+Mailpit is licensed under the MIT License; see LICENSE in this archive.
+Upstream Mailpit tag v1.30.1 does not provide a NOTICE file.

--- a/release/artifacts/recipes/mailpit/build.sh
+++ b/release/artifacts/recipes/mailpit/build.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/../../../.." && pwd)
+# shellcheck source=/dev/null
+. "$ROOT/release/artifacts/recipes/common.sh"
+
+OUT_DIR=${PV_ARTIFACT_OUT_DIR:-"$ROOT/release/artifacts/out"}
+RECORD_DIR=${PV_ARTIFACT_RECORD_DIR:-"$ROOT/release/artifacts/records"}
+TRACK=${PV_RECIPE_TRACK:-1}
+PLATFORM=${PV_RECIPE_PLATFORM:-darwin-arm64}
+PV_COMMIT=${PV_COMMIT:-}
+BUILD_RUN_ID=${PV_BUILD_RUN_ID:-local-mailpit}
+recipe_dir="$ROOT/release/artifacts/recipes/mailpit"
+
+need cargo
+need curl
+need git
+need shasum
+need tar
+
+if [ -z "$PV_COMMIT" ]; then
+  PV_COMMIT=$(git -C "$ROOT" rev-parse HEAD)
+fi
+
+env_file="$OUT_DIR/work/mailpit-$TRACK-$PLATFORM.env"
+mkdir -p "$(dirname "$env_file")" "$OUT_DIR/sources"
+cargo run -p pv-release -- print-recipe-env \
+  --mailpit "$recipe_dir/recipe.toml" \
+  --resource mailpit \
+  --track "$TRACK" \
+  --platform "$PLATFORM" >"$env_file"
+# shellcheck source=/dev/null
+. "$env_file"
+
+source_archive="$OUT_DIR/sources/mailpit-$PV_UPSTREAM_VERSION-$PV_PLATFORM.tar.gz"
+curl -L --fail --show-error --silent \
+  --retry 3 --retry-delay 2 --retry-all-errors \
+  --connect-timeout 20 --max-time 300 \
+  "$PV_SOURCE_URL" -o "$source_archive"
+require_sha256 "$source_archive" "$PV_SOURCE_SHA256"
+
+artifact_basename=$(artifact_basename mailpit "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+work_dir="$OUT_DIR/work/$artifact_basename"
+extract_dir="$work_dir/source"
+root_dir="$work_dir/$artifact_basename"
+archive="$OUT_DIR/$artifact_basename.tar.gz"
+record=$(artifact_record_path "$RECORD_DIR" mailpit "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+object_key=$(artifact_object_key mailpit "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+
+rm -rf "$work_dir"
+mkdir -p "$extract_dir" "$root_dir/bin"
+tar -xzf "$source_archive" -C "$extract_dir"
+[ -f "$extract_dir/mailpit" ] || die "Mailpit upstream archive did not contain mailpit"
+cp "$extract_dir/mailpit" "$root_dir/bin/mailpit"
+chmod 755 "$root_dir/bin/mailpit"
+cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
+{
+  cat "$recipe_dir/NOTICE"
+  printf '\nArtifact build metadata:\n'
+  printf 'Resource: %s\n' "$PV_RESOURCE"
+  printf 'Track: %s\n' "$PV_TRACK"
+  printf 'Artifact version: %s\n' "$PV_ARTIFACT_VERSION"
+  printf 'Upstream version: %s\n' "$PV_UPSTREAM_VERSION"
+  printf 'Source URL: %s\n' "$PV_SOURCE_URL"
+  printf 'Source SHA-256: %s\n' "$PV_SOURCE_SHA256"
+} >"$root_dir/NOTICE"
+
+mkdir -p "$OUT_DIR" "$(dirname "$record")"
+COPYFILE_DISABLE=1 tar -czf "$archive" -C "$work_dir" "$artifact_basename"
+write_record "$record" mailpit "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/mailpit/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
+
+PV_UPSTREAM_VERSION="$PV_UPSTREAM_VERSION" \
+  cargo run -p pv-release -- validate-archive --archive "$archive" --record "$record" --smoke-hook "$recipe_dir/smoke.sh"
+printf '%s\n' "$archive"

--- a/release/artifacts/recipes/mailpit/build.sh
+++ b/release/artifacts/recipes/mailpit/build.sh
@@ -11,11 +11,16 @@ TRACK=${PV_RECIPE_TRACK:-1}
 PLATFORM=${PV_RECIPE_PLATFORM:-darwin-arm64}
 PV_COMMIT=${PV_COMMIT:-}
 BUILD_RUN_ID=${PV_BUILD_RUN_ID:-local-mailpit}
+MAILPIT_DEPLOYMENT_TARGET=13.0
 recipe_dir="$ROOT/release/artifacts/recipes/mailpit"
 
+need awk
 need cargo
+need codesign
 need curl
 need git
+need lipo
+need otool
 need shasum
 need tar
 
@@ -44,8 +49,10 @@ artifact_basename=$(artifact_basename mailpit "$PV_ARTIFACT_VERSION" "$PV_PLATFO
 work_dir="$OUT_DIR/work/$artifact_basename"
 extract_dir="$work_dir/source"
 root_dir="$work_dir/$artifact_basename"
-archive="$OUT_DIR/$artifact_basename.tar.gz"
-record=$(artifact_record_path "$RECORD_DIR" mailpit "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+final_archive="$OUT_DIR/$artifact_basename.tar.gz"
+staged_archive="$work_dir/staged-archives/$artifact_basename.tar.gz"
+final_record=$(artifact_record_path "$RECORD_DIR" mailpit "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+staged_record="$work_dir/staged-records/mailpit/$PV_TRACK/$PV_ARTIFACT_VERSION/$PV_PLATFORM/$artifact_basename.json"
 object_key=$(artifact_object_key mailpit "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
 
 rm -rf "$work_dir"
@@ -54,6 +61,8 @@ tar -xzf "$source_archive" -C "$extract_dir"
 [ -f "$extract_dir/mailpit" ] || die "Mailpit upstream archive did not contain mailpit"
 cp "$extract_dir/mailpit" "$root_dir/bin/mailpit"
 chmod 755 "$root_dir/bin/mailpit"
+validate_macho_binary "$root_dir/bin/mailpit" "$PV_PLATFORM" "$MAILPIT_DEPLOYMENT_TARGET"
+sign_macho_binary "$root_dir/bin/mailpit"
 cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
 {
   cat "$recipe_dir/NOTICE"
@@ -66,10 +75,13 @@ cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
   printf 'Source SHA-256: %s\n' "$PV_SOURCE_SHA256"
 } >"$root_dir/NOTICE"
 
-mkdir -p "$OUT_DIR" "$(dirname "$record")"
-COPYFILE_DISABLE=1 tar -czf "$archive" -C "$work_dir" "$artifact_basename"
-write_record "$record" mailpit "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/mailpit/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
+mkdir -p "$(dirname "$staged_archive")" "$(dirname "$staged_record")"
+COPYFILE_DISABLE=1 tar -czf "$staged_archive" -C "$work_dir" "$artifact_basename"
+write_record "$staged_record" mailpit "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$staged_archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/mailpit/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
 
 PV_UPSTREAM_VERSION="$PV_UPSTREAM_VERSION" \
-  cargo run -p pv-release -- validate-archive --archive "$archive" --record "$record" --smoke-hook "$recipe_dir/smoke.sh"
-printf '%s\n' "$archive"
+  cargo run -p pv-release -- validate-archive --archive "$staged_archive" --record "$staged_record" --smoke-hook "$recipe_dir/smoke.sh"
+mkdir -p "$OUT_DIR" "$(dirname "$final_record")"
+mv "$staged_archive" "$final_archive"
+mv "$staged_record" "$final_record"
+printf '%s\n' "$final_archive"

--- a/release/artifacts/recipes/mailpit/recipe.toml
+++ b/release/artifacts/recipes/mailpit/recipe.toml
@@ -1,0 +1,25 @@
+[recipe]
+resources = ["mailpit"]
+default_track = "1"
+platforms = ["darwin-arm64", "darwin-amd64"]
+minimum_pv_version = "0.1.0"
+pv_build_revision = "pv1"
+license_files = ["LICENSE"]
+notice_files = ["NOTICE"]
+
+[artifact]
+payload_paths = ["bin/mailpit"]
+
+[[tracks]]
+name = "1"
+upstream_version = "1.30.1"
+
+[[tracks.sources]]
+platform = "darwin-arm64"
+source_url = "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-arm64.tar.gz"
+source_sha256 = "1cce392a19a6093fcc859aeb87d9999671fed9a0a7a1c227a7f7df6307741be2"
+
+[[tracks.sources]]
+platform = "darwin-amd64"
+source_url = "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-amd64.tar.gz"
+source_sha256 = "a2d7df1b34967e51604b42136260789b75a45233a03c9dc773b98024e1390974"

--- a/release/artifacts/recipes/mailpit/smoke.sh
+++ b/release/artifacts/recipes/mailpit/smoke.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+set -eu
+
+artifact_root=$1
+mailpit_binary="$artifact_root/bin/mailpit"
+expected_version=${PV_UPSTREAM_VERSION:-}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf '%s\n' "missing required command: $1" >&2
+    exit 42
+  }
+}
+
+available_port() {
+  python3 - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+}
+
+check_tcp_bind() {
+  port=$1
+  python3 - "$port" <<'PY'
+import socket
+import sys
+
+port = int(sys.argv[1])
+with socket.create_connection(("127.0.0.1", port), timeout=1):
+    pass
+PY
+}
+
+[ -x "$mailpit_binary" ] || {
+  printf '%s\n' "missing executable bin/mailpit in $artifact_root" >&2
+  exit 42
+}
+[ -n "$expected_version" ] || {
+  printf '%s\n' "PV_UPSTREAM_VERSION is required for Mailpit smoke" >&2
+  exit 42
+}
+
+need curl
+need grep
+need mktemp
+need python3
+
+"$mailpit_binary" version | grep -F "v$expected_version" >/dev/null
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/pv-mailpit-smoke.XXXXXX")
+http_port=$(available_port)
+smtp_port=$(available_port)
+"$mailpit_binary" \
+  --database "$tmp_dir/mailpit.db" \
+  --listen "127.0.0.1:$http_port" \
+  --smtp "127.0.0.1:$smtp_port" \
+  --disable-version-check \
+  --quiet &
+pid=$!
+trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; rm -rf "$tmp_dir"' 0
+
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl --fail --silent "http://127.0.0.1:$http_port/" >/dev/null &&
+    check_tcp_bind "$smtp_port"; then
+    exit 0
+  fi
+  sleep 1
+done
+
+printf '%s\n' "Mailpit HTTP UI or SMTP bind smoke failed" >&2
+exit 43

--- a/release/artifacts/recipes/mailpit/smoke.sh
+++ b/release/artifacts/recipes/mailpit/smoke.sh
@@ -4,6 +4,8 @@ set -eu
 artifact_root=$1
 mailpit_binary="$artifact_root/bin/mailpit"
 expected_version=${PV_UPSTREAM_VERSION:-}
+pid=
+tmp_dir=
 
 need() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -34,6 +36,60 @@ with socket.create_connection(("127.0.0.1", port), timeout=1):
 PY
 }
 
+actual_mailpit_version() {
+  "$mailpit_binary" version | awk '
+    {
+      for (field_index = 1; field_index <= NF; field_index++) {
+        version = $field_index
+        if (version ~ /^v?[0-9]+[.][0-9]+/) {
+          sub(/^v/, "", version)
+          print version
+          exit
+        }
+      }
+    }
+  '
+}
+
+# Invoked by the EXIT trap below.
+# shellcheck disable=SC2329
+cleanup() {
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  if [ -n "$tmp_dir" ]; then
+    rm -rf "$tmp_dir"
+  fi
+}
+
+wait_for_stop() {
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid" 2>/dev/null || true
+      pid=
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+stop_mailpit() {
+  if ! kill -0 "$pid" 2>/dev/null; then
+    printf '%s\n' "Mailpit smoke failed: server exited before clean shutdown" >&2
+    exit 44
+  fi
+  kill "$pid" 2>/dev/null || {
+    printf '%s\n' "Mailpit smoke failed: could not request server shutdown" >&2
+    exit 44
+  }
+  if ! wait_for_stop; then
+    printf '%s\n' "Mailpit smoke failed: server did not stop cleanly" >&2
+    exit 44
+  fi
+}
+
 [ -x "$mailpit_binary" ] || {
   printf '%s\n' "missing executable bin/mailpit in $artifact_root" >&2
   exit 42
@@ -43,16 +99,22 @@ PY
   exit 42
 }
 
+need awk
 need curl
-need grep
 need mktemp
 need python3
+need sleep
 
-"$mailpit_binary" version | grep -F "v$expected_version" >/dev/null
+actual_version=$(actual_mailpit_version)
+[ "$actual_version" = "$expected_version" ] || {
+  printf '%s\n' "Mailpit version mismatch: expected $expected_version, got ${actual_version:-<unknown>}" >&2
+  exit 43
+}
 
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/pv-mailpit-smoke.XXXXXX")
 http_port=$(available_port)
 smtp_port=$(available_port)
+trap cleanup 0
 "$mailpit_binary" \
   --database "$tmp_dir/mailpit.db" \
   --listen "127.0.0.1:$http_port" \
@@ -60,12 +122,18 @@ smtp_port=$(available_port)
   --disable-version-check \
   --quiet &
 pid=$!
-trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; rm -rf "$tmp_dir"' 0
 
 for _ in 1 2 3 4 5 6 7 8 9 10; do
   if curl --fail --silent "http://127.0.0.1:$http_port/" >/dev/null &&
     check_tcp_bind "$smtp_port"; then
+    stop_mailpit
     exit 0
+  fi
+  if ! kill -0 "$pid" 2>/dev/null; then
+    printf '%s\n' "Mailpit HTTP UI or SMTP bind smoke failed: server exited early" >&2
+    wait "$pid" 2>/dev/null || true
+    pid=
+    exit 43
   fi
   sleep 1
 done

--- a/release/artifacts/recipes/rustfs/LICENSE
+++ b/release/artifacts/recipes/rustfs/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Beijing Henghesha Technology Co., Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/release/artifacts/recipes/rustfs/NOTICE
+++ b/release/artifacts/recipes/rustfs/NOTICE
@@ -1,0 +1,8 @@
+PV packages upstream RustFS 1.0.0-beta.7 binaries from:
+https://github.com/rustfs/rustfs/releases/tag/1.0.0-beta.7
+
+Upstream RustFS source for this artifact is tracked at:
+https://github.com/rustfs/rustfs/tree/1.0.0-beta.7
+
+RustFS is licensed under the Apache License 2.0; see LICENSE in this archive.
+Upstream RustFS tag 1.0.0-beta.7 does not provide a NOTICE file.

--- a/release/artifacts/recipes/rustfs/build.sh
+++ b/release/artifacts/recipes/rustfs/build.sh
@@ -11,11 +11,16 @@ TRACK=${PV_RECIPE_TRACK:-1}
 PLATFORM=${PV_RECIPE_PLATFORM:-darwin-arm64}
 PV_COMMIT=${PV_COMMIT:-}
 BUILD_RUN_ID=${PV_BUILD_RUN_ID:-local-rustfs}
+RUSTFS_DEPLOYMENT_TARGET=13.0
 recipe_dir="$ROOT/release/artifacts/recipes/rustfs"
 
+need awk
 need cargo
+need codesign
 need curl
 need git
+need lipo
+need otool
 need shasum
 need unzip
 need tar
@@ -45,8 +50,10 @@ artifact_basename=$(artifact_basename rustfs "$PV_ARTIFACT_VERSION" "$PV_PLATFOR
 work_dir="$OUT_DIR/work/$artifact_basename"
 extract_dir="$work_dir/source"
 root_dir="$work_dir/$artifact_basename"
-archive="$OUT_DIR/$artifact_basename.tar.gz"
-record=$(artifact_record_path "$RECORD_DIR" rustfs "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+final_archive="$OUT_DIR/$artifact_basename.tar.gz"
+staged_archive="$work_dir/staged-archives/$artifact_basename.tar.gz"
+final_record=$(artifact_record_path "$RECORD_DIR" rustfs "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+staged_record="$work_dir/staged-records/rustfs/$PV_TRACK/$PV_ARTIFACT_VERSION/$PV_PLATFORM/$artifact_basename.json"
 object_key=$(artifact_object_key rustfs "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
 
 rm -rf "$work_dir"
@@ -55,6 +62,8 @@ unzip -q "$source_archive" -d "$extract_dir"
 [ -f "$extract_dir/rustfs" ] || die "RustFS upstream archive did not contain rustfs"
 cp "$extract_dir/rustfs" "$root_dir/bin/rustfs"
 chmod 755 "$root_dir/bin/rustfs"
+validate_macho_binary "$root_dir/bin/rustfs" "$PV_PLATFORM" "$RUSTFS_DEPLOYMENT_TARGET"
+sign_macho_binary "$root_dir/bin/rustfs"
 cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
 {
   cat "$recipe_dir/NOTICE"
@@ -67,10 +76,13 @@ cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
   printf 'Source SHA-256: %s\n' "$PV_SOURCE_SHA256"
 } >"$root_dir/NOTICE"
 
-mkdir -p "$OUT_DIR" "$(dirname "$record")"
-COPYFILE_DISABLE=1 tar -czf "$archive" -C "$work_dir" "$artifact_basename"
-write_record "$record" rustfs "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/rustfs/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
+mkdir -p "$(dirname "$staged_archive")" "$(dirname "$staged_record")"
+COPYFILE_DISABLE=1 tar -czf "$staged_archive" -C "$work_dir" "$artifact_basename"
+write_record "$staged_record" rustfs "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$staged_archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/rustfs/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
 
 PV_UPSTREAM_VERSION="$PV_UPSTREAM_VERSION" \
-  cargo run -p pv-release -- validate-archive --archive "$archive" --record "$record" --smoke-hook "$recipe_dir/smoke.sh"
-printf '%s\n' "$archive"
+  cargo run -p pv-release -- validate-archive --archive "$staged_archive" --record "$staged_record" --smoke-hook "$recipe_dir/smoke.sh"
+mkdir -p "$OUT_DIR" "$(dirname "$final_record")"
+mv "$staged_archive" "$final_archive"
+mv "$staged_record" "$final_record"
+printf '%s\n' "$final_archive"

--- a/release/artifacts/recipes/rustfs/build.sh
+++ b/release/artifacts/recipes/rustfs/build.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/../../../.." && pwd)
+# shellcheck source=/dev/null
+. "$ROOT/release/artifacts/recipes/common.sh"
+
+OUT_DIR=${PV_ARTIFACT_OUT_DIR:-"$ROOT/release/artifacts/out"}
+RECORD_DIR=${PV_ARTIFACT_RECORD_DIR:-"$ROOT/release/artifacts/records"}
+TRACK=${PV_RECIPE_TRACK:-1}
+PLATFORM=${PV_RECIPE_PLATFORM:-darwin-arm64}
+PV_COMMIT=${PV_COMMIT:-}
+BUILD_RUN_ID=${PV_BUILD_RUN_ID:-local-rustfs}
+recipe_dir="$ROOT/release/artifacts/recipes/rustfs"
+
+need cargo
+need curl
+need git
+need shasum
+need unzip
+need tar
+
+if [ -z "$PV_COMMIT" ]; then
+  PV_COMMIT=$(git -C "$ROOT" rev-parse HEAD)
+fi
+
+env_file="$OUT_DIR/work/rustfs-$TRACK-$PLATFORM.env"
+mkdir -p "$(dirname "$env_file")" "$OUT_DIR/sources"
+cargo run -p pv-release -- print-recipe-env \
+  --rustfs "$recipe_dir/recipe.toml" \
+  --resource rustfs \
+  --track "$TRACK" \
+  --platform "$PLATFORM" >"$env_file"
+# shellcheck source=/dev/null
+. "$env_file"
+
+source_archive="$OUT_DIR/sources/rustfs-$PV_UPSTREAM_VERSION-$PV_PLATFORM.zip"
+curl -L --fail --show-error --silent \
+  --retry 3 --retry-delay 2 --retry-all-errors \
+  --connect-timeout 20 --max-time 600 \
+  "$PV_SOURCE_URL" -o "$source_archive"
+require_sha256 "$source_archive" "$PV_SOURCE_SHA256"
+
+artifact_basename=$(artifact_basename rustfs "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+work_dir="$OUT_DIR/work/$artifact_basename"
+extract_dir="$work_dir/source"
+root_dir="$work_dir/$artifact_basename"
+archive="$OUT_DIR/$artifact_basename.tar.gz"
+record=$(artifact_record_path "$RECORD_DIR" rustfs "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+object_key=$(artifact_object_key rustfs "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+
+rm -rf "$work_dir"
+mkdir -p "$extract_dir" "$root_dir/bin"
+unzip -q "$source_archive" -d "$extract_dir"
+[ -f "$extract_dir/rustfs" ] || die "RustFS upstream archive did not contain rustfs"
+cp "$extract_dir/rustfs" "$root_dir/bin/rustfs"
+chmod 755 "$root_dir/bin/rustfs"
+cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
+{
+  cat "$recipe_dir/NOTICE"
+  printf '\nArtifact build metadata:\n'
+  printf 'Resource: %s\n' "$PV_RESOURCE"
+  printf 'Track: %s\n' "$PV_TRACK"
+  printf 'Artifact version: %s\n' "$PV_ARTIFACT_VERSION"
+  printf 'Upstream version: %s\n' "$PV_UPSTREAM_VERSION"
+  printf 'Source URL: %s\n' "$PV_SOURCE_URL"
+  printf 'Source SHA-256: %s\n' "$PV_SOURCE_SHA256"
+} >"$root_dir/NOTICE"
+
+mkdir -p "$OUT_DIR" "$(dirname "$record")"
+COPYFILE_DISABLE=1 tar -czf "$archive" -C "$work_dir" "$artifact_basename"
+write_record "$record" rustfs "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/rustfs/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
+
+PV_UPSTREAM_VERSION="$PV_UPSTREAM_VERSION" \
+  cargo run -p pv-release -- validate-archive --archive "$archive" --record "$record" --smoke-hook "$recipe_dir/smoke.sh"
+printf '%s\n' "$archive"

--- a/release/artifacts/recipes/rustfs/recipe.toml
+++ b/release/artifacts/recipes/rustfs/recipe.toml
@@ -1,0 +1,25 @@
+[recipe]
+resources = ["rustfs"]
+default_track = "1"
+platforms = ["darwin-arm64", "darwin-amd64"]
+minimum_pv_version = "0.1.0"
+pv_build_revision = "pv1"
+license_files = ["LICENSE"]
+notice_files = ["NOTICE"]
+
+[artifact]
+payload_paths = ["bin/rustfs"]
+
+[[tracks]]
+name = "1"
+upstream_version = "1.0.0-beta.7"
+
+[[tracks.sources]]
+platform = "darwin-arm64"
+source_url = "https://github.com/rustfs/rustfs/releases/download/1.0.0-beta.7/rustfs-macos-aarch64-v1.0.0-beta.7.zip"
+source_sha256 = "8ff8db2068db450b22c4dbaa86b7abcf35110307f8e036aa83db387f540a2b53"
+
+[[tracks.sources]]
+platform = "darwin-amd64"
+source_url = "https://github.com/rustfs/rustfs/releases/download/1.0.0-beta.7/rustfs-macos-x86_64-v1.0.0-beta.7.zip"
+source_sha256 = "b45cd47c3b3c903ab31b2b6d936be474d5ee64527a40271e7817dd6c961d5387"

--- a/release/artifacts/recipes/rustfs/smoke.sh
+++ b/release/artifacts/recipes/rustfs/smoke.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+set -eu
+
+artifact_root=$1
+rustfs_binary="$artifact_root/bin/rustfs"
+expected_version=${PV_UPSTREAM_VERSION:-}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf '%s\n' "missing required command: $1" >&2
+    exit 42
+  }
+}
+
+available_port() {
+  python3 - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+}
+
+[ -x "$rustfs_binary" ] || {
+  printf '%s\n' "missing executable bin/rustfs in $artifact_root" >&2
+  exit 42
+}
+[ -n "$expected_version" ] || {
+  printf '%s\n' "PV_UPSTREAM_VERSION is required for RustFS smoke" >&2
+  exit 42
+}
+
+need grep
+need mktemp
+need python3
+
+"$rustfs_binary" --version | grep -F "rustfs $expected_version" >/dev/null
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/pv-rustfs-smoke.XXXXXX")
+data_dir="$tmp_dir/data"
+log_file="$tmp_dir/rustfs.log"
+api_port=$(available_port)
+access_key=pvsmokeaccess
+secret_key=pvsmokesecret1234567890
+bucket=pv-smoke-bucket
+mkdir -p "$data_dir"
+
+"$rustfs_binary" server \
+  --address "127.0.0.1:$api_port" \
+  --access-key "$access_key" \
+  --secret-key "$secret_key" \
+  "$data_dir" >"$log_file" 2>&1 &
+pid=$!
+trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; rm -rf "$tmp_dir"' 0
+
+endpoint="http://127.0.0.1:$api_port"
+export PV_RUSTFS_SMOKE_ENDPOINT="$endpoint"
+export PV_RUSTFS_SMOKE_ACCESS_KEY="$access_key"
+export PV_RUSTFS_SMOKE_SECRET_KEY="$secret_key"
+export PV_RUSTFS_SMOKE_BUCKET="$bucket"
+
+python3 <<'PY'
+import datetime
+import hashlib
+import hmac
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+endpoint = os.environ["PV_RUSTFS_SMOKE_ENDPOINT"].rstrip("/")
+access_key = os.environ["PV_RUSTFS_SMOKE_ACCESS_KEY"]
+secret_key = os.environ["PV_RUSTFS_SMOKE_SECRET_KEY"]
+bucket = os.environ["PV_RUSTFS_SMOKE_BUCKET"]
+region = "us-east-1"
+service = "s3"
+
+def sign(key, message):
+    return hmac.new(key, message.encode("utf-8"), hashlib.sha256).digest()
+
+def signing_key(date_stamp):
+    key = ("AWS4" + secret_key).encode("utf-8")
+    key = sign(key, date_stamp)
+    key = sign(key, region)
+    key = sign(key, service)
+    return sign(key, "aws4_request")
+
+def request(method, path):
+    parsed = urllib.parse.urlparse(endpoint)
+    host = parsed.netloc
+    now = datetime.datetime.utcnow()
+    amz_date = now.strftime("%Y%m%dT%H%M%SZ")
+    date_stamp = now.strftime("%Y%m%d")
+    payload_hash = hashlib.sha256(b"").hexdigest()
+    canonical_headers = (
+        f"host:{host}\n"
+        f"x-amz-content-sha256:{payload_hash}\n"
+        f"x-amz-date:{amz_date}\n"
+    )
+    signed_headers = "host;x-amz-content-sha256;x-amz-date"
+    canonical_request = "\n".join([
+        method,
+        path,
+        "",
+        canonical_headers,
+        signed_headers,
+        payload_hash,
+    ])
+    credential_scope = f"{date_stamp}/{region}/{service}/aws4_request"
+    string_to_sign = "\n".join([
+        "AWS4-HMAC-SHA256",
+        amz_date,
+        credential_scope,
+        hashlib.sha256(canonical_request.encode("utf-8")).hexdigest(),
+    ])
+    signature = hmac.new(
+        signing_key(date_stamp),
+        string_to_sign.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    authorization = (
+        "AWS4-HMAC-SHA256 "
+        f"Credential={access_key}/{credential_scope}, "
+        f"SignedHeaders={signed_headers}, Signature={signature}"
+    )
+    req = urllib.request.Request(
+        endpoint + path,
+        method=method,
+        headers={
+            "Authorization": authorization,
+            "x-amz-content-sha256": payload_hash,
+            "x-amz-date": amz_date,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=3) as response:
+        return response.status, response.read()
+
+last_error = None
+for _ in range(30):
+    try:
+        status, _body = request("GET", "/")
+        if 200 <= status < 300:
+            break
+    except (OSError, urllib.error.URLError, urllib.error.HTTPError) as error:
+        last_error = error
+        time.sleep(1)
+else:
+    print(f"RustFS S3 API readiness failed: {last_error}", file=sys.stderr)
+    sys.exit(43)
+
+status, _body = request("PUT", f"/{bucket}")
+if not 200 <= status < 300:
+    print(f"RustFS create bucket returned HTTP {status}", file=sys.stderr)
+    sys.exit(44)
+
+status, body = request("GET", "/")
+if not 200 <= status < 300 or bucket.encode("utf-8") not in body:
+    print("RustFS list buckets did not include smoke bucket", file=sys.stderr)
+    sys.exit(45)
+PY

--- a/release/artifacts/recipes/rustfs/smoke.sh
+++ b/release/artifacts/recipes/rustfs/smoke.sh
@@ -4,6 +4,8 @@ set -eu
 artifact_root=$1
 rustfs_binary="$artifact_root/bin/rustfs"
 expected_version=${PV_UPSTREAM_VERSION:-}
+pid=
+tmp_dir=
 
 need() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -22,6 +24,49 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
 PY
 }
 
+actual_rustfs_version() {
+  "$rustfs_binary" --version | awk '$1 == "rustfs" { print $2; exit }'
+}
+
+# Invoked by the EXIT trap below.
+# shellcheck disable=SC2329
+cleanup() {
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill -KILL "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  if [ -n "$tmp_dir" ]; then
+    rm -rf "$tmp_dir"
+  fi
+}
+
+wait_for_stop() {
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid" 2>/dev/null || true
+      pid=
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+stop_rustfs() {
+  if ! kill -0 "$pid" 2>/dev/null; then
+    printf '%s\n' "RustFS smoke failed: server exited before clean shutdown" >&2
+    exit 46
+  fi
+  kill "$pid" 2>/dev/null || {
+    printf '%s\n' "RustFS smoke failed: could not request server shutdown" >&2
+    exit 46
+  }
+  if ! wait_for_stop; then
+    printf '%s\n' "RustFS smoke failed: server did not stop cleanly" >&2
+    exit 46
+  fi
+}
+
 [ -x "$rustfs_binary" ] || {
   printf '%s\n' "missing executable bin/rustfs in $artifact_root" >&2
   exit 42
@@ -31,28 +76,35 @@ PY
   exit 42
 }
 
-need grep
+need awk
 need mktemp
 need python3
+need sleep
 
-"$rustfs_binary" --version | grep -F "rustfs $expected_version" >/dev/null
+actual_version=$(actual_rustfs_version)
+[ "$actual_version" = "$expected_version" ] || {
+  printf '%s\n' "RustFS version mismatch: expected $expected_version, got ${actual_version:-<unknown>}" >&2
+  exit 43
+}
 
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/pv-rustfs-smoke.XXXXXX")
 data_dir="$tmp_dir/data"
 log_file="$tmp_dir/rustfs.log"
 api_port=$(available_port)
+console_port=$(available_port)
 access_key=pvsmokeaccess
 secret_key=pvsmokesecret1234567890
 bucket=pv-smoke-bucket
 mkdir -p "$data_dir"
+trap cleanup 0
 
 "$rustfs_binary" server \
   --address "127.0.0.1:$api_port" \
+  --console-address "127.0.0.1:$console_port" \
   --access-key "$access_key" \
   --secret-key "$secret_key" \
   "$data_dir" >"$log_file" 2>&1 &
 pid=$!
-trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; rm -rf "$tmp_dir"' 0
 
 endpoint="http://127.0.0.1:$api_port"
 export PV_RUSTFS_SMOKE_ENDPOINT="$endpoint"
@@ -139,7 +191,7 @@ def request(method, path):
         return response.status, response.read()
 
 last_error = None
-for _ in range(30):
+for _ in range(20):
     try:
         status, _body = request("GET", "/")
         if 200 <= status < 300:
@@ -161,3 +213,5 @@ if not 200 <= status < 300 or bucket.encode("utf-8") not in body:
     print("RustFS list buckets did not include smoke bucket", file=sys.stderr)
     sys.exit(45)
 PY
+
+stop_rustfs


### PR DESCRIPTION
## Summary
- Adds Mailpit default track `1` artifact recipes.
- Adds RustFS default track `1` artifact recipes using upstream `1.0.0-beta.7`.
- Adds metadata, legal files, smoke scripts, fixture coverage, and default-track integration for both resources.

## Stack
3/5. Base: `feat/pr25-redis-recipe-stack`. Next: `feat/pr25-sql-recipes-stack`.

## Test Plan
- `cargo nextest run -p pv-release --locked` (90/90 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all --check`
- `actionlint .github/workflows/artifact-publication.yml .github/workflows/artifact-recipes.yml .github/workflows/ci.yml`
- `shellcheck release/artifacts/recipes/common.sh release/artifacts/recipes/php/*.sh release/artifacts/recipes/composer/*.sh release/artifacts/recipes/redis/*.sh release/artifacts/recipes/mysql/*.sh release/artifacts/recipes/postgres/*.sh release/artifacts/recipes/mailpit/*.sh release/artifacts/recipes/rustfs/*.sh`
- `git diff --check`
- no pending `.snap.new`; no conflict markers

## Remaining Release Evidence
Draft until native Artifact Recipes and R2 publication verification are recorded under Solo todo 72.