### PR TITLE
feat(release): add SQL artifact recipes

### DIFF
--- a/.github/workflows/artifact-recipes.yml
+++ b/.github/workflows/artifact-recipes.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       resource:
-        description: "Resource to build: all, php, composer, redis, mailpit, rustfs"
+        description: "Resource to build: all, php, composer, redis, mysql, postgres, mailpit, rustfs"
         required: true
         default: "all"
         type: choice
@@ -13,10 +13,12 @@ on:
           - php
           - composer
           - redis
+          - mysql
+          - postgres
           - mailpit
           - rustfs
       track:
-        description: "Track to build: all, 8.2, 8.3, 8.4, 2, 1"
+        description: "Track to build: all, 8.2, 8.3, 8.4, 18, 2, 1"
         required: true
         default: "all"
         type: string
@@ -58,6 +60,8 @@ jobs:
             php:all | php:8.2 | php:8.3 | php:8.4) ;;
             composer:all | composer:2) ;;
             redis:all | redis:8.2) ;;
+            mysql:all | mysql:8.4) ;;
+            postgres:all | postgres:18) ;;
             mailpit:all | mailpit:1) ;;
             rustfs:all | rustfs:1) ;;
             *)
@@ -108,6 +112,8 @@ jobs:
             --php release/artifacts/recipes/php/tracks.toml \
             --composer release/artifacts/recipes/composer/composer.toml \
             --redis release/artifacts/recipes/redis/recipe.toml \
+            --mysql release/artifacts/recipes/mysql/recipe.toml \
+            --postgres release/artifacts/recipes/postgres/recipe.toml \
             --mailpit release/artifacts/recipes/mailpit/recipe.toml \
             --rustfs release/artifacts/recipes/rustfs/recipe.toml \
             --archives "$fixtures_dir/archives" \
@@ -139,6 +145,8 @@ jobs:
           build_php_family=false
           build_composer=false
           build_redis=false
+          build_mysql=false
+          build_postgres=false
           build_mailpit=false
           build_rustfs=false
           case "$PV_RECIPE_RESOURCE" in
@@ -146,6 +154,8 @@ jobs:
               build_php_family=true
               build_composer=true
               build_redis=true
+              build_mysql=true
+              build_postgres=true
               build_mailpit=true
               build_rustfs=true
               ;;
@@ -157,6 +167,12 @@ jobs:
               ;;
             redis)
               build_redis=true
+              ;;
+            mysql)
+              build_mysql=true
+              ;;
+            postgres)
+              build_postgres=true
               ;;
             mailpit)
               build_mailpit=true
@@ -197,6 +213,16 @@ jobs:
           if [ "$build_redis" = true ]; then
             PV_RECIPE_TRACK=8.2 \
               release/artifacts/recipes/redis/build.sh
+          fi
+
+          if [ "$build_mysql" = true ]; then
+            PV_RECIPE_TRACK=8.4 \
+              release/artifacts/recipes/mysql/build.sh
+          fi
+
+          if [ "$build_postgres" = true ]; then
+            PV_RECIPE_TRACK=18 \
+              release/artifacts/recipes/postgres/build.sh
           fi
 
           if [ "$build_mailpit" = true ]; then
@@ -244,6 +270,8 @@ jobs:
               write_default_track frankenphp "$php_default_track"
               write_default_track composer 2
               write_default_track redis 8.2
+              write_default_track mysql 8.4
+              write_default_track postgres 18
               write_default_track mailpit 1
               write_default_track rustfs 1
               ;;
@@ -256,6 +284,12 @@ jobs:
               ;;
             redis)
               write_default_track redis 8.2
+              ;;
+            mysql)
+              write_default_track mysql 8.4
+              ;;
+            postgres)
+              write_default_track postgres 18
               ;;
             mailpit)
               write_default_track mailpit 1

--- a/.github/workflows/artifact-recipes.yml
+++ b/.github/workflows/artifact-recipes.yml
@@ -18,7 +18,7 @@ on:
           - mailpit
           - rustfs
       track:
-        description: "Track to build: all, 8.2, 8.3, 8.4, 18, 2, 1"
+        description: "Track to build: all; PHP/all supports 8.2, 8.3, 8.4; resource tracks: composer 2, redis 8.2, mysql 8.4, postgres 18, mailpit 1, rustfs 1"
         required: true
         default: "all"
         type: string

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: cargo shear
 
       - name: Check artifact recipe scripts
-        run: shellcheck release/artifacts/recipes/common.sh release/artifacts/recipes/php/*.sh release/artifacts/recipes/composer/*.sh release/artifacts/recipes/redis/*.sh release/artifacts/recipes/mailpit/*.sh release/artifacts/recipes/rustfs/*.sh
+        run: shellcheck release/artifacts/recipes/common.sh release/artifacts/recipes/php/*.sh release/artifacts/recipes/composer/*.sh release/artifacts/recipes/redis/*.sh release/artifacts/recipes/mysql/*.sh release/artifacts/recipes/postgres/*.sh release/artifacts/recipes/mailpit/*.sh release/artifacts/recipes/rustfs/*.sh
 
       - name: Validate artifact recipe metadata and fixtures
         run: |
@@ -49,6 +49,8 @@ jobs:
             --php release/artifacts/recipes/php/tracks.toml \
             --composer release/artifacts/recipes/composer/composer.toml \
             --redis release/artifacts/recipes/redis/recipe.toml \
+            --mysql release/artifacts/recipes/mysql/recipe.toml \
+            --postgres release/artifacts/recipes/postgres/recipe.toml \
             --mailpit release/artifacts/recipes/mailpit/recipe.toml \
             --rustfs release/artifacts/recipes/rustfs/recipe.toml \
             --archives /tmp/pv-recipe-fixtures/archives \

--- a/crates/pv-release/src/cli.rs
+++ b/crates/pv-release/src/cli.rs
@@ -131,6 +131,10 @@ enum Command {
         #[arg(long)]
         redis: Option<Utf8PathBuf>,
         #[arg(long)]
+        mysql: Option<Utf8PathBuf>,
+        #[arg(long)]
+        postgres: Option<Utf8PathBuf>,
+        #[arg(long)]
         mailpit: Option<Utf8PathBuf>,
         #[arg(long)]
         rustfs: Option<Utf8PathBuf>,
@@ -264,6 +268,8 @@ pub fn run() -> anyhow::Result<()> {
             php,
             composer,
             redis,
+            mysql,
+            postgres,
             mailpit,
             rustfs,
             resource,
@@ -275,6 +281,8 @@ pub fn run() -> anyhow::Result<()> {
                     php: php.as_deref(),
                     composer: composer.as_deref(),
                     redis: redis.as_deref(),
+                    mysql: mysql.as_deref(),
+                    postgres: postgres.as_deref(),
                     mailpit: mailpit.as_deref(),
                     rustfs: rustfs.as_deref(),
                 },
@@ -295,6 +303,8 @@ struct RecipeEnvPaths<'a> {
     php: Option<&'a Utf8Path>,
     composer: Option<&'a Utf8Path>,
     redis: Option<&'a Utf8Path>,
+    mysql: Option<&'a Utf8Path>,
+    postgres: Option<&'a Utf8Path>,
     mailpit: Option<&'a Utf8Path>,
     rustfs: Option<&'a Utf8Path>,
 }
@@ -357,25 +367,46 @@ fn print_recipe_env(
     track: &str,
     platform: &str,
 ) -> anyhow::Result<String> {
-    match (
-        paths.php,
-        paths.composer,
-        paths.redis,
-        paths.mailpit,
-        paths.rustfs,
-    ) {
-        (Some(php), None, None, None, None) => {
-            let context = format!("failed to print PHP recipe environment for `{php}`");
-            crate::recipe::php_recipe_env(php, resource, track, platform).context(context)
+    let mut metadata_paths = Vec::new();
+    if let Some(path) = paths.php {
+        metadata_paths.push(("php", path));
+    }
+    if let Some(path) = paths.composer {
+        metadata_paths.push(("composer", path));
+    }
+    if let Some(path) = paths.redis {
+        metadata_paths.push(("redis", path));
+    }
+    if let Some(path) = paths.mysql {
+        metadata_paths.push(("mysql", path));
+    }
+    if let Some(path) = paths.postgres {
+        metadata_paths.push(("postgres", path));
+    }
+    if let Some(path) = paths.mailpit {
+        metadata_paths.push(("mailpit", path));
+    }
+    if let Some(path) = paths.rustfs {
+        metadata_paths.push(("rustfs", path));
+    }
+
+    let [(kind, path)] = metadata_paths.as_slice() else {
+        anyhow::bail!("print-recipe-env requires exactly one recipe metadata path");
+    };
+
+    match *kind {
+        "php" => {
+            let context = format!("failed to print PHP recipe environment for `{path}`");
+            crate::recipe::php_recipe_env(path, resource, track, platform).context(context)
         }
-        (None, Some(composer), None, None, None) => {
-            let context = format!("failed to print Composer recipe environment for `{composer}`");
-            crate::recipe::composer_recipe_env(composer, resource, track, platform).context(context)
+        "composer" => {
+            let context = format!("failed to print Composer recipe environment for `{path}`");
+            crate::recipe::composer_recipe_env(path, resource, track, platform).context(context)
         }
-        (None, None, Some(redis), None, None) => {
-            let context = format!("failed to print Redis recipe environment for `{redis}`");
+        "redis" => {
+            let context = format!("failed to print Redis recipe environment for `{path}`");
             crate::recipe::backing_recipe_env(
-                redis,
+                path,
                 BackingRecipeKind::Redis,
                 resource,
                 track,
@@ -383,10 +414,32 @@ fn print_recipe_env(
             )
             .context(context)
         }
-        (None, None, None, Some(mailpit), None) => {
-            let context = format!("failed to print Mailpit recipe environment for `{mailpit}`");
+        "mysql" => {
+            let context = format!("failed to print MySQL recipe environment for `{path}`");
             crate::recipe::backing_recipe_env(
-                mailpit,
+                path,
+                BackingRecipeKind::Mysql,
+                resource,
+                track,
+                platform,
+            )
+            .context(context)
+        }
+        "postgres" => {
+            let context = format!("failed to print Postgres recipe environment for `{path}`");
+            crate::recipe::backing_recipe_env(
+                path,
+                BackingRecipeKind::Postgres,
+                resource,
+                track,
+                platform,
+            )
+            .context(context)
+        }
+        "mailpit" => {
+            let context = format!("failed to print Mailpit recipe environment for `{path}`");
+            crate::recipe::backing_recipe_env(
+                path,
                 BackingRecipeKind::Mailpit,
                 resource,
                 track,
@@ -394,10 +447,10 @@ fn print_recipe_env(
             )
             .context(context)
         }
-        (None, None, None, None, Some(rustfs)) => {
-            let context = format!("failed to print RustFS recipe environment for `{rustfs}`");
+        "rustfs" => {
+            let context = format!("failed to print RustFS recipe environment for `{path}`");
             crate::recipe::backing_recipe_env(
-                rustfs,
+                path,
                 BackingRecipeKind::Rustfs,
                 resource,
                 track,
@@ -405,7 +458,7 @@ fn print_recipe_env(
             )
             .context(context)
         }
-        _ => anyhow::bail!("print-recipe-env requires exactly one recipe metadata path"),
+        _ => anyhow::bail!("unsupported recipe metadata path kind `{kind}`"),
     }
 }
 
@@ -885,6 +938,8 @@ mod tests {
                 php,
                 composer,
                 redis,
+                mysql,
+                postgres,
                 mailpit,
                 rustfs,
                 resource,
@@ -899,6 +954,8 @@ mod tests {
                     ))
                 );
                 assert_eq!(redis, None);
+                assert_eq!(mysql, None);
+                assert_eq!(postgres, None);
                 assert_eq!(mailpit, None);
                 assert_eq!(rustfs, None);
                 assert_eq!(resource, "composer");
@@ -930,6 +987,8 @@ mod tests {
                 php,
                 composer,
                 redis,
+                mysql,
+                postgres,
                 mailpit,
                 rustfs,
                 resource,
@@ -944,6 +1003,8 @@ mod tests {
                 );
                 assert_eq!(composer, None);
                 assert_eq!(redis, None);
+                assert_eq!(mysql, None);
+                assert_eq!(postgres, None);
                 assert_eq!(mailpit, None);
                 assert_eq!(rustfs, None);
                 assert_eq!(resource, "php");
@@ -975,6 +1036,8 @@ mod tests {
                 php,
                 composer,
                 redis,
+                mysql,
+                postgres,
                 mailpit,
                 rustfs,
                 resource,
@@ -989,10 +1052,110 @@ mod tests {
                         "release/artifacts/recipes/redis/recipe.toml"
                     ))
                 );
+                assert_eq!(mysql, None);
+                assert_eq!(postgres, None);
                 assert_eq!(mailpit, None);
                 assert_eq!(rustfs, None);
                 assert_eq!(resource, "redis");
                 assert_eq!(track, "8.2");
+                assert_eq!(platform, "darwin-arm64");
+                Ok(())
+            }
+            command => bail!("parsed unexpected command: {command:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_print_recipe_env_mysql_arguments() -> anyhow::Result<()> {
+        let args = Args::try_parse_from([
+            "pv-release",
+            "print-recipe-env",
+            "--mysql",
+            "release/artifacts/recipes/mysql/recipe.toml",
+            "--resource",
+            "mysql",
+            "--track",
+            "8.4",
+            "--platform",
+            "darwin-arm64",
+        ])?;
+
+        match args.command {
+            Command::PrintRecipeEnv {
+                php,
+                composer,
+                redis,
+                mysql,
+                postgres,
+                mailpit,
+                rustfs,
+                resource,
+                track,
+                platform,
+            } => {
+                assert_eq!(php, None);
+                assert_eq!(composer, None);
+                assert_eq!(redis, None);
+                assert_eq!(
+                    mysql,
+                    Some(Utf8PathBuf::from(
+                        "release/artifacts/recipes/mysql/recipe.toml"
+                    ))
+                );
+                assert_eq!(postgres, None);
+                assert_eq!(mailpit, None);
+                assert_eq!(rustfs, None);
+                assert_eq!(resource, "mysql");
+                assert_eq!(track, "8.4");
+                assert_eq!(platform, "darwin-arm64");
+                Ok(())
+            }
+            command => bail!("parsed unexpected command: {command:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_print_recipe_env_postgres_arguments() -> anyhow::Result<()> {
+        let args = Args::try_parse_from([
+            "pv-release",
+            "print-recipe-env",
+            "--postgres",
+            "release/artifacts/recipes/postgres/recipe.toml",
+            "--resource",
+            "postgres",
+            "--track",
+            "18",
+            "--platform",
+            "darwin-arm64",
+        ])?;
+
+        match args.command {
+            Command::PrintRecipeEnv {
+                php,
+                composer,
+                redis,
+                mysql,
+                postgres,
+                mailpit,
+                rustfs,
+                resource,
+                track,
+                platform,
+            } => {
+                assert_eq!(php, None);
+                assert_eq!(composer, None);
+                assert_eq!(redis, None);
+                assert_eq!(mysql, None);
+                assert_eq!(
+                    postgres,
+                    Some(Utf8PathBuf::from(
+                        "release/artifacts/recipes/postgres/recipe.toml"
+                    ))
+                );
+                assert_eq!(mailpit, None);
+                assert_eq!(rustfs, None);
+                assert_eq!(resource, "postgres");
+                assert_eq!(track, "18");
                 assert_eq!(platform, "darwin-arm64");
                 Ok(())
             }
@@ -1020,6 +1183,8 @@ mod tests {
                 php,
                 composer,
                 redis,
+                mysql,
+                postgres,
                 mailpit,
                 rustfs,
                 resource,
@@ -1029,6 +1194,8 @@ mod tests {
                 assert_eq!(php, None);
                 assert_eq!(composer, None);
                 assert_eq!(redis, None);
+                assert_eq!(mysql, None);
+                assert_eq!(postgres, None);
                 assert_eq!(
                     mailpit,
                     Some(Utf8PathBuf::from(
@@ -1065,6 +1232,8 @@ mod tests {
                 php,
                 composer,
                 redis,
+                mysql,
+                postgres,
                 mailpit,
                 rustfs,
                 resource,
@@ -1074,6 +1243,8 @@ mod tests {
                 assert_eq!(php, None);
                 assert_eq!(composer, None);
                 assert_eq!(redis, None);
+                assert_eq!(mysql, None);
+                assert_eq!(postgres, None);
                 assert_eq!(mailpit, None);
                 assert_eq!(
                     rustfs,
@@ -1095,6 +1266,7 @@ mod tests {
         let php = Utf8Path::new("release/artifacts/recipes/php/tracks.toml");
         let composer = Utf8Path::new("release/artifacts/recipes/composer/composer.toml");
         let redis = Utf8Path::new("release/artifacts/recipes/redis/recipe.toml");
+        let mysql = Utf8Path::new("release/artifacts/recipes/mysql/recipe.toml");
         let mailpit = Utf8Path::new("release/artifacts/recipes/mailpit/recipe.toml");
 
         assert!(
@@ -1133,6 +1305,7 @@ mod tests {
             print_recipe_env(
                 RecipeEnvPaths {
                     redis: Some(redis),
+                    mysql: Some(mysql),
                     mailpit: Some(mailpit),
                     ..RecipeEnvPaths::default()
                 },

--- a/crates/pv-release/tests/recipe_fixtures.rs
+++ b/crates/pv-release/tests/recipe_fixtures.rs
@@ -44,6 +44,8 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest() -> Result
     let php = workspace_root.join("release/artifacts/recipes/php/tracks.toml");
     let composer = workspace_root.join("release/artifacts/recipes/composer/composer.toml");
     let redis = workspace_root.join("release/artifacts/recipes/redis/recipe.toml");
+    let mysql = workspace_root.join("release/artifacts/recipes/mysql/recipe.toml");
+    let postgres = workspace_root.join("release/artifacts/recipes/postgres/recipe.toml");
     let mailpit = workspace_root.join("release/artifacts/recipes/mailpit/recipe.toml");
     let rustfs = workspace_root.join("release/artifacts/recipes/rustfs/recipe.toml");
     let defaults = workspace_root.join("release/artifacts/default-tracks.toml");
@@ -59,6 +61,8 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest() -> Result
         &composer,
         &[
             (BackingRecipeKind::Redis, redis.clone()),
+            (BackingRecipeKind::Mysql, mysql),
+            (BackingRecipeKind::Postgres, postgres),
             (BackingRecipeKind::Mailpit, mailpit),
             (BackingRecipeKind::Rustfs, rustfs),
         ],
@@ -120,12 +124,36 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest() -> Result
                 "darwin-arm64",
                 "mailpit-1.30.1-pv1-darwin-arm64",
             ),
+            ArchiveRoot::new(
+                "mysql",
+                "8.4",
+                "darwin-amd64",
+                "mysql-8.4.9-pv1-darwin-amd64"
+            ),
+            ArchiveRoot::new(
+                "mysql",
+                "8.4",
+                "darwin-arm64",
+                "mysql-8.4.9-pv1-darwin-arm64"
+            ),
             ArchiveRoot::new("php", "8.2", "darwin-amd64", "php-8.2.31-pv1-darwin-amd64"),
             ArchiveRoot::new("php", "8.2", "darwin-arm64", "php-8.2.31-pv1-darwin-arm64"),
             ArchiveRoot::new("php", "8.3", "darwin-amd64", "php-8.3.31-pv1-darwin-amd64"),
             ArchiveRoot::new("php", "8.3", "darwin-arm64", "php-8.3.31-pv1-darwin-arm64"),
             ArchiveRoot::new("php", "8.4", "darwin-amd64", "php-8.4.20-pv1-darwin-amd64"),
             ArchiveRoot::new("php", "8.4", "darwin-arm64", "php-8.4.20-pv1-darwin-arm64"),
+            ArchiveRoot::new(
+                "postgres",
+                "18",
+                "darwin-amd64",
+                "postgres-18.3-pv1-darwin-amd64",
+            ),
+            ArchiveRoot::new(
+                "postgres",
+                "18",
+                "darwin-arm64",
+                "postgres-18.3-pv1-darwin-arm64",
+            ),
             ArchiveRoot::new(
                 "redis",
                 "8.2",
@@ -181,6 +209,8 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest_with_backin
     let mailpit = workspace_root.join("release/artifacts/recipes/mailpit/recipe.toml");
     let rustfs = workspace_root.join("release/artifacts/recipes/rustfs/recipe.toml");
     let defaults = workspace_root.join("release/artifacts/default-tracks.toml");
+    let mysql = workspace_root.join("release/artifacts/recipes/mysql/recipe.toml");
+    let postgres = workspace_root.join("release/artifacts/recipes/postgres/recipe.toml");
     let redis = tempdir
         .path()
         .join("release/artifacts/recipes/redis/recipe.toml");
@@ -192,6 +222,8 @@ fn recipe_fixture_generation_validates_archives_records_and_manifest_with_backin
         &composer,
         &[
             (BackingRecipeKind::Redis, redis.clone()),
+            (BackingRecipeKind::Mysql, mysql),
+            (BackingRecipeKind::Postgres, postgres),
             (BackingRecipeKind::Mailpit, mailpit),
             (BackingRecipeKind::Rustfs, rustfs),
         ],

--- a/crates/pv-release/tests/recipe_metadata.rs
+++ b/crates/pv-release/tests/recipe_metadata.rs
@@ -93,6 +93,14 @@ fn committed_recipe_metadata_parses() -> Result<()> {
         &workspace_root.join("release/artifacts/recipes/redis/recipe.toml"),
         BackingRecipeKind::Redis,
     )?;
+    let mysql = BackingRecipe::load(
+        &workspace_root.join("release/artifacts/recipes/mysql/recipe.toml"),
+        BackingRecipeKind::Mysql,
+    )?;
+    let postgres = BackingRecipe::load(
+        &workspace_root.join("release/artifacts/recipes/postgres/recipe.toml"),
+        BackingRecipeKind::Postgres,
+    )?;
     let mailpit = BackingRecipe::load(
         &workspace_root.join("release/artifacts/recipes/mailpit/recipe.toml"),
         BackingRecipeKind::Mailpit,
@@ -111,6 +119,24 @@ fn committed_recipe_metadata_parses() -> Result<()> {
     assert_eq!(redis.default_track().as_str(), "8.2");
     assert_eq!(redis.tracks().len(), 1);
     assert_eq!(redis.payload_paths(), ["bin/redis-server", "bin/redis-cli"]);
+    assert_eq!(mysql.default_track().as_str(), "8.4");
+    assert_eq!(
+        mysql
+            .tracks()
+            .iter()
+            .map(|track| (track.name().as_str(), track.upstream_version()))
+            .collect::<Vec<_>>(),
+        vec![("8.4", "8.4.9")]
+    );
+    assert_eq!(postgres.default_track().as_str(), "18");
+    assert_eq!(
+        postgres
+            .tracks()
+            .iter()
+            .map(|track| (track.name().as_str(), track.upstream_version()))
+            .collect::<Vec<_>>(),
+        vec![("18", "18.3")]
+    );
     assert_eq!(mailpit.default_track().as_str(), "1");
     assert_eq!(mailpit.payload_paths(), ["bin/mailpit"]);
     assert_eq!(rustfs.default_track().as_str(), "1");
@@ -119,6 +145,8 @@ fn committed_recipe_metadata_parses() -> Result<()> {
     assert_default_track(&defaults, "frankenphp", "8.4")?;
     assert_default_track(&defaults, "composer", "2")?;
     assert_default_track(&defaults, "redis", "8.2")?;
+    assert_default_track(&defaults, "mysql", "8.4")?;
+    assert_default_track(&defaults, "postgres", "18")?;
     assert_default_track(&defaults, "mailpit", "1")?;
     assert_default_track(&defaults, "rustfs", "1")?;
 
@@ -428,6 +456,42 @@ fn print_recipe_env_redis() -> Result<()> {
 }
 
 #[test]
+fn print_recipe_env_mysql() -> Result<()> {
+    let tempdir = tempdir()?;
+    let mysql = tempdir.path().join("recipe.toml");
+    write_file(&mysql, VALID_MYSQL_TOML)?;
+
+    let env = backing_recipe_env(
+        &mysql,
+        BackingRecipeKind::Mysql,
+        "mysql",
+        "8.4",
+        "darwin-arm64",
+    )?;
+
+    assert_snapshot!(env);
+    Ok(())
+}
+
+#[test]
+fn print_recipe_env_postgres() -> Result<()> {
+    let tempdir = tempdir()?;
+    let postgres = tempdir.path().join("recipe.toml");
+    write_file(&postgres, VALID_POSTGRES_TOML)?;
+
+    let env = backing_recipe_env(
+        &postgres,
+        BackingRecipeKind::Postgres,
+        "postgres",
+        "18",
+        "darwin-arm64",
+    )?;
+
+    assert_snapshot!(env);
+    Ok(())
+}
+
+#[test]
 fn print_backing_recipe_env_mailpit() -> Result<()> {
     let tempdir = tempdir()?;
     let mailpit = tempdir.path().join("recipe.toml");
@@ -619,4 +683,44 @@ source_sha256 = "1cce392a19a6093fcc859aeb87d9999671fed9a0a7a1c227a7f7df6307741be
 platform = "darwin-amd64"
 source_url = "https://github.com/axllent/mailpit/releases/download/v1.30.1/mailpit-darwin-amd64.tar.gz"
 source_sha256 = "a2d7df1b34967e51604b42136260789b75a45233a03c9dc773b98024e1390974"
+"#;
+
+const VALID_MYSQL_TOML: &str = r#"
+[recipe]
+resources = ["mysql"]
+default_track = "8.4"
+platforms = ["darwin-arm64", "darwin-amd64"]
+minimum_pv_version = "0.1.0"
+pv_build_revision = "pv1"
+license_files = ["LICENSE"]
+notice_files = ["NOTICE"]
+
+[artifact]
+payload_paths = ["bin/mysqld", "bin/mysql", "bin/mysqladmin"]
+
+[[tracks]]
+name = "8.4"
+upstream_version = "8.4.9"
+source_url = "https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9.tar.gz"
+source_sha256 = "e4aa8b39e42d1fe078f33bbd73695fac2b54dbc7bb137f0bdbe63f7be1a02d6b"
+"#;
+
+const VALID_POSTGRES_TOML: &str = r#"
+[recipe]
+resources = ["postgres"]
+default_track = "18"
+platforms = ["darwin-arm64", "darwin-amd64"]
+minimum_pv_version = "0.1.0"
+pv_build_revision = "pv1"
+license_files = ["LICENSE"]
+notice_files = ["NOTICE"]
+
+[artifact]
+payload_paths = ["bin/postgres", "bin/initdb", "bin/pg_ctl", "bin/psql"]
+
+[[tracks]]
+name = "18"
+upstream_version = "18.3"
+source_url = "https://ftp.postgresql.org/pub/source/v18.3/postgresql-18.3.tar.gz"
+source_sha256 = "9e054ffd6e013da2c2c9a1bfd6e062c98875d340df080516551c96b9b0926a59"
 "#;

--- a/crates/pv-release/tests/recipe_metadata.rs
+++ b/crates/pv-release/tests/recipe_metadata.rs
@@ -121,6 +121,10 @@ fn committed_recipe_metadata_parses() -> Result<()> {
     assert_eq!(redis.payload_paths(), ["bin/redis-server", "bin/redis-cli"]);
     assert_eq!(mysql.default_track().as_str(), "8.4");
     assert_eq!(
+        mysql.payload_paths(),
+        ["bin/mysqld", "bin/mysql", "bin/mysqladmin"]
+    );
+    assert_eq!(
         mysql
             .tracks()
             .iter()
@@ -129,6 +133,10 @@ fn committed_recipe_metadata_parses() -> Result<()> {
         vec![("8.4", "8.4.9")]
     );
     assert_eq!(postgres.default_track().as_str(), "18");
+    assert_eq!(
+        postgres.payload_paths(),
+        ["bin/postgres", "bin/initdb", "bin/pg_ctl", "bin/psql"]
+    );
     assert_eq!(
         postgres
             .tracks()

--- a/crates/pv-release/tests/smoke.rs
+++ b/crates/pv-release/tests/smoke.rs
@@ -781,6 +781,130 @@ fn rustfs_build_recipe_rejects_newer_macho_minimum_os() -> Result<()> {
 }
 
 #[test]
+fn common_recipe_helper_ad_hoc_signs_macho_files() -> Result<()> {
+    let tempdir = tempdir()?;
+    let fake_bin = tempdir.path().join("bin");
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+    let artifact_lib = artifact_root.join("lib");
+    let sign_log = tempdir.path().join("codesign.log");
+    let harness = tempdir.path().join("sign-harness.sh");
+    let common =
+        Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../release/artifacts/recipes/common.sh");
+
+    create_dir_all(&fake_bin)?;
+    create_dir_all(&artifact_bin)?;
+    create_dir_all(&artifact_lib)?;
+    write_file(&artifact_bin.join("mysql"), "mach-o fixture\n")?;
+    write_file(&artifact_bin.join("mysqladmin"), "mach-o fixture\n")?;
+    write_file(&artifact_bin.join("README"), "plain text\n")?;
+    write_file(
+        &artifact_lib.join("libmysqlclient.dylib"),
+        "mach-o fixture\n",
+    )?;
+    write_file(&sign_log, "")?;
+    write_fake_signing_otool(&fake_bin.join("otool"))?;
+    write_fake_codesign(&fake_bin.join("codesign"))?;
+    write_executable(
+        &harness,
+        r#"#!/bin/sh
+set -eu
+
+# shellcheck source=/dev/null
+. "$PV_TEST_COMMON_SH"
+pv_recipe_ad_hoc_sign_macho_tree "$PV_TEST_ARTIFACT_ROOT"
+"#,
+    )?;
+
+    let output = StdCommand::new(&harness)
+        .env("PATH", format!("{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"))
+        .env("PV_TEST_ARTIFACT_ROOT", &artifact_root)
+        .env("PV_TEST_CODESIGN_LOG", &sign_log)
+        .env("PV_TEST_COMMON_SH", &common)
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "signing helper failed: {}",
+        command_output_debug(&output)
+    );
+    assert_debug_snapshot!(read_file(&sign_log)?.replace(tempdir.path().as_str(), "<tmp>"));
+
+    Ok(())
+}
+
+#[test]
+fn common_recipe_helper_rewrites_nested_macho_install_names() -> Result<()> {
+    let tempdir = tempdir()?;
+    let fake_bin = tempdir.path().join("bin");
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+    let artifact_lib = artifact_root.join("lib");
+    let artifact_plugin = artifact_lib.join("plugin");
+    let artifact_postgresql = artifact_lib.join("postgresql");
+    let install_name_log = tempdir.path().join("install-name.log");
+    let harness = tempdir.path().join("rewrite-harness.sh");
+    let common =
+        Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../release/artifacts/recipes/common.sh");
+
+    create_dir_all(&fake_bin)?;
+    create_dir_all(&artifact_bin)?;
+    create_dir_all(&artifact_lib)?;
+    create_dir_all(&artifact_plugin)?;
+    create_dir_all(&artifact_postgresql)?;
+    write_file(&artifact_bin.join("mysql"), "mach-o fixture\n")?;
+    write_file(
+        &artifact_lib.join("libmysqlclient.dylib"),
+        "mach-o fixture\n",
+    )?;
+    write_file(&artifact_plugin.join("auth.so"), "mach-o fixture\n")?;
+    write_file(
+        &artifact_postgresql.join("extension.so"),
+        "mach-o fixture\n",
+    )?;
+    write_file(&install_name_log, "")?;
+    write_fake_install_name_otool(&fake_bin.join("otool"))?;
+    write_fake_install_name_tool(&fake_bin.join("install_name_tool"))?;
+    write_executable(
+        &harness,
+        r#"#!/bin/sh
+set -eu
+
+# shellcheck source=/dev/null
+. "$PV_TEST_COMMON_SH"
+rewrite_macho_install_names "$PV_TEST_ARTIFACT_ROOT" "$PV_TEST_INSTALL_DIR"
+"#,
+    )?;
+
+    let install_dir = "/opt/pv-mysql";
+    let output = StdCommand::new(&harness)
+        .env("PATH", format!("{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"))
+        .env("PV_TEST_ARTIFACT_ROOT", &artifact_root)
+        .env("PV_TEST_COMMON_SH", &common)
+        .env("PV_TEST_INSTALL_DIR", install_dir)
+        .env("PV_TEST_INSTALL_NAME_LOG", &install_name_log)
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "rewrite helper failed: {}",
+        command_output_debug(&output)
+    );
+
+    let mut rewrites = read_file(&install_name_log)?
+        .lines()
+        .map(|line| {
+            line.replace(tempdir.path().as_str(), "<tmp>")
+                .replace(install_dir, "<install>")
+        })
+        .collect::<Vec<_>>();
+    rewrites.sort();
+    assert_debug_snapshot!(rewrites);
+
+    Ok(())
+}
+
+#[test]
 fn php_build_smoke_rejects_unexpected_macho_architecture() -> Result<()> {
     let run = run_php_build_recipe_smoke_with_options(BuildRecipeOptions {
         lipo_archs: "x86_64",
@@ -2270,6 +2394,77 @@ EOF
     exit 78
     ;;
 esac
+"#,
+    )
+}
+
+fn write_fake_signing_otool(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+[ "${1:-}" = "-L" ] || exit 78
+case "${2##*/}" in
+  mysql | mysqladmin | libmysqlclient.dylib)
+    printf '%s:\n' "$2"
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+"#,
+    )
+}
+
+fn write_fake_install_name_otool(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+mode=${1:-}
+binary=${2:-}
+
+case "$mode" in
+  -D)
+    printf '%s:\n' "$binary"
+    case "$binary" in
+      */lib/libmysqlclient.dylib)
+        printf '%s/lib/libmysqlclient.dylib\n' "$PV_TEST_INSTALL_DIR"
+        ;;
+    esac
+    ;;
+  -L)
+    case "$binary" in
+      */bin/mysql | */lib/libmysqlclient.dylib | */lib/plugin/auth.so | */lib/postgresql/extension.so)
+        printf '%s:\n' "$binary"
+        printf '\t%s/lib/libmysqlclient.dylib (compatibility version 1.0.0, current version 1.0.0)\n' "$PV_TEST_INSTALL_DIR"
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  *)
+    exit 78
+    ;;
+esac
+"#,
+    )
+}
+
+fn write_fake_install_name_tool(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+printf 'argv=' >>"$PV_TEST_INSTALL_NAME_LOG"
+for arg in "$@"; do
+  printf '[%s]' "$arg" >>"$PV_TEST_INSTALL_NAME_LOG"
+done
+printf '\n' >>"$PV_TEST_INSTALL_NAME_LOG"
 "#,
     )
 }

--- a/crates/pv-release/tests/smoke.rs
+++ b/crates/pv-release/tests/smoke.rs
@@ -524,7 +524,7 @@ fn redis_smoke_kills_server_when_shutdown_fails() -> Result<()> {
         &artifact_bin.join("redis-server"),
         r#"#!/bin/sh
 set -eu
-exec /bin/sleep 5
+exec /bin/sleep 10
 "#,
     )?;
     write_executable(
@@ -550,7 +550,7 @@ exit 72
         command_output_debug(&output)
     );
     assert!(
-        started.elapsed() < Duration::from_secs(5),
+        started.elapsed() < Duration::from_secs(10),
         "Redis smoke should kill the server instead of waiting for it to exit"
     );
 
@@ -613,7 +613,7 @@ fn mailpit_smoke_fails_when_server_does_not_stop() -> Result<()> {
             format!("{command_bin}:/usr/bin:/bin:/usr/sbin:/sbin"),
         )
         .env("PV_TEST_MAILPIT_IGNORE_TERM", "1")
-        .env("PV_TEST_MAILPIT_SLEEP_SECONDS", "3")
+        .env("PV_TEST_MAILPIT_SLEEP_SECONDS", "10")
         .env("PV_TEST_MAILPIT_VERSION_OUTPUT", "Mailpit v1.30.1")
         .env("PV_UPSTREAM_VERSION", "1.30.1")
         .output()?;
@@ -624,7 +624,7 @@ fn mailpit_smoke_fails_when_server_does_not_stop() -> Result<()> {
         command_output_debug(&output)
     );
     assert!(
-        started.elapsed() < Duration::from_secs(3),
+        started.elapsed() < Duration::from_secs(10),
         "Mailpit smoke should use a bounded shutdown wait"
     );
 
@@ -706,7 +706,7 @@ fn rustfs_smoke_fails_when_server_does_not_stop() -> Result<()> {
     let output = StdCommand::new(rustfs_smoke_hook())
         .arg(&artifact_root)
         .env("PV_TEST_RUSTFS_IGNORE_TERM", "1")
-        .env("PV_TEST_RUSTFS_SLEEP_SECONDS", "3")
+        .env("PV_TEST_RUSTFS_SLEEP_SECONDS", "10")
         .env("PV_TEST_RUSTFS_VERSION_OUTPUT", "rustfs 1.0.0-beta.7")
         .env("PV_UPSTREAM_VERSION", "1.0.0-beta.7")
         .output()?;
@@ -717,7 +717,7 @@ fn rustfs_smoke_fails_when_server_does_not_stop() -> Result<()> {
         command_output_debug(&output)
     );
     assert!(
-        started.elapsed() < Duration::from_secs(3),
+        started.elapsed() < Duration::from_secs(10),
         "RustFS smoke should use a bounded shutdown wait"
     );
 
@@ -900,6 +900,155 @@ rewrite_macho_install_names "$PV_TEST_ARTIFACT_ROOT" "$PV_TEST_INSTALL_DIR"
         .collect::<Vec<_>>();
     rewrites.sort();
     assert_debug_snapshot!(rewrites);
+
+    Ok(())
+}
+
+#[test]
+fn common_recipe_helper_fails_when_signing_one_macho_file_fails() -> Result<()> {
+    let tempdir = tempdir()?;
+    let fake_bin = tempdir.path().join("bin");
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+    let sign_count = tempdir.path().join("codesign.count");
+    let harness = tempdir.path().join("sign-fail-harness.sh");
+    let common =
+        Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../release/artifacts/recipes/common.sh");
+
+    create_dir_all(&fake_bin)?;
+    create_dir_all(&artifact_bin)?;
+    write_file(&artifact_bin.join("mysql"), "mach-o fixture\n")?;
+    write_file(&artifact_bin.join("mysqladmin"), "mach-o fixture\n")?;
+    write_fake_signing_otool(&fake_bin.join("otool"))?;
+    write_fake_first_call_failing_codesign(&fake_bin.join("codesign"))?;
+    write_file(&sign_count, "0\n")?;
+    write_executable(
+        &harness,
+        r#"#!/bin/sh
+set -eu
+
+# shellcheck source=/dev/null
+. "$PV_TEST_COMMON_SH"
+pv_recipe_ad_hoc_sign_macho_tree "$PV_TEST_ARTIFACT_ROOT"
+"#,
+    )?;
+
+    let output = StdCommand::new(&harness)
+        .env("PATH", format!("{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"))
+        .env("PV_TEST_ARTIFACT_ROOT", &artifact_root)
+        .env("PV_TEST_CODESIGN_COUNT", &sign_count)
+        .env("PV_TEST_COMMON_SH", &common)
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "signing helper should fail on the first failed file: {}",
+        command_output_debug(&output)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn common_recipe_helper_fails_when_install_name_rewrite_fails() -> Result<()> {
+    let tempdir = tempdir()?;
+    let fake_bin = tempdir.path().join("bin");
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_lib = artifact_root.join("lib");
+    let install_name_count = tempdir.path().join("install-name.count");
+    let harness = tempdir.path().join("rewrite-fail-harness.sh");
+    let common =
+        Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../release/artifacts/recipes/common.sh");
+
+    create_dir_all(&fake_bin)?;
+    create_dir_all(&artifact_lib)?;
+    write_file(&artifact_lib.join("liba.dylib"), "mach-o fixture\n")?;
+    write_file(&artifact_lib.join("libz.dylib"), "mach-o fixture\n")?;
+    write_fake_rewrite_failure_otool(&fake_bin.join("otool"))?;
+    write_fake_first_call_failing_install_name_tool(&fake_bin.join("install_name_tool"))?;
+    write_file(&install_name_count, "0\n")?;
+    write_executable(
+        &harness,
+        r#"#!/bin/sh
+set -eu
+
+# shellcheck source=/dev/null
+. "$PV_TEST_COMMON_SH"
+rewrite_macho_install_names "$PV_TEST_ARTIFACT_ROOT" "$PV_TEST_INSTALL_DIR"
+"#,
+    )?;
+
+    let output = StdCommand::new(&harness)
+        .env("PATH", format!("{fake_bin}:/usr/bin:/bin:/usr/sbin:/sbin"))
+        .env("PV_TEST_ARTIFACT_ROOT", &artifact_root)
+        .env("PV_TEST_COMMON_SH", &common)
+        .env("PV_TEST_INSTALL_DIR", "/opt/pv-mysql")
+        .env("PV_TEST_INSTALL_NAME_COUNT", &install_name_count)
+        .output()?;
+
+    assert!(
+        !output.status.success(),
+        "rewrite helper should fail on the first failed file: {}",
+        command_output_debug(&output)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mysql_smoke_uses_tcp_readiness_and_select() -> Result<()> {
+    let tempdir = tempdir()?;
+    let artifact_root = tempdir.path().join("artifact");
+    let artifact_bin = artifact_root.join("bin");
+    let command_bin = tempdir.path().join("commands");
+
+    create_dir_all(&artifact_bin)?;
+    create_dir_all(&command_bin)?;
+    write_fake_mysql_server(&artifact_bin.join("mysqld"))?;
+    write_fake_mysqladmin_requires_tcp(&artifact_bin.join("mysqladmin"))?;
+    write_fake_mysql_requires_tcp(&artifact_bin.join("mysql"))?;
+    write_executable(&command_bin.join("sleep"), "#!/bin/sh\nexit 0\n")?;
+
+    let output = StdCommand::new(mysql_smoke_hook())
+        .arg(&artifact_root)
+        .env(
+            "PATH",
+            format!("{command_bin}:/usr/bin:/bin:/usr/sbin:/sbin"),
+        )
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "MySQL smoke should validate TCP readiness and SELECT 1: {}",
+        command_output_debug(&output)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn sql_build_recipes_pin_macos_deployment_target() -> Result<()> {
+    let workspace_root = Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let mysql_build = read_file(&workspace_root.join("release/artifacts/recipes/mysql/build.sh"))?;
+    let postgres_build =
+        read_file(&workspace_root.join("release/artifacts/recipes/postgres/build.sh"))?;
+
+    assert!(
+        mysql_build.contains("\nDEPLOYMENT_TARGET=13.0\n"),
+        "MySQL build recipe should pin the deployment target to macOS 13.0"
+    );
+    assert!(
+        !mysql_build.contains("PV_MACOSX_DEPLOYMENT_TARGET"),
+        "MySQL build recipe should not allow caller-controlled deployment targets"
+    );
+    assert!(
+        postgres_build.contains("\nDEPLOYMENT_TARGET=13.0\n"),
+        "Postgres build recipe should pin the deployment target to macOS 13.0"
+    );
+    assert!(
+        !postgres_build.contains("PV_MACOSX_DEPLOYMENT_TARGET"),
+        "Postgres build recipe should not allow caller-controlled deployment targets"
+    );
 
     Ok(())
 }
@@ -1171,6 +1320,10 @@ fn composer_smoke_hook() -> camino::Utf8PathBuf {
 
 fn redis_smoke_hook() -> camino::Utf8PathBuf {
     Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../release/artifacts/recipes/redis/smoke.sh")
+}
+
+fn mysql_smoke_hook() -> camino::Utf8PathBuf {
+    Utf8Path::new(env!("CARGO_MANIFEST_DIR")).join("../../release/artifacts/recipes/mysql/smoke.sh")
 }
 
 fn mailpit_smoke_hook() -> camino::Utf8PathBuf {
@@ -2333,6 +2486,84 @@ PY
     )
 }
 
+fn write_fake_mysql_server(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+for arg in "$@"; do
+  case "$arg" in
+    --initialize-insecure)
+      exit 0
+      ;;
+  esac
+done
+
+exit 0
+"#,
+    )
+}
+
+fn write_fake_mysqladmin_requires_tcp(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+protocol=
+command=
+for arg in "$@"; do
+  case "$arg" in
+    --protocol=*)
+      protocol=${arg#--protocol=}
+      ;;
+    ping | shutdown)
+      command=$arg
+      ;;
+  esac
+done
+
+[ "$protocol" = "tcp" ] || exit 70
+case "$command" in
+  ping | shutdown) exit 0 ;;
+  *) exit 78 ;;
+esac
+"#,
+    )
+}
+
+fn write_fake_mysql_requires_tcp(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+protocol=
+host=
+port=
+for arg in "$@"; do
+  case "$arg" in
+    --protocol=*)
+      protocol=${arg#--protocol=}
+      ;;
+    --host=*)
+      host=${arg#--host=}
+      ;;
+    --port=*)
+      port=${arg#--port=}
+      ;;
+  esac
+done
+
+[ "$protocol" = "tcp" ] || exit 70
+[ "$host" = "127.0.0.1" ] || exit 71
+[ -n "$port" ] || exit 72
+printf '%s\n' 1
+"#,
+    )
+}
+
 fn write_fake_lipo(path: &Utf8Path) -> Result<()> {
     write_executable(
         path,
@@ -2469,6 +2700,46 @@ printf '\n' >>"$PV_TEST_INSTALL_NAME_LOG"
     )
 }
 
+fn write_fake_rewrite_failure_otool(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+mode=${1:-}
+binary=${2:-}
+
+case "$mode" in
+  -D)
+    printf '%s:\n' "$binary"
+    printf '%s/lib/%s\n' "$PV_TEST_INSTALL_DIR" "${binary##*/}"
+    ;;
+  -L)
+    printf '%s:\n' "$binary"
+    ;;
+  *)
+    exit 78
+    ;;
+esac
+"#,
+    )
+}
+
+fn write_fake_first_call_failing_install_name_tool(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+count=$(cat "$PV_TEST_INSTALL_NAME_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" >"$PV_TEST_INSTALL_NAME_COUNT"
+[ "$count" -ne 1 ] || exit 71
+exit 0
+"#,
+    )
+}
+
 fn write_fake_spc(path: &Utf8Path) -> Result<()> {
     write_executable(
         path,
@@ -2540,6 +2811,21 @@ for arg in "$@"; do
   printf '[%s]' "$arg" >>"$PV_TEST_CODESIGN_LOG"
 done
 printf '\n' >>"$PV_TEST_CODESIGN_LOG"
+"#,
+    )
+}
+
+fn write_fake_first_call_failing_codesign(path: &Utf8Path) -> Result<()> {
+    write_executable(
+        path,
+        r#"#!/bin/sh
+set -eu
+
+count=$(cat "$PV_TEST_CODESIGN_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" >"$PV_TEST_CODESIGN_COUNT"
+[ "$count" -ne 1 ] || exit 71
+exit 0
 "#,
     )
 }

--- a/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_archives_records_and_manifest.snap
+++ b/crates/pv-release/tests/snapshots/recipe_fixtures__recipe_fixture_generation_validates_archives_records_and_manifest.snap
@@ -275,6 +275,51 @@ expression: manifest_json
       ]
     },
     {
+      "name": "mysql",
+      "default_track": "8.4",
+      "tracks": [
+        {
+          "name": "8.4",
+          "artifacts": [
+            {
+              "artifact_version": "8.4.9-pv1",
+              "upstream_version": "8.4.9",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-amd64",
+              "url": "https://artifacts.example.test/resources/mysql/8.4/8.4.9-pv1/darwin-amd64/mysql-8.4.9-pv1-darwin-amd64.tar.gz",
+              "sha256": "140e3b8bf6b1027b876dea2442a9de3c255d46807f3b188ae059f4cd8c8add9c",
+              "size": 242,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9.tar.gz",
+                "source_sha256": "e4aa8b39e42d1fe078f33bbd73695fac2b54dbc7bb137f0bdbe63f7be1a02d6b",
+                "recipe": "release/artifacts/recipes/mysql/recipe.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            },
+            {
+              "artifact_version": "8.4.9-pv1",
+              "upstream_version": "8.4.9",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-arm64",
+              "url": "https://artifacts.example.test/resources/mysql/8.4/8.4.9-pv1/darwin-arm64/mysql-8.4.9-pv1-darwin-arm64.tar.gz",
+              "sha256": "cd4c719eff4500b9029df3d4fe818e454d3f697fcf2dc1a28339935693d9abe6",
+              "size": 241,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9.tar.gz",
+                "source_sha256": "e4aa8b39e42d1fe078f33bbd73695fac2b54dbc7bb137f0bdbe63f7be1a02d6b",
+                "recipe": "release/artifacts/recipes/mysql/recipe.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "php",
       "default_track": "8.4",
       "tracks": [
@@ -389,6 +434,51 @@ expression: manifest_json
                 "source_url": "https://www.php.net/distributions/php-8.4.20.tar.gz",
                 "source_sha256": "a2def5d534d57c6a0236f2265de7537608af871900a4f7955eff463e9e38247d",
                 "recipe": "release/artifacts/recipes/php/tracks.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "postgres",
+      "default_track": "18",
+      "tracks": [
+        {
+          "name": "18",
+          "artifacts": [
+            {
+              "artifact_version": "18.3-pv1",
+              "upstream_version": "18.3",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-amd64",
+              "url": "https://artifacts.example.test/resources/postgres/18/18.3-pv1/darwin-amd64/postgres-18.3-pv1-darwin-amd64.tar.gz",
+              "sha256": "7ba0ea5e85a170ffd53fd5a457892fe75bed6a3b4786500b1dac29598169d931",
+              "size": 264,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://ftp.postgresql.org/pub/source/v18.3/postgresql-18.3.tar.gz",
+                "source_sha256": "9e054ffd6e013da2c2c9a1bfd6e062c98875d340df080516551c96b9b0926a59",
+                "recipe": "release/artifacts/recipes/postgres/recipe.toml",
+                "pv_commit": "0123456789abcdef0123456789abcdef01234567",
+                "build_run_id": "local-test"
+              }
+            },
+            {
+              "artifact_version": "18.3-pv1",
+              "upstream_version": "18.3",
+              "pv_build_revision": "pv1",
+              "platform": "darwin-arm64",
+              "url": "https://artifacts.example.test/resources/postgres/18/18.3-pv1/darwin-arm64/postgres-18.3-pv1-darwin-arm64.tar.gz",
+              "sha256": "6c76187ba10776de7e60c4c024057f3739d2296a9cace78341dca4c03371f33a",
+              "size": 263,
+              "published_at": "2026-01-01T00:00:00Z",
+              "provenance": {
+                "source_url": "https://ftp.postgresql.org/pub/source/v18.3/postgresql-18.3.tar.gz",
+                "source_sha256": "9e054ffd6e013da2c2c9a1bfd6e062c98875d340df080516551c96b9b0926a59",
+                "recipe": "release/artifacts/recipes/postgres/recipe.toml",
                 "pv_commit": "0123456789abcdef0123456789abcdef01234567",
                 "build_run_id": "local-test"
               }

--- a/crates/pv-release/tests/snapshots/recipe_metadata__print_recipe_env_mysql.snap
+++ b/crates/pv-release/tests/snapshots/recipe_metadata__print_recipe_env_mysql.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pv-release/tests/recipe_metadata.rs
+expression: env
+---
+PV_RESOURCE='mysql'
+PV_TRACK='8.4'
+PV_PLATFORM='darwin-arm64'
+PV_UPSTREAM_VERSION='8.4.9'
+PV_ARTIFACT_VERSION='8.4.9-pv1'
+PV_SOURCE_URL='https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9.tar.gz'
+PV_SOURCE_SHA256='e4aa8b39e42d1fe078f33bbd73695fac2b54dbc7bb137f0bdbe63f7be1a02d6b'
+PV_MINIMUM_PV_VERSION='0.1.0'
+PV_PV_BUILD_REVISION='pv1'

--- a/crates/pv-release/tests/snapshots/recipe_metadata__print_recipe_env_postgres.snap
+++ b/crates/pv-release/tests/snapshots/recipe_metadata__print_recipe_env_postgres.snap
@@ -1,0 +1,13 @@
+---
+source: crates/pv-release/tests/recipe_metadata.rs
+expression: env
+---
+PV_RESOURCE='postgres'
+PV_TRACK='18'
+PV_PLATFORM='darwin-arm64'
+PV_UPSTREAM_VERSION='18.3'
+PV_ARTIFACT_VERSION='18.3-pv1'
+PV_SOURCE_URL='https://ftp.postgresql.org/pub/source/v18.3/postgresql-18.3.tar.gz'
+PV_SOURCE_SHA256='9e054ffd6e013da2c2c9a1bfd6e062c98875d340df080516551c96b9b0926a59'
+PV_MINIMUM_PV_VERSION='0.1.0'
+PV_PV_BUILD_REVISION='pv1'

--- a/crates/pv-release/tests/snapshots/smoke__common_recipe_helper_ad_hoc_signs_macho_files.snap
+++ b/crates/pv-release/tests/snapshots/smoke__common_recipe_helper_ad_hoc_signs_macho_files.snap
@@ -1,0 +1,5 @@
+---
+source: crates/pv-release/tests/smoke.rs
+expression: "read_file(&sign_log)?.replace(tempdir.path().as_str(), \"<tmp>\")"
+---
+"argv=[--force][--sign][-][<tmp>/artifact/bin/mysql]\nargv=[--force][--sign][-][<tmp>/artifact/bin/mysqladmin]\nargv=[--force][--sign][-][<tmp>/artifact/lib/libmysqlclient.dylib]\n"

--- a/crates/pv-release/tests/snapshots/smoke__common_recipe_helper_rewrites_nested_macho_install_names.snap
+++ b/crates/pv-release/tests/snapshots/smoke__common_recipe_helper_rewrites_nested_macho_install_names.snap
@@ -1,0 +1,11 @@
+---
+source: crates/pv-release/tests/smoke.rs
+expression: rewrites
+---
+[
+    "argv=[-change][<install>/lib/libmysqlclient.dylib][@loader_path/../lib/libmysqlclient.dylib][<tmp>/artifact/bin/mysql]",
+    "argv=[-change][<install>/lib/libmysqlclient.dylib][@loader_path/../libmysqlclient.dylib][<tmp>/artifact/lib/plugin/auth.so]",
+    "argv=[-change][<install>/lib/libmysqlclient.dylib][@loader_path/../libmysqlclient.dylib][<tmp>/artifact/lib/postgresql/extension.so]",
+    "argv=[-change][<install>/lib/libmysqlclient.dylib][@loader_path/libmysqlclient.dylib][<tmp>/artifact/lib/libmysqlclient.dylib]",
+    "argv=[-id][@loader_path/libmysqlclient.dylib][<tmp>/artifact/lib/libmysqlclient.dylib]",
+]

--- a/release/artifacts/default-tracks.toml
+++ b/release/artifacts/default-tracks.toml
@@ -15,6 +15,14 @@ name = "redis"
 default_track = "8.2"
 
 [[resource]]
+name = "mysql"
+default_track = "8.4"
+
+[[resource]]
+name = "postgres"
+default_track = "18"
+
+[[resource]]
 name = "mailpit"
 default_track = "1"
 

--- a/release/artifacts/recipes/common.sh
+++ b/release/artifacts/recipes/common.sh
@@ -21,6 +21,96 @@ require_sha256() {
   [ "$actual" = "$expected" ] || die "$file checksum mismatch: expected $expected, got $actual"
 }
 
+pv_recipe_macho_loader_prefix() {
+  root_dir=$1
+  macho=$2
+
+  case "$macho" in
+    "$root_dir"/lib/*)
+      relative=${macho#"$root_dir"/lib/}
+      case "$relative" in
+        */*)
+          directory=${relative%/*}
+          loader_prefix="@loader_path"
+          while :; do
+            loader_prefix="$loader_prefix/.."
+            case "$directory" in
+              */*) directory=${directory#*/} ;;
+              *) break ;;
+            esac
+          done
+          printf '%s\n' "$loader_prefix"
+          ;;
+        *) printf '%s\n' "@loader_path" ;;
+      esac
+      ;;
+    *) printf '%s\n' "@loader_path/../lib" ;;
+  esac
+}
+
+rewrite_macho_install_names() {
+  root_dir=$1
+  install_dir=$2
+
+  need install_name_tool
+  need find
+  need otool
+
+  if [ -d "$root_dir/lib" ]; then
+    find "$root_dir/lib" -type f -name '*.dylib' -exec sh -c '
+      install_dir=$1
+      shift
+      for library do
+        install_name=$(
+          otool -D "$library" 2>/dev/null | {
+            IFS= read -r _ || true
+            IFS= read -r line || true
+            printf "%s\n" "$line"
+          }
+        )
+        case "$install_name" in
+          "$install_dir"/lib/*)
+            install_name_tool -id "@loader_path/${install_name##*/}" "$library"
+            ;;
+        esac
+      done
+    ' sh "$install_dir" {} +
+  fi
+
+  for macho_dir in "$root_dir/bin" "$root_dir/lib"; do
+    [ -d "$macho_dir" ] || continue
+    find "$macho_dir" -type f | while IFS= read -r macho; do
+      otool -L "$macho" >/dev/null 2>&1 || continue
+      loader_prefix=$(pv_recipe_macho_loader_prefix "$root_dir" "$macho")
+      otool -L "$macho" | while read -r linked _; do
+        case "$linked" in
+          "$install_dir"/lib/*)
+            install_name_tool -change "$linked" "$loader_prefix/${linked##*/}" "$macho"
+            ;;
+        esac
+      done
+    done
+  done
+}
+
+pv_recipe_ad_hoc_sign_macho_tree() {
+  root_dir=$1
+
+  need codesign
+  need find
+  need otool
+
+  for macho_dir in "$root_dir/bin" "$root_dir/lib"; do
+    [ -d "$macho_dir" ] || continue
+    find "$macho_dir" -type f -exec sh -c '
+      for macho do
+        otool -L "$macho" >/dev/null 2>&1 || continue
+        codesign --force --sign - "$macho" >/dev/null
+      done
+    ' sh {} +
+  done
+}
+
 expected_arch_for_platform() {
   case "$1" in
     darwin-arm64) printf '%s\n' arm64 ;;
@@ -140,6 +230,10 @@ sign_macho_binary() {
   binary=$1
   codesign --force --sign - "$binary"
   codesign --verify "$binary"
+}
+
+pv_recipe_validate_macho_binary() {
+  validate_macho_binary "$@"
 }
 
 artifact_basename() {

--- a/release/artifacts/recipes/common.sh
+++ b/release/artifacts/recipes/common.sh
@@ -32,6 +32,7 @@ pv_recipe_macho_loader_prefix() {
         */*)
           directory=${relative%/*}
           loader_prefix="@loader_path"
+          # Nested lib modules need enough ".." hops to resolve back to the artifact lib root.
           while :; do
             loader_prefix="$loader_prefix/.."
             case "$directory" in
@@ -58,6 +59,7 @@ rewrite_macho_install_names() {
 
   if [ -d "$root_dir/lib" ]; then
     find "$root_dir/lib" -type f -name '*.dylib' -exec sh -c '
+      set -e
       install_dir=$1
       shift
       for library do
@@ -70,7 +72,7 @@ rewrite_macho_install_names() {
         )
         case "$install_name" in
           "$install_dir"/lib/*)
-            install_name_tool -id "@loader_path/${install_name##*/}" "$library"
+            install_name_tool -id "@loader_path/${install_name##*/}" "$library" || exit 1
             ;;
         esac
       done
@@ -85,7 +87,7 @@ rewrite_macho_install_names() {
       otool -L "$macho" | while read -r linked _; do
         case "$linked" in
           "$install_dir"/lib/*)
-            install_name_tool -change "$linked" "$loader_prefix/${linked##*/}" "$macho"
+            install_name_tool -change "$linked" "$loader_prefix/${linked##*/}" "$macho" || exit 1
             ;;
         esac
       done
@@ -103,9 +105,10 @@ pv_recipe_ad_hoc_sign_macho_tree() {
   for macho_dir in "$root_dir/bin" "$root_dir/lib"; do
     [ -d "$macho_dir" ] || continue
     find "$macho_dir" -type f -exec sh -c '
+      set -e
       for macho do
         otool -L "$macho" >/dev/null 2>&1 || continue
-        codesign --force --sign - "$macho" >/dev/null
+        codesign --force --sign - "$macho" >/dev/null || exit 1
       done
     ' sh {} +
   done

--- a/release/artifacts/recipes/mysql/LICENSE
+++ b/release/artifacts/recipes/mysql/LICENSE
@@ -1,0 +1,5360 @@
+Licensing Information User Manual
+
+MySQL 8.4.9 Community
+     __________________________________________________________________
+
+Introduction
+
+   This License Information User Manual contains Oracle's product license
+   and other licensing information, including licensing information for
+   third-party software which may be included in this distribution of
+   MySQL 8.4.9 Community.
+
+   Last updated: February 2026
+
+Licensing Information
+
+   This release of MySQL 8.4.9 Community is brought to you by the MySQL
+   team at Oracle. This software is released under version 2 of the GNU
+   General Public License (GPLv2), as set forth below, with the following
+   additional permissions:
+
+   This distribution of MySQL 8.4.9 Community is designed to work with
+   certain software (including but not limited to OpenSSL) that is
+   licensed under separate terms, as designated in a particular file or
+   component or in the license documentation. Without limiting your rights
+   under the GPLv2, the authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have either included with the
+   program or referenced in the documentation.
+
+   This distribution includes the MySQL C API client library
+   (libmysqlclient) otherwise known as MySQL Connector/C. Without limiting
+   the foregoing grant of rights under the GPLv2 and additional permission
+   as to separately licensed software, this Connector is also subject to
+   the Universal FOSS Exception, version 1.0, a copy of which is
+   reproduced below and can also be found along with its FAQ at
+   http://oss.oracle.com/licenses/universal-foss-exception.
+
+   Copyright (c) 1997, 2026, Oracle and/or its affiliates.
+
+Election of GPLv2
+
+   For the avoidance of doubt, except that if any license choice other
+   than GPL or LGPL is available it will apply instead, Oracle elects to
+   use only the General Public License version 2 (GPLv2) at this time for
+   any software where a choice of GPL license versions is made available
+   with the language indicating that GPLv2 or any later version may be
+   used, or where a choice of which version of the GPL is applied is
+   otherwise unspecified.
+
+GNU General Public License Version 2.0, June 1991
+
+The following applies to all products licensed under the GNU General
+Public License, Version 2.0: You may not use the identified files
+except in compliance with the GNU General Public License, Version
+2.0 (the "License.") You may obtain a copy of the License at
+http://www.gnu.org/licenses/gpl-2.0.txt. A copy of the license is
+also reproduced below. Unless required by applicable law or agreed
+to in writing, software distributed under the License is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+
+
+  ======================================================================
+  ======================================================================
+
+
+GNU GENERAL PUBLIC LICENSE
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+Everyone is permitted to copy and distribute verbatim
+copies of this license document, but changing it is not
+allowed.
+
+                     Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software,
+and (2) offer you this license which gives you legal permission to
+copy, distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on,
+we want its recipients to know that what they have is not the original,
+so that any problems introduced by others will not reflect on the
+original authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software
+    interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as
+a special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new
+versions of the General Public License from time to time.  Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Program does not specify a
+version number of this License, you may choose any version ever
+published by the Free Software Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the
+author to ask for permission.  For software which is copyrighted by the
+Free Software Foundation, write to the Free Software Foundation; we
+sometimes make exceptions for this.  Our decision will be guided by the
+two goals of preserving the free status of all derivatives of our free
+software and of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND,
+EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS
+WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or
+    modify it under the terms of the GNU General Public License as
+    published by the Free Software Foundation; either version 2 of
+
+    the License, or (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+    02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details
+    type 'show w'. This is free software, and you are welcome
+    to redistribute it under certain conditions; type 'show c'
+    for details.
+
+The hypothetical commands 'show w' and 'show c' should show the
+appropriate parts of the General Public License.  Of course, the
+commands you use may be called something other than 'show w' and
+'show c'; they could even be mouse-clicks or menu items--whatever
+suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  program 'Gnomovision' (which makes passes at compilers) written
+  by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library,
+you may consider it more useful to permit linking proprietary
+applications with the library.  If this is what you want to do, use
+the GNU Lesser General Public License instead of this License.
+
+   ======================================================================
+   ======================================================================
+
+The Universal FOSS Exception, Version 1.0
+
+   In addition to the rights set forth in the other license(s) included in
+   the distribution for this software, data, and/or documentation
+   (collectively the "Software", and such licenses collectively with this
+   additional permission the "Software License"), the copyright holders
+   wish to facilitate interoperability with other software, data, and/or
+   documentation distributed with complete corresponding source under a
+   license that is OSI-approved and/or categorized by the FSF as free
+   (collectively "Other FOSS"). We therefore hereby grant the following
+   additional permission with respect to the use and distribution of the
+   Software with Other FOSS, and the constants, function signatures, data
+   structures and other invocation methods used to run or interact with
+   each of them (as to each, such software's "Interfaces"):
+
+    i. The Software's Interfaces may, to the extent permitted by the
+       license of the Other FOSS, be copied into, used and distributed in
+       the Other FOSS in order to enable interoperability, without
+       requiring a change to the license of the Other FOSS other than as
+       to any Interfaces of the Software embedded therein. The Software's
+       Interfaces remain at all times under the Software License,
+       including without limitation as used in the Other FOSS (which upon
+       any such use also then contains a portion of the Software under the
+       Software License).
+
+   ii. The Other FOSS's Interfaces may, to the extent permitted by the
+       license of the Other FOSS, be copied into, used and distributed in
+       the Software in order to enable interoperability, without requiring
+       that such Interfaces be licensed under the terms of the Software
+       License or otherwise altering their original terms, if this does
+       not require any portion of the Software other than such Interfaces
+       to be licensed under the terms other than the Software License.
+
+   iii. If only Interfaces and no other code is copied between the
+       Software and the Other FOSS in either direction, the use and/or
+       distribution of the Software with the Other FOSS shall not be
+       deemed to require that the Other FOSS be licensed under the license
+       of the Software, other than as to any Interfaces of the Software
+       copied into the Other FOSS. This includes, by way of example and
+       without limitation, statically or dynamically linking the Software
+       together with Other FOSS after enabling interoperability using the
+       Interfaces of one or both, and distributing the resulting
+       combination under different licenses for the respective portions
+       thereof.
+
+       For avoidance of doubt, a license which is OSI-approved or
+       categorized by the FSF as free, includes, for the purpose of this
+       permission, such licenses with additional permissions, and any
+       license that has previously been so approved or categorized as
+       free, even if now deprecated or otherwise no longer recognized as
+       approved or free. Nothing in this additional permission grants any
+       right to distribute any portion of the Software on terms other than
+       those of the Software License or grants any additional permission
+       of any kind for use or distribution of the Software in conjunction
+       with software other than Other FOSS.
+
+   ======================================================================
+   ======================================================================
+
+Licenses for Third-Party Components
+
+   The following sections contain licensing information for libraries that
+   may be included with this product. We are thankful to all individuals
+   that have created these. Standard licenses referenced herein are
+   detailed in the Standard Licenses section.
+
+Boost C++ Libraries
+
+Use of any of this software is governed by the terms of the license
+below:
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or
+organization obtaining a copy of the software and accompanying
+documentation covered by this license (the "Software") to use,
+reproduce, display, distribute, execute, and transmit the Software,
+and to prepare derivative works of the Software, and to permit
+third-parties to whom the Software is furnished to do so, all
+subject to the following:
+
+The copyright notices in the Software and this entire statement,
+including the above license grant, this restriction and the
+following disclaimer, must be included in all copies of the
+Software, in whole or in part, and all derivative works of the
+Software, unless such copies or derivative works are solely in the
+form of machine-executable object code generated by a source
+language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE AND
+NON-INFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR ANYONE
+DISTRIBUTING THE SOFTWARE BE LIABLE FOR ANY DAMAGES OR OTHER
+LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT
+OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+   ======================================================================
+   ======================================================================
+
+cURL (libcurl)
+
+cURL (libcurl)
+
+Use of any of this software is governed by the terms of the license below:
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1996 - 2019, Daniel Stenberg, <daniel@haxx.se>, and many
+contributors, see the THANKS file.
+
+All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright
+notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other
+dealings in this Software without prior written authorization of the copyright
+holder.
+
+
+   ======================================================================
+   ======================================================================
+
+Cyrus SASL
+
+ * Copyright (c) 1998-2003 Carnegie Mellon University.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. The name "Carnegie Mellon University" must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For permission or any other legal
+ *    details, please contact
+ *      Office of Technology Transfer
+ *      Carnegie Mellon University
+ *      5000 Forbes Avenue
+ *      Pittsburgh, PA  15213-3890
+ *      (412) 268-4387, fax: (412) 268-7395
+*      tech-transfer@andrew.cmu.edu
+ *
+ * 4. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    "This product includes software developed by Computing Services
+ *     at Carnegie Mellon University (http://www.cmu.edu/computing/)."
+ *
+ * CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+ * THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+ * FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+ * AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+ * OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+The following files
+
+./lib
+     saslint.h auxprop.c canonusr.c checkpw.c client.c common.c config.c
+     external.c saslutil.c server.c seterror.c dlopen.c
+./plugins
+    scram.c gssapi.c
+./common
+   plugin_common.c
+
+have a license header similar to the above with the following copyright:
+/*
+ * Copyright (c) 1998-2016 Carnegie Mellon University.  All rights reserved.
+ *
+
+./lib/md5.c includes the following license header:
+/* MD5C.C - RSA Data Security, Inc., MD5 message-digest algorithm
+*/
+
+/* Function names changed to avoid namespace collisions: Rob Siemborski */
+
+/* Copyright (C) 1991-2, RSA Data Security, Inc. Created 1991. All
+rights reserved.
+
+License to copy and use this software is granted provided that it
+is identified as the "RSA Data Security, Inc. MD5 Message-Digest
+Algorithm" in all material mentioning or referencing this software
+or this function.
+
+License is also granted to make and use derivative works provided
+that such works are identified as "derived from the RSA Data
+Security, Inc. MD5 Message-Digest Algorithm" in all material
+mentioning or referencing the derived work.
+
+RSA Data Security, Inc. makes no representations concerning either
+the merchantability of this software or the suitability of this
+software for any particular purpose. It is provided "as is"
+without express or implied warranty of any kind.
+
+These notices must be retained in any copies of any part of this
+documentation and/or software.
+*/
+
+   ======================================================================
+   ======================================================================
+
+dtoa.c
+
+The author of this software is David M. Gay.
+
+Copyright (c) 1991, 2000, 2001 by Lucent Technologies.
+
+Permission to use, copy, modify, and distribute this software for
+any purpose without fee is hereby granted, provided that this entire
+notice is included in all copies of any software which is or includes
+a copy or modification of this software and in all copies of the
+supporting documentation for such software.
+
+THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTY. IN PARTICULAR, NEITHER THE AUTHOR NOR LUCENT
+MAKES ANY REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE
+MERCHANTABILITY OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR
+PURPOSE.
+
+   ======================================================================
+   ======================================================================
+
+Editline Library (libedit)
+
+Copyright (c) 1992, 1993
+ The Regents of the University of California.  All rights reserved.
+
+This code is derived from software contributed to Berkeley by
+Christos Zoulas of Cornell University.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+Files with different/specific license header
+======================
+src/readline.c
+src/literal.h
+src/literal.c
+src/getline.c
+src/filecomplete.h
+src/filecomplete.c
+src/eln.c
+src/chartype.h
+src/chartype.c
+src/read.h
+-----------------------
+/*-
+ * Copyright (c) 1997 The NetBSD Foundation, Inc.
+ * Copyright (c) 2001 The NetBSD Foundation, Inc.
+ * All rights reserved.
+ *
+ * This code is derived from software contributed to The NetBSD Foundation
+ * by Jaromir Dolecek.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+src/wcsdup.c
+-------------
+*
+ * Copyright (C) 2006 Aleksey Cheusov
+ *
+ * This material is provided "as is", with absolutely no warranty expressed
+ * or implied. Any use is at your own risk.
+ *
+ * Permission to use or copy this software for any purpose is hereby granted
+ * without fee. Permission to modify the code and to distribute modified
+ * code is also granted without any restrictions.
+ */
+
+src/reallocarr.c
+----------------
+/*-
+ * Copyright (c) 2015 Joerg Sonnenberger <joerg@NetBSD.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+   ======================================================================
+   ======================================================================
+
+EPSG Geodetic Parameter Dataset
+
+This product includes the EPSG Geodetic Parameter Dataset.
+
+The EPSG Dataset is owned by the International Association of Oil
+and Gas Producers, incorporated in England as a company limited by
+guarantee (number 1832064) and is subject to the terms of use here:
+http://www.epsg.org/TermsOfUse.
+
+The user assumes the entire risk as to the accuracy and the use of
+this data.  The data may be used, copied and distributed subject
+to the following conditions:
+1. INFORMATION PROVIDED IN THIS DOCUMENT IS PROVIDED "AS IS" WITHOUT
+WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR
+FITNESS FOR A PARTICULAR PURPOSE.
+2. The data may be included in any commercial package provided that
+any commerciality is based on value added by the provider and not
+on a value ascribed to the EPSG dataset which is made available at
+no charge. The ownership of the EPSG dataset [OGP] must be acknowledged.
+3. Subsets of information may be extracted from the dataset. Users
+are advised that coordinate reference system and coordinate
+transformation descriptions are incomplete unless all elements
+detailed as essential in OGP Surveying and Positioning Guidance
+Note 7-1 annex F are included.
+4. Essential elements should preferably be reproduced as described
+in the dataset. Modification of parameter values is permitted as
+described in the table below to allow change to the content of the
+information provided that numeric equivalence is achieved. Numeric
+equivalence refers to the results of geodetic calculations in which
+the parameters are used, for example (i) conversion of ellipsoid
+defining parameters, or (ii) conversion of parameters between one
+and two standard parallel projection methods, or (iii) conversion
+of parameters between 7-parameter geocentric transformation methods.
+
+   ======================================================================
+   ======================================================================
+
+Facebook Fast Checksum Patch
+
+Facebook Fast Checksum Patch
+
+Copyright (C) 2009-2010 Facebook, Inc.  All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY FACEBOOK, INC. "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
+EVENT SHALL FACEBOOK, INC. BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Also included:
+
+crc32.c -- compute the CRC-32 of a buf stream
+Copyright (C) 1995-2005 Mark Adler
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+Jean-loup Gailly jloup@gzip.org
+Mark Adler madler@alumni.caltech.edu
+
+   ======================================================================
+   ======================================================================
+
+Facebook Patches
+
+Copyright (c) 2012, Facebook, Inc.
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+FMT
+
+Copyright (c) 2012 - present, Victor Zverovich
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--- Optional exception to the license ---
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into a machine-executable object form of such
+source code, you may redistribute such embedded portions in such object form
+without including the above copyright and permission notices.
+
+   ======================================================================
+   ======================================================================
+
+Fred Fish's Dbug Library
+
+                                N O T I C E
+
+                   Copyright Abandoned, 1987, Fred Fish
+
+     This previously copyrighted work has been placed into the  public
+     domain  by  the  author  and  may be freely used for any purpose,
+     private or commercial.
+
+     Because of the number of inquiries I was receiving about the  use
+     of this product in commercially developed works I have decided to
+     simply make it public domain to further its unrestricted use.   I
+     specifically  would  be  most happy to see this material become a
+     part of the standard Unix distributions by AT&T and the  Berkeley
+     Computer  Science  Research Group, and a standard part of the GNU
+     system from the Free Software Foundation.
+
+     I would appreciate it, as a courtesy, if this notice is  left  in
+     all copies and derivative works.  Thank you.
+
+     The author makes no warranty of any kind  with  respect  to  this
+     product  and  explicitly disclaims any implied warranties of mer-
+     chantability or fitness for any particular purpose.
+
+The dbug_analyze.c file is subject to the following notice:
+
+     Copyright June 1987, Binayak Banerjee
+     All rights reserved.
+
+     This program may be freely distributed under the same terms and
+     conditions as Fred Fish's Dbug package.
+
+   ======================================================================
+   ======================================================================
+
+Google Controlling Master Thread I/O Rate Patch
+
+Copyright (c) 2009, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of the Google Inc. nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+Google Perftools (TCMalloc utility)
+
+Google Perftools (TCMalloc utility)
+
+Copyright (c) 1998-2006, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or
+without modification, are permitted provided that the following
+conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+Google Protocol Buffers
+
+You may be receiving a copy of abseil-cpp as part of this product in object code
+ form.
+The terms of the Oracle license do NOT apply to abseil-cpp.
+abseil-cpp is licensed under the Apache 2.0 license, separate from the Oracle pr
+oduct.
+If you do not wish to install this library, you may remove it, but the Oracle pr
+ogram
+might not operate properly or at all without it.
+
+Copyright 2008 Google Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Code generated by the Protocol Buffer compiler is owned by the owner
+of the input file used when generating it.  This code is not
+standalone and requires a support library to be linked with it.  This
+support library is itself covered by the above license.
+
+4th party - abseil-cpp
+----------------------
+
+=== Header in source files:
+// Copyright 2017 The Abseil Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// This header file contains C++11 versions of standard <utility> header
+// abstractions available within C++14 and C++17, and are designed to be
+// drop-in replacement for code compliant with C++14 and C++17.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+A copy of the Apache License v2.0, January 2004 license can be found
+in the 'Standard Licenses' section.
+
+   ======================================================================
+   ======================================================================
+
+Google SMP Patch
+
+Google SMP patch
+
+Copyright (c) 2008, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of the Google Inc. nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+Google Test (including GMock)
+
+Google Mock (GMock) is an extension to Google Test for writing and
+using C++ mock classes. Google Test (including the Google Mock
+extension) is licensed under the following terms:
+
+Copyright 2008, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+* Neither the name of Google Inc. nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+gperftools
+
+Copyright (c) 2005, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+ICU4C Unicode Libraries
+
+COPYRIGHT AND PERMISSION NOTICE (ICU 58 and later)
+
+Copyright (c) 1991-2019 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.
+
+---------------------
+
+Third-Party Software Licenses
+
+This section contains third-party software notices and/or additional
+terms for licensed third-party software components included within ICU
+libraries.
+
+1. ICU License - ICU 1.8.1 to ICU 57.1
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1995-2016 International Business Machines Corporation and
+others
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, and/or sell copies of the Software, and to permit persons
+to whom the Software is furnished to do so, provided that the above
+copyright notice(s) and this permission notice appear in all copies of
+the Software and that both the above copyright notice(s) and this
+permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+HOLDERS INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY
+SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale, use
+or other dealings in this Software without prior written authorization
+of the copyright holder.
+
+All trademarks and registered trademarks mentioned herein are the
+property of their respective owners.
+
+2. Chinese/Japanese Word Break Dictionary Data (cjdict.txt)
+
+ #     The Google Chrome software developed by Google is licensed under
+ # the BSD license. Other software included in this distribution is
+ # provided under other licenses, as set forth below.
+ #
+ #  The BSD License
+ #  http://opensource.org/licenses/bsd-license.php
+ #  Copyright (C) 2006-2008, Google Inc.
+ #
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ # modification, are permitted provided that the following conditions are met:
+ #
+ #  Redistributions of source code must retain the above copyright notice,
+ # this list of conditions and the following disclaimer.
+ #  Redistributions in binary form must reproduce the above
+ # copyright notice, this list of conditions and the following
+ # disclaimer in the documentation and/or other materials provided with
+ # the distribution.
+ #  Neither the name of  Google Inc. nor the names of its
+ # contributors may be used to endorse or promote products derived from
+ # this software without specific prior written permission.
+ #
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ # CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ # INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ # MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ # DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ # LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ # CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ # SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ # BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+ #
+ #  The word list in cjdict.txt are generated by combining three word lists
+ # listed below with further processing for compound word breaking. The
+ # frequency is generated with an iterative training against Google web
+ # corpora.
+ #
+ #  * Libtabe (Chinese)
+ #    - https://sourceforge.net/project/?group_id=1519
+ #    - Its license terms and conditions are shown below.
+ #
+ #  * IPADIC (Japanese)
+ #    - http://chasen.aist-nara.ac.jp/chasen/distribution.html
+ #    - Its license terms and conditions are shown below.
+ #
+ #  ---------COPYING.libtabe ---- BEGIN--------------------
+ #
+ #  /*
+ #   * Copyright (c) 1999 TaBE Project.
+ #   * Copyright (c) 1999 Pai-Hsiang Hsiao.
+ #   * All rights reserved.
+ #   *
+ #   * Redistribution and use in source and binary forms, with or without
+ #   * modification, are permitted provided that the following conditions
+ #   * are met:
+ #   *
+ #   * . Redistributions of source code must retain the above copyright
+ #   *   notice, this list of conditions and the following disclaimer.
+ #   * . Redistributions in binary form must reproduce the above copyright
+ #   *   notice, this list of conditions and the following disclaimer in
+ #   *   the documentation and/or other materials provided with the
+ #   *   distribution.
+ #   * . Neither the name of the TaBE Project nor the names of its
+ #   *   contributors may be used to endorse or promote products derived
+ #   *   from this software without specific prior written permission.
+ #   *
+ #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+ #   */
+ #
+ #  /*
+ #   * Copyright (c) 1999 Computer Systems and Communication Lab,
+ #   *                    Institute of Information Science, Academia
+ #       *                    Sinica. All rights reserved.
+ #   *
+ #   * Redistribution and use in source and binary forms, with or without
+ #   * modification, are permitted provided that the following conditions
+ #   * are met:
+ #   *
+ #   * . Redistributions of source code must retain the above copyright
+ #   *   notice, this list of conditions and the following disclaimer.
+ #   * . Redistributions in binary form must reproduce the above copyright
+ #   *   notice, this list of conditions and the following disclaimer in
+ #   *   the documentation and/or other materials provided with the
+ #   *   distribution.
+ #   * . Neither the name of the Computer Systems and Communication Lab
+ #   *   nor the names of its contributors may be used to endorse or
+ #   *   promote products derived from this software without specific
+ #   *   prior written permission.
+ #   *
+ #   * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ #   * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ #   * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ #   * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ #   * REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ #   * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ #   * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ #   * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ #   * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ #   * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ #   * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ #   * OF THE POSSIBILITY OF SUCH DAMAGE.
+ #   */
+ #
+ #  Copyright 1996 Chih-Hao Tsai @ Beckman Institute,
+ #      University of Illinois
+ #  c-tsai4@uiuc.edu  http://casper.beckman.uiuc.edu/~c-tsai4
+ #
+ #  ---------------COPYING.libtabe-----END--------------------------------
+ #
+ #
+ #  ---------------COPYING.ipadic-----BEGIN-------------------------------
+ #
+ #  Copyright 2000, 2001, 2002, 2003 Nara Institute of Science
+ #  and Technology.  All Rights Reserved.
+ #
+ #  Use, reproduction, and distribution of this software is permitted.
+ #  Any copy of this software, whether in its original form or modified,
+ #  must include both the above copyright notice and the following
+ #  paragraphs.
+ #
+ #  Nara Institute of Science and Technology (NAIST),
+ #  the copyright holders, disclaims all warranties with regard to this
+ #  software, including all implied warranties of merchantability and
+ #  fitness, in no event shall NAIST be liable for
+ #  any special, indirect or consequential damages or any damages
+ #  whatsoever resulting from loss of use, data or profits, whether in an
+ #  action of contract, negligence or other tortuous action, arising out
+ #  of or in connection with the use or performance of this software.
+ #
+ #  A large portion of the dictionary entries
+ #  originate from ICOT Free Software.  The following conditions for ICOT
+ #  Free Software applies to the current dictionary as well.
+ #
+ #  Each User may also freely distribute the Program, whether in its
+ #  original form or modified, to any third party or parties, PROVIDED
+ #  that the provisions of Section 3 ("NO WARRANTY") will ALWAYS appear
+ #  on, or be attached to, the Program, which is distributed substantially
+ #  in the same form as set out herein and that such intended
+ #  distribution, if actually made, will neither violate or otherwise
+ #  contravene any of the laws and regulations of the countries having
+ #  jurisdiction over the User or the intended distribution itself.
+ #
+ #  NO WARRANTY
+ #
+ #  The program was produced on an experimental basis in the course of the
+ #  research and development conducted during the project and is provided
+ #  to users as so produced on an experimental basis.  Accordingly, the
+ #  program is provided without any warranty whatsoever, whether express,
+ #  implied, statutory or otherwise.  The term "warranty" used herein
+ #  includes, but is not limited to, any warranty of the quality,
+ #  performance, merchantability and fitness for a particular purpose of
+ #  the program and the nonexistence of any infringement or violation of
+ #  any right of any third party.
+ #
+ #  Each user of the program will agree and understand, and be deemed to
+ #  have agreed and understood, that there is no warranty whatsoever for
+ #  the program and, accordingly, the entire risk arising from or
+ #  otherwise connected with the program is assumed by the user.
+ #
+ #  Therefore, neither ICOT, the copyright holder, or any other
+ #  organization that participated in or was otherwise related to the
+ #  development of the program and their respective officials, directors,
+ #  officers and other employees shall be held liable for any and all
+ #  damages, including, without limitation, general, special, incidental
+ #  and consequential damages, arising out of or otherwise in connection
+ #  with the use or inability to use the program or any product, material
+ #  or result produced or otherwise obtained by using the program,
+ #  regardless of whether they have been advised of, or otherwise had
+ #  knowledge of, the possibility of such damages at any time during the
+ #  project or thereafter.  Each user will be deemed to have agreed to the
+ #  foregoing by his or her commencement of use of the program.  The term
+ #  "use" as used herein includes, but is not limited to, the use,
+ #  modification, copying and distribution of the program and the
+ #  production of secondary products from the program.
+ #
+ #  In the case where the program, whether in its original form or
+ #  modified, was distributed or delivered to or received by a user from
+ #  any person, organization or entity other than ICOT, unless it makes or
+ #  grants independently of ICOT any specific warranty to the user in
+ #  writing, such person, organization or entity, will also be exempted
+ #  from and not be held liable to the user for any such damages as noted
+ #  above as far as the program is concerned.
+ #
+ #  ---------------COPYING.ipadic-----END----------------------------------
+
+3. Lao Word Break Dictionary Data (laodict.txt)
+
+ #  Copyright (c) 2013 International Business Machines Corporation
+ #  and others. All Rights Reserved.
+ #
+ # Project: http://code.google.com/p/lao-dictionary/
+ # Dictionary: http://lao-dictionary.googlecode.com/git/Lao-Dictionary.txt
+ # License:
+ # http://lao-dictionary.googlecode.com/git/Lao-Dictionary-LICENSE.txt
+ #              (copied below)
+ #
+ #  This file is derived from the above dictionary, with slight
+ #  modifications.
+ #  ----------------------------------------------------------------------
+ #  Copyright (C) 2013 Brian Eugene Wilson, Robert Martin Campbell.
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification,
+ #  are permitted provided that the following conditions are met:
+ #
+ #
+ # Redistributions of source code must retain the above copyright notice, this
+ #  list of conditions and the following disclaimer. Redistributions in
+ #  binary form must reproduce the above copyright notice, this list of
+ #  conditions and the following disclaimer in the documentation and/or
+ #  other materials provided with the distribution.
+ #
+ #
+ # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ # FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ # INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ # (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ # SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ # HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ # OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+--------------------------------------------------------------------------
+
+4. Burmese Word Break Dictionary Data (burmesedict.txt)
+
+ #  Copyright (c) 2014 International Business Machines Corporation
+ #  and others. All Rights Reserved.
+ #
+ #  This list is part of a project hosted at:
+ #    github.com/kanyawtech/myanmar-karen-word-lists
+ #
+ #
+--------------------------------------------------------------------------
+ #  Copyright (c) 2013, LeRoy Benjamin Sharon
+ #  All rights reserved.
+ #
+ #  Redistribution and use in source and binary forms, with or without
+ #  modification, are permitted provided that the following conditions
+ #  are met: Redistributions of source code must retain the above
+ #  copyright notice, this list of conditions and the following
+ #  disclaimer.  Redistributions in binary form must reproduce the
+ #  above copyright notice, this list of conditions and the following
+ #  disclaimer in the documentation and/or other materials provided
+ #  with the distribution.
+ #
+ #    Neither the name Myanmar Karen Word Lists, nor the names of its
+ #    contributors may be used to endorse or promote products derived
+ #    from this software without specific prior written permission.
+ #
+ #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ #  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ #  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ #  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ #  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+ #  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ #  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ #  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ #  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ #  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ #  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ #  THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ #  SUCH DAMAGE.
+ #
+--------------------------------------------------------------------------
+
+5. Time Zone Database
+
+  ICU uses the public domain data and code derived from Time Zone
+Database for its time zone support. The ownership of the TZ database
+is explained in BCP 175: Procedure for Maintaining the Time Zone
+Database section 7.
+
+ # 7.  Database Ownership
+ #
+ #    The TZ database itself is not an IETF Contribution or an IETF
+ #    document.  Rather it is a pre-existing and regularly updated work
+ #    that is in the public domain, and is intended to remain in the
+ #    public domain.  Therefore, BCPs 78 [RFC5378] and 79 [RFC3979] do
+ #    not apply to the TZ Database or contributions that individuals make
+ #    to it.  Should any claims be made and substantiated against the TZ
+ #    Database, the organization that is providing the IANA
+ #    Considerations defined in this RFC, under the memorandum of
+ #    understanding with the IETF, currently ICANN, may act in accordance
+ #    with all competent court orders.  No ownership claims will be made
+ #    by ICANN or the IETF Trust on the database or the code.  Any person
+ #    making a contribution to the database or code waives all rights to
+ #    future claims in that contribution or in the TZ Database.
+
+6. Google double-conversion
+
+Copyright 2006-2011, the V8 project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+jemalloc
+
+Copyright (C) 2002-present Jason Evans <jasone@canonware.com>.
+All rights reserved.
+Copyright (C) 2007-2012 Mozilla Foundation.  All rights reserved.
+Copyright (C) 2009-present Facebook, Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice(s),
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice(s),
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER(S) BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+Kerberos5
+
+You may be receiving a copy of the kerberos documentation as part of this
+product. The terms of the Oracle license do NOT apply to Kerberos documentation.
+
+Kerberos documentation is licensed under the CC-BY-SA 3.0 license, separate from
+
+the Oracle product.
+If you do not wish to install this library, you may remove it, but
+the Oracle program might not operate properly or at all without it.
+
+Copyright (C) 1985-2019 by the Massachusetts Institute of Technology.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Downloading of this software may constitute an export of cryptographic
+software from the United States of America that is subject to the
+United States Export Administration Regulations (EAR), 15 CFR 730-774.
+Additional laws or regulations may apply.  It is the responsibility of
+the person or entity contemplating export to comply with all
+applicable export laws and regulations, including obtaining any
+required license from the U.S. government.
+
+The U.S. government prohibits export of encryption source code to
+certain countries and individuals, including, but not limited to, the
+countries of Cuba, Iran, North Korea, Sudan, Syria, and residents and
+nationals of those countries.
+
+Documentation components of this software distribution are licensed
+under a Creative Commons Attribution-ShareAlike 3.0 Unported License.
+(http://creativecommons.org/licenses/by-sa/3.0/)
+
+Individual source code files are copyright MIT, Cygnus Support,
+Novell, OpenVision Technologies, Oracle, Red Hat, Sun Microsystems,
+FundsXpress, and others.
+
+Project Athena, Athena, Athena MUSE, Discuss, Hesiod, Kerberos, Moira,
+and Zephyr are trademarks of the Massachusetts Institute of Technology
+(MIT).  No commercial use of these trademarks may be made without
+prior written permission of MIT.
+
+"Commercial use" means use of a name in a product or other for-profit
+manner.  It does NOT prevent a commercial firm from referring to the
+MIT trademarks in order to convey information (although in doing so,
+recognition of their trademark status should be given).
+
+======================================================================
+
+The following copyright and permission notice applies to the
+OpenVision Kerberos Administration system located in "kadmin/create",
+"kadmin/dbutil", "kadmin/passwd", "kadmin/server", "lib/kadm5", and
+portions of "lib/rpc":
+
+   Copyright, OpenVision Technologies, Inc., 1993-1996, All Rights
+   Reserved
+
+   WARNING:  Retrieving the OpenVision Kerberos Administration system
+   source code, as described below, indicates your acceptance of the
+   following terms.  If you do not agree to the following terms, do
+   not retrieve the OpenVision Kerberos administration system.
+
+   You may freely use and distribute the Source Code and Object Code
+   compiled from it, with or without modification, but this Source
+   Code is provided to you "AS IS" EXCLUSIVE OF ANY WARRANTY,
+   INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY OR
+   FITNESS FOR A PARTICULAR PURPOSE, OR ANY OTHER WARRANTY, WHETHER
+   EXPRESS OR IMPLIED. IN NO EVENT WILL OPENVISION HAVE ANY LIABILITY
+   FOR ANY LOST PROFITS, LOSS OF DATA OR COSTS OF PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES, OR FOR ANY SPECIAL, INDIRECT, OR
+   CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, INCLUDING,
+   WITHOUT LIMITATION, THOSE RESULTING FROM THE USE OF THE SOURCE
+   CODE, OR THE FAILURE OF THE SOURCE CODE TO PERFORM, OR FOR ANY
+   OTHER REASON.
+
+   OpenVision retains all copyrights in the donated Source Code.
+   OpenVision also retains copyright to derivative works of the Source
+   Code, whether created by OpenVision or by a third party. The
+   OpenVision copyright notice must be preserved if derivative works
+   are made based on the donated Source Code.
+
+   OpenVision Technologies, Inc. has donated this Kerberos
+   Administration system to MIT for inclusion in the standard Kerberos
+   5 distribution. This donation underscores our commitment to
+   continuing Kerberos technology development and our gratitude for
+   the valuable work which has been performed by MIT and the Kerberos
+   community.
+
+======================================================================
+
+   Portions contributed by Matt Crawford "crawdad@fnal.gov" were work
+performed at Fermi National Accelerator Laboratory, which is
+   operated by Universities Research Association, Inc., under contract
+   DE-AC02-76CHO3000 with the U.S. Department of Energy.
+
+======================================================================
+
+Portions of "src/lib/crypto" have the following copyright:
+
+   Copyright (C) 1998 by the FundsXpress, INC.
+
+   All rights reserved.
+
+      Export of this software from the United States of America may
+      require a specific license from the United States Government.
+      It is the responsibility of any person or organization
+      contemplating export to obtain such a license before exporting.
+
+   WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+   distribute this software and its documentation for any purpose and
+   without fee is hereby granted, provided that the above copyright
+   notice appear in all copies and that both that copyright notice and
+   this permission notice appear in supporting documentation, and that
+   the name of FundsXpress. not be used in advertising or publicity
+   pertaining to distribution of the software without specific,
+   written prior permission.  FundsXpress makes no representations
+   about the suitability of this software for any purpose.  It is
+   provided "as is" without express or implied warranty.
+
+   THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+   WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+======================================================================
+
+The implementation of the AES encryption algorithm in
+"src/lib/crypto/builtin/aes" has the following copyright:
+
+   Copyright (C) 2001, Dr Brian Gladman "brg@gladman.uk.net", Worcester, UK.
+   All rights reserved.
+
+   LICENSE TERMS
+
+   The free distribution and use of this software in both source and
+   binary form is allowed (with or without changes) provided that:
+
+   1. distributions of this source code include the above copyright
+      notice, this list of conditions and the following disclaimer;
+
+   2. distributions in binary form include the above copyright notice,
+      this list of conditions and the following disclaimer in the
+      documentation and/or other associated materials;
+
+   3. the copyright holder's name is not used to endorse products
+      built using this software without specific written permission.
+
+   DISCLAIMER
+
+   This software is provided 'as is' with no explcit or implied
+   warranties in respect of any properties, including, but not limited
+   to, correctness and fitness for purpose.
+
+======================================================================
+
+Portions contributed by Red Hat, including the pre-authentication
+plug-in framework and the NSS crypto implementation, contain the
+following copyright:
+
+   Copyright (C) 2006 Red Hat, Inc.
+   Portions copyright (C) 2006 Massachusetts Institute of Technology
+   All Rights Reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * Neither the name of Red Hat, Inc., nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+   COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+The bundled verto source code is subject to the following license:
+
+   Copyright 2011 Red Hat, Inc.
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+   DEALINGS IN THE SOFTWARE.
+
+======================================================================
+
+The MS-KKDCP client implementation has the following copyright:
+
+   Copyright 2013,2014 Red Hat, Inc.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+      1. Redistributions of source code must retain the above
+         copyright notice, this list of conditions and the following
+         disclaimer.
+
+      2. Redistributions in binary form must reproduce the above
+         copyright notice, this list of conditions and the following
+         disclaimer in the documentation and/or other materials
+         provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+   COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+The implementations of GSSAPI mechglue in GSSAPI-SPNEGO in
+"src/lib/gssapi", including the following files:
+
+   lib/gssapi/generic/gssapi_err_generic.et
+   lib/gssapi/mechglue/g_accept_sec_context.c
+   lib/gssapi/mechglue/g_acquire_cred.c
+   lib/gssapi/mechglue/g_canon_name.c
+   lib/gssapi/mechglue/g_compare_name.c
+   lib/gssapi/mechglue/g_context_time.c
+   lib/gssapi/mechglue/g_delete_sec_context.c
+   lib/gssapi/mechglue/g_dsp_name.c
+   lib/gssapi/mechglue/g_dsp_status.c
+   lib/gssapi/mechglue/g_dup_name.c
+   lib/gssapi/mechglue/g_exp_sec_context.c
+   lib/gssapi/mechglue/g_export_name.c
+   lib/gssapi/mechglue/g_glue.c
+   lib/gssapi/mechglue/g_imp_name.c
+   lib/gssapi/mechglue/g_imp_sec_context.c
+   lib/gssapi/mechglue/g_init_sec_context.c
+   lib/gssapi/mechglue/g_initialize.c
+   lib/gssapi/mechglue/g_inquire_context.c
+   lib/gssapi/mechglue/g_inquire_cred.c
+   lib/gssapi/mechglue/g_inquire_names.c
+   lib/gssapi/mechglue/g_process_context.c
+   lib/gssapi/mechglue/g_rel_buffer.c
+   lib/gssapi/mechglue/g_rel_cred.c
+   lib/gssapi/mechglue/g_rel_name.c
+   lib/gssapi/mechglue/g_rel_oid_set.c
+   lib/gssapi/mechglue/g_seal.c
+   lib/gssapi/mechglue/g_sign.c
+   lib/gssapi/mechglue/g_store_cred.c
+   lib/gssapi/mechglue/g_unseal.c
+   lib/gssapi/mechglue/g_userok.c
+   lib/gssapi/mechglue/g_utils.c
+   lib/gssapi/mechglue/g_verify.c
+   lib/gssapi/mechglue/gssd_pname_to_uid.c
+   lib/gssapi/mechglue/mglueP.h
+   lib/gssapi/mechglue/oid_ops.c
+   lib/gssapi/spnego/gssapiP_spnego.h
+   lib/gssapi/spnego/spnego_mech.c
+
+and the initial implementation of incremental propagation, including
+the following new or changed files:
+
+   include/iprop_hdr.h
+   kadmin/server/ipropd_svc.c
+   lib/kdb/iprop.x
+   lib/kdb/kdb_convert.c
+   lib/kdb/kdb_log.c
+   lib/kdb/kdb_log.h
+   lib/krb5/error_tables/kdb5_err.et
+   slave/kpropd_rpc.c
+   slave/kproplog.c
+
+are subject to the following license:
+
+   Copyright (C) 2004 Sun Microsystems, Inc.
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+
+======================================================================
+
+Kerberos V5 includes documentation and software developed at the
+University of California at Berkeley, which includes this copyright
+notice:
+
+   Copyright (C) 1983 Regents of the University of California.
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   3. Neither the name of the University nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS
+   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.
+
+======================================================================
+
+Portions contributed by Novell, Inc., including the LDAP database
+backend, are subject to the following license:
+
+   Copyright (C) 2004-2005, Novell, Inc.
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   * The copyright holder's name is not used to endorse or promote
+     products derived from this software without specific prior
+     written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+   COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+Portions funded by Sandia National Laboratory and developed by the
+University of Michigan's Center for Information Technology
+Integration, including the PKINIT implementation, are subject to the
+following license:
+
+   COPYRIGHT (C) 2006-2007
+   THE REGENTS OF THE UNIVERSITY OF MICHIGAN
+   ALL RIGHTS RESERVED
+
+   Permission is granted to use, copy, create derivative works and
+   redistribute this software and such derivative works for any
+   purpose, so long as the name of The University of Michigan is not
+   used in any advertising or publicity pertaining to the use of
+   distribution of this software without specific, written prior
+   authorization.  If the above copyright notice or any other
+   identification of the University of Michigan is included in any
+   copy of any portion of this software, then the disclaimer below
+   must also be included.
+
+   THIS SOFTWARE IS PROVIDED AS IS, WITHOUT REPRESENTATION FROM THE
+   UNIVERSITY OF MICHIGAN AS TO ITS FITNESS FOR ANY PURPOSE, AND
+   WITHOUT WARRANTY BY THE UNIVERSITY OF MICHIGAN OF ANY KIND, EITHER
+   EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+   THE REGENTS OF THE UNIVERSITY OF MICHIGAN SHALL NOT BE LIABLE FOR
+   ANY DAMAGES, INCLUDING SPECIAL, INDIRECT, INCIDENTAL, OR
+   CONSEQUENTIAL DAMAGES, WITH RESPECT TO ANY CLAIM ARISING OUT OF OR
+   IN CONNECTION WITH THE USE OF THE SOFTWARE, EVEN IF IT HAS BEEN OR
+   IS HEREAFTER ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+======================================================================
+
+The pkcs11.h file included in the PKINIT code has the following
+license:
+
+   Copyright 2006 g10 Code GmbH
+   Copyright 2006 Andreas Jellinghaus
+
+   This file is free software; as a special exception the author gives
+   unlimited permission to copy and/or distribute it, with or without
+   modifications, as long as this notice is preserved.
+
+   This file is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY, to the extent permitted by law; without even
+   the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+   PURPOSE.
+
+======================================================================
+
+Portions contributed by Apple Inc. are subject to the following
+license:
+
+   Copyright 2004-2008 Apple Inc.  All Rights Reserved.
+
+      Export of this software from the United States of America may
+      require a specific license from the United States Government.
+      It is the responsibility of any person or organization
+      contemplating export to obtain such a license before exporting.
+
+   WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+   distribute this software and its documentation for any purpose and
+   without fee is hereby granted, provided that the above copyright
+   notice appear in all copies and that both that copyright notice and
+   this permission notice appear in supporting documentation, and that
+   the name of Apple Inc. not be used in advertising or publicity
+   pertaining to distribution of the software without specific,
+   written prior permission.  Apple Inc. makes no representations
+   about the suitability of this software for any purpose.  It is
+   provided "as is" without express or implied warranty.
+
+   THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+   WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+======================================================================
+
+The implementations of UTF-8 string handling in src/util/support and
+src/lib/krb5/unicode are subject to the following copyright and
+permission notice:
+
+   The OpenLDAP Public License
+   Version 2.8, 17 August 2003
+
+   Redistribution and use of this software and associated
+   documentation ("Software"), with or without modification, are
+   permitted provided that the following conditions are met:
+
+   1. Redistributions in source form must retain copyright statements
+      and notices,
+
+   2. Redistributions in binary form must reproduce applicable
+      copyright statements and notices, this list of conditions, and
+      the following disclaimer in the documentation and/or other
+      materials provided with the distribution, and
+
+   3. Redistributions must contain a verbatim copy of this document.
+
+   The OpenLDAP Foundation may revise this license from time to time.
+   Each revision is distinguished by a version number.  You may use
+   this Software under terms of this license revision or under the
+   terms of any subsequent revision of the license.
+
+   THIS SOFTWARE IS PROVIDED BY THE OPENLDAP FOUNDATION AND ITS
+   CONTRIBUTORS "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED.  IN NO EVENT SHALL THE OPENLDAP FOUNDATION, ITS
+   CONTRIBUTORS, OR THE AUTHOR(S) OR OWNER(S) OF THE SOFTWARE BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+   OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+   BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+   DAMAGE.
+
+   The names of the authors and copyright holders must not be used in
+   advertising or otherwise to promote the sale, use or other dealing
+   in this Software without specific, written prior permission.  Title
+   to copyright in this Software shall at all times remain with
+   copyright holders.
+
+   OpenLDAP is a registered trademark of the OpenLDAP Foundation.
+
+   Copyright 1999-2003 The OpenLDAP Foundation, Redwood City,
+   California, USA.  All Rights Reserved.  Permission to copy and
+   distribute verbatim copies of this document is granted.
+
+Marked test programs in src/lib/krb5/krb have the following copyright:
+
+
+   Copyright (C) 2006 Kungliga Tekniska Högskolan
+   (Royal Institute of Technology, Stockholm, Sweden).
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   3. Neither the name of KTH nor the names of its contributors may be
+      used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY KTH AND ITS CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+   THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL KTH OR ITS
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.
+
+======================================================================
+
+The KCM Mach RPC definition file used on macOS has the following
+copyright:
+
+      Copyright (C) 2009 Kungliga Tekniska Högskolan
+      (Royal Institute of Technology, Stockholm, Sweden).
+      All rights reserved.
+
+   Portions Copyright (C) 2009 Apple Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   3. Neither the name of the Institute nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE
+   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.
+
+======================================================================
+
+Portions of the RPC implementation in src/lib/rpc and
+src/include/gssrpc have the following copyright and permission notice:
+
+   Copyright (C) 2010, Oracle America, Inc.
+
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   3. Neither the name of the "Oracle America, Inc." nor the names of
+      its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+   COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+   Copyright (C) 2006,2007,2009 NTT (Nippon Telegraph and Telephone
+   Corporation).  All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer as
+      the first lines of this file unmodified.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY NTT "AS IS" AND ANY EXPRESS OR IMPLIED
+   WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL NTT BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+   Copyright 2000 by Carnegie Mellon University
+
+   All Rights Reserved
+
+   Permission to use, copy, modify, and distribute this software and
+   its documentation for any purpose and without fee is hereby
+   granted, provided that the above copyright notice appear in all
+   copies and that both that copyright notice and this permission
+   notice appear in supporting documentation, and that the name of
+   Carnegie Mellon University not be used in advertising or publicity
+   pertaining to distribution of the software without specific,
+   written prior permission.
+
+   CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+   THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+   AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+   FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+   AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+   OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+   SOFTWARE.
+
+======================================================================
+
+   Copyright (C) 2002 Naval Research Laboratory (NRL/CCS)
+
+   Permission to use, copy, modify and distribute this software and
+   its documentation is hereby granted, provided that both the
+   copyright notice and this permission notice appear in all copies of
+   the software, derivative works or modified versions, and any
+   portions thereof.
+
+   NRL ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" CONDITION AND
+   DISCLAIMS ANY LIABILITY OF ANY KIND FOR ANY DAMAGES WHATSOEVER
+   RESULTING FROM THE USE OF THIS SOFTWARE.
+
+======================================================================
+
+Portions extracted from Internet RFCs have the following copyright
+notice:
+
+   Copyright (C) The Internet Society (2006).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on
+   an "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE
+   REPRESENTS OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT
+   THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR
+   ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+   PARTICULAR PURPOSE.
+
+======================================================================
+
+   Copyright (C) 1991, 1992, 1994 by Cygnus Support.
+
+   Permission to use, copy, modify, and distribute this software and
+   its documentation for any purpose and without fee is hereby
+   granted, provided that the above copyright notice appear in all
+   copies and that both that copyright notice and this permission
+   notice appear in supporting documentation. Cygnus Support makes no
+   representations about the suitability of this software for any
+   purpose.  It is provided "as is" without express or implied
+   warranty.
+
+======================================================================
+
+   Copyright (C) 2006 Secure Endpoints Inc.
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+
+======================================================================
+
+Portions of the implementation of the Fortuna-like PRNG are subject to
+the following notice:
+
+
+   Copyright (C) 2005 Marko Kreen
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.
+
+   Copyright (C) 1994 by the University of Southern California
+
+      EXPORT OF THIS SOFTWARE from the United States of America may
+      require a specific license from the United States Government. It
+      is the responsibility of any person or organization
+      contemplating export to obtain such a license before exporting.
+
+   WITHIN THAT CONSTRAINT, permission to copy, modify, and distribute
+   this software and its documentation in source and binary forms is
+   hereby granted, provided that any documentation or other materials
+   related to such distribution or use acknowledge that the software
+   was developed by the University of Southern California.
+
+   DISCLAIMER OF WARRANTY.  THIS SOFTWARE IS PROVIDED "AS IS".  The
+   University of Southern California MAKES NO REPRESENTATIONS OR
+   WARRANTIES, EXPRESS OR IMPLIED.  By way of example, but not
+   limitation, the University of Southern California MAKES NO
+   REPRESENTATIONS OR WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY
+   PARTICULAR PURPOSE. The University of Southern California shall not
+   be held liable for any liability nor for any direct, indirect, or
+   consequential damages with respect to any claim by the user or
+   distributor of the ksu software.
+
+======================================================================
+
+   Copyright (C) 1995
+   The President and Fellows of Harvard University
+
+   This code is derived from software contributed to Harvard by Jeremy
+   Rassen.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   3. All advertising materials mentioning features or use of this
+      software must display the following acknowledgement:
+
+         This product includes software developed by the University of
+         California, Berkeley and its contributors.
+
+   4. Neither the name of the University nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS
+   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.
+
+======================================================================
+
+   Copyright (C) 2008 by the Massachusetts Institute of Technology.
+   Copyright 1995 by Richard P. Basch.  All Rights Reserved.
+   Copyright 1995 by Lehman Brothers, Inc.  All Rights Reserved.
+
+      Export of this software from the United States of America may
+      require a specific license from the United States Government. It
+      is the responsibility of any person or organization
+      contemplating export to obtain such a license before exporting.
+
+   WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+   distribute this software and its documentation for any purpose and
+   without fee is hereby granted, provided that the above copyright
+   notice appear in all copies and that both that copyright notice and
+   this permission notice appear in supporting documentation, and that
+   the name of Richard P. Basch, Lehman Brothers and M.I.T. not be
+   used in advertising or publicity pertaining to distribution of the
+   software without specific, written prior permission.  Richard P.
+   Basch, Lehman Brothers and M.I.T. make no representations about the
+   suitability of this software for any purpose.  It is provided "as
+   is" without express or implied warranty.
+
+======================================================================
+
+The following notice applies to "src/lib/krb5/krb/strptime.c" and
+"src/include/k5-queue.h".
+
+   Copyright (C) 1997, 1998 The NetBSD Foundation, Inc.
+   All rights reserved.
+
+   This code was contributed to The NetBSD Foundation by Klaus Klein.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   3. All advertising materials mentioning features or use of this
+      software must display the following acknowledgement:
+
+         This product includes software developed by the NetBSD
+         Foundation, Inc. and its contributors.
+
+   4. Neither the name of The NetBSD Foundation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND
+   CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+   INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+   OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+   BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+   DAMAGE.
+
+======================================================================
+
+The following notice applies to Unicode library files in
+"src/lib/krb5/unicode":
+
+   Copyright 1997, 1998, 1999 Computing Research Labs,
+   New Mexico State University
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT.  IN NO EVENT SHALL THE COMPUTING RESEARCH LAB OR
+   NEW MEXICO STATE UNIVERSITY BE LIABLE FOR ANY CLAIM, DAMAGES OR
+   OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+   OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+======================================================================
+
+The following notice applies to "src/util/support/strlcpy.c":
+
+   Copyright (C) 1998 Todd C. Miller "Todd.Miller@courtesan.com"
+
+   Permission to use, copy, modify, and distribute this software for
+   any purpose with or without fee is hereby granted, provided that
+   the above copyright notice and this permission notice appear in all
+   copies.
+
+   THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+   WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+   AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+   CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+   OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+   NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+   CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+======================================================================
+
+The following notice applies to "src/util/profile/argv_parse.c" and
+"src/util/profile/argv_parse.h":
+
+   Copyright 1999 by Theodore Ts'o.
+
+   Permission to use, copy, modify, and distribute this software for
+   any purpose with or without fee is hereby granted, provided that
+   the above copyright notice and this permission notice appear in all
+   copies.  THE SOFTWARE IS PROVIDED "AS IS" AND THEODORE TS'O (THE
+   AUTHOR) DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+   INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN
+   NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+   INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+   RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+   OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+   IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.  (Isn't
+   it sick that the U.S. culture of lawsuit-happy lawyers requires
+   this kind of disclaimer?)
+
+======================================================================
+
+The following notice applies to SWIG-generated code in
+"src/util/profile/profile_tcl.c":
+
+   Copyright (C) 1999-2000, The University of Chicago
+
+   This file may be freely redistributed without license or fee
+   provided this copyright message remains intact.
+
+======================================================================
+
+The following notice applies to portiions of "src/lib/rpc" and
+"src/include/gssrpc":
+
+   Copyright (C) 2000 The Regents of the University of Michigan. All
+   rights reserved.
+
+   Copyright (C) 2000 Dug Song "dugsong@UMICH.EDU". All rights
+   reserved, all wrongs reversed.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   3. Neither the name of the University nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+   WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+   OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+   BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+   LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+   USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+   DAMAGE.
+
+Implementations of the MD4 algorithm are subject to the following
+notice:
+
+   Copyright (C) 1990, RSA Data Security, Inc. All rights reserved.
+
+   License to copy and use this software is granted provided that it
+   is identified as the "RSA Data Security, Inc. MD4 Message Digest
+   Algorithm" in all material mentioning or referencing this software
+   or this function.
+
+   License is also granted to make and use derivative works provided
+   that such works are identified as "derived from the RSA Data
+   Security, Inc. MD4 Message Digest Algorithm" in all material
+   mentioning or referencing the derived work.
+
+   RSA Data Security, Inc. makes no representations concerning either
+   the merchantability of this software or the suitability of this
+   software for any particular purpose.  It is provided "as is"
+   without express or implied warranty of any kind.
+
+   These notices must be retained in any copies of any part of this
+   documentation and/or software.
+
+======================================================================
+
+Implementations of the MD5 algorithm are subject to the following
+notice:
+
+   Copyright (C) 1990, RSA Data Security, Inc. All rights reserved.
+
+   License to copy and use this software is granted provided that it
+   is identified as the "RSA Data Security, Inc. MD5 Message- Digest
+   Algorithm" in all material mentioning or referencing this software
+   or this function.
+
+   License is also granted to make and use derivative works provided
+   that such works are identified as "derived from the RSA Data
+   Security, Inc. MD5 Message-Digest Algorithm" in all material
+   mentioning or referencing the derived work.
+
+   RSA Data Security, Inc. makes no representations concerning either
+   the merchantability of this software or the suitability of this
+   software for any particular purpose.  It is provided "as is"
+   without express or implied warranty of any kind.
+
+   These notices must be retained in any copies of any part of this
+   documentation and/or software.
+
+======================================================================
+
+The following notice applies to
+"src/lib/crypto/crypto_tests/t_mddriver.c":
+
+   Copyright (C) 1990-2, RSA Data Security, Inc. Created 1990. All
+   rights reserved.
+
+   RSA Data Security, Inc. makes no representations concerning either
+   the merchantability of this software or the suitability of this
+   software for any particular purpose. It is provided "as is" without
+   express or implied warranty of any kind.
+
+   These notices must be retained in any copies of any part of this
+   documentation and/or software.
+
+======================================================================
+
+Portions of "src/lib/krb5" are subject to the following notice:
+
+   Copyright (C) 1994 CyberSAFE Corporation.
+   Copyright 1990,1991,2007,2008 by the Massachusetts Institute of
+Technology.
+   All Rights Reserved.
+
+      Export of this software from the United States of America may
+      require a specific license from the United States Government. It
+      is the responsibility of any person or organization
+      contemplating export to obtain such a license before exporting.
+
+   WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+   distribute this software and its documentation for any purpose and
+   without fee is hereby granted, provided that the above copyright
+   notice appear in all copies and that both that copyright notice and
+   this permission notice appear in supporting documentation, and that
+   the name of M.I.T. not be used in advertising or publicity
+   pertaining to distribution of the software without specific,
+   written prior permission.  Furthermore if you modify this software
+   you must label your software as modified software and not
+   distribute it in such a fashion that it might be confused with the
+   original M.I.T. software. Neither M.I.T., the Open Computing
+   Security Group, nor CyberSAFE Corporation make any representations
+   about the suitability of this software for any purpose.  It is
+   provided "as is" without express or implied warranty.
+
+======================================================================
+
+Portions contributed by PADL Software are subject to the following
+license:
+
+   Copyright (c) 2011, PADL Software Pty Ltd. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   3. Neither the name of PADL Software nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY PADL SOFTWARE AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+   TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL PADL SOFTWARE
+   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+   USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+   ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.
+
+======================================================================
+
+The bundled libev source code is subject to the following license:
+
+   All files in libev are Copyright (C)2007,2008,2009 Marc Alexander
+   Lehmann.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+   COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   Alternatively, the contents of this package may be used under the
+   terms of the GNU General Public License ("GPL") version 2 or any
+   later version, in which case the provisions of the GPL are
+   applicable instead of the above. If you wish to allow the use of
+   your version of this package only under the terms of the GPL and
+   not to allow others to use your version of this file under the BSD
+   license, indicate your decision by deleting the provisions above
+   and replace them with the notice and other provisions required by
+   the GPL in this and the other files of this package. If you do not
+   delete the provisions above, a recipient may use your version of
+   this file under either the BSD or the GPL.
+
+======================================================================
+
+Files copied from the Intel AESNI Sample Library are subject to the
+following license:
+
+   Copyright (C) 2010, Intel Corporation
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+
+      * Redistributions in binary form must reproduce the above
+        copyright notice, this list of conditions and the following
+        disclaimer in the documentation and/or other materials
+        provided with the distribution.
+
+      * Neither the name of Intel Corporation nor the names of its
+        contributors may be used to endorse or promote products
+        derived from this software without specific prior written
+        permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+   COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+The following notice applies to
+"src/ccapi/common/win/OldCC/autolock.hxx":
+
+   Copyright (C) 1998 by Danilo Almeida.  All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+   COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+Libaio
+
+You may be receiving a copy of the Libaio library with this MySQL
+product. The terms of the Oracle license do NOT apply to the Libaio
+library; it is licensed under the following license, separately from
+the Oracle programs you receive. If you do not wish to install this
+program, you may delete its files.
+
+This component is licensed under
+GNU Lesser General Public License v2.1, February 1999.
+See the 'Standard Licenses' section for license text.
+
+   ======================================================================
+   ======================================================================
+
+libevent
+
+Copyright (c) 2000-2007 Niels Provos <provos@citi.umich.edu>
+Copyright (c) 2007-2012 Niels Provos and Nick Mathewson
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+==============================
+
+Portions of Libevent are based on works by others, also made available by
+them under the three-clause BSD license above.  The copyright notices are
+available in the corresponding source files; the license is as above.  Here's
+a list:
+
+log.c:
+   Copyright (c) 2000 Dug Song <dugsong@monkey.org>
+   Copyright (c) 1993 The Regents of the University of California.
+
+strlcpy.c:
+   Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+
+win32select.c:
+   Copyright (c) 2003 Michael A. Davis <mike@datanerds.net>
+
+evport.c:
+   Copyright (c) 2007 Sun Microsystems
+
+ht-internal.h:
+   Copyright (c) 2002 Christopher Clark
+
+minheap-internal.h:
+   Copyright (c) 2006 Maxim Yegorushkin <maxim.yegorushkin@gmail.com>
+
+==============================
+
+The arc4module is available under the following, sometimes called the
+"OpenBSD" license:
+
+   Copyright (c) 1996, David Mazieres <dm@uun.org>
+   Copyright (c) 2008, Damien Miller <djm@openbsd.org>
+
+   Permission to use, copy, modify, and distribute this software for any
+   purpose with or without fee is hereby granted, provided that the above
+   copyright notice and this permission notice appear in all copies.
+
+   THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+   WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+   MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+   ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+   WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+   ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+==============================
+
+The Windows timer code is based on code from libutp, which is
+distributed under this license, sometimes called the "MIT" license.
+
+Copyright (c) 2010 BitTorrent, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+   ======================================================================
+   ======================================================================
+
+LibFIDO
+
+Copyright (c) 2018-2021 Yubico AB. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+4th Party
+=========
+
+libcbor
+-------
+
+MIT License
+
+Copyright (c) 2014-2017 Pavel Kalvoda
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+----
+zlib
+----
+
+Copyright notice:
+
+ (C) 1995-2017 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
+
+If you use the zlib library in a product, we would appreciate *not* receiving
+lengthy legal documents to sign.  The sources are provided for free but
+without warranty of any kind.  The library has been entirely written by
+Jean-loup Gailly and Mark Adler; it does not include third-party code.
+
+If you redistribute modified sources, we would appreciate that you include in
+the file ChangeLog history information documenting your changes.  Please read
+the FAQ for more information on the distribution of modified source versions.
+
+------------------------------------------------------------------------------
+OpenSSL (See its own license section)
+------------------------------------------------------------------------------
+
+   ======================================================================
+   ======================================================================
+
+libtirpc
+
+/*
+ * Copyright (c) Copyright (c) Bull S.A.  2005  All Rights Reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+   ======================================================================
+   ======================================================================
+
+LZ4
+
+LZ4 Library
+Copyright (c) 2011-2016, Yann Collet
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+MeCab
+
+Copyright (c) 2001-2008, Taku Kudo
+Copyright (c) 2004-2008, Nippon Telegraph and Telephone Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+ * Redistributions of source code must retain the above
+   copyright notice, this list of conditions and the
+   following disclaimer.
+
+ * Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other
+   materials provided with the distribution.
+
+ * Neither the name of the Nippon Telegraph and Telegraph Corporation
+   nor the names of its contributors may be used to endorse or
+   promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+MeCab Dictionary
+
+Copyright 2000, 2001, 2002, 2003 Nara Institute of Science and Technology.
+All Rights Reserved.
+
+Use, reproduction, and distribution of this software is permitted. Any copy
+of this software, whether in its original form or modified, must include both
+the above copyright notice and the following paragraphs.
+
+Nara Institute of Science and Technology (NAIST), the copyright holders,
+disclaims all warranties with regard to this software, including all implied
+warranties of merchantability and fitness, in no event shall NAIST be liable
+for any special, indirect or consequential damages or any damages whatsoever
+resulting from loss of use, data or profits, whether in an action of
+contract, negligence or other tortuous action, arising out of or in
+connection with the use or performance of this software.
+
+A large portion of the dictionary entries originate from ICOT Free Software.
+The following conditions for ICOT Free Software applies to the current
+dictionary as well.
+
+Each User may also freely distribute the Program, whether in its original
+form or modified, to any third party or parties, PROVIDED that the provisions
+of Section 3 ("NO WARRANTY") will ALWAYS appear on, or be attached to, the
+Program, which is distributed substantially in the same form as set out
+herein and that such intended distribution, if actually made, will neither
+violate or otherwise contravene any of the laws and regulations of the
+countries having jurisdiction over the User or the intended distribution
+itself.
+
+NO WARRANTY
+
+The program was produced on an experimental basis in the course of the
+research and development conducted during the project and is provided to
+users as so produced on an experimental basis.  Accordingly, the program is
+provided without any warranty whatsoever, whether express, implied, statutory
+or otherwise.  The term "warranty" used herein
+includes, but is not limited to, any warranty of the quality, performance,
+merchantability and fitness for a particular purpose of the program and the
+nonexistence of any infringement or violation of any right of any third
+party.
+
+Each user of the program will agree and understand, and be deemed to have
+agreed and understood, that there is no warranty whatsoever for the program
+and, accordingly, the entire risk arising from or otherwise connected with
+the program is assumed by the user.
+
+Therefore, neither ICOT, the copyright holder, or any other organization that
+participated in or was otherwise related to the development of the program
+and their respective officials, directors, officers and other employees shall
+be held liable for any and all damages, including, without limitation,
+general, special, incidental and consequential damages, arising out of or
+otherwise in connection with the use or inability to use the program or any
+product, material or result produced or otherwise obtained by using the
+program, regardless of whether they have been advised of, or otherwise had
+knowledge of, the possibility of such damages at any time during the project
+or thereafter.  Each user will be deemed to have agreed to the foregoing by
+his or her commencement of use of the program.  The term "use" as used herein
+includes, but is not limited to, the use, modification, copying and
+distribution of the program and the production of secondary products from the
+program.
+
+In the case where the program, whether in its original form or modified, was
+distributed or delivered to or received by a user from any person,
+organization or entity other than ICOT, unless it makes or grants
+independently of ICOT any specific warranty to the user in writing, such
+person, organization or entity, will also be exempted from and not be held
+liable to the user for any such damages as noted above as far as the program
+is concerned.
+
+   ======================================================================
+   ======================================================================
+
+memcached
+
+Copyright (c) 2003, Danga Interactive, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+    * Neither the name of the Danga Interactive nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+Memcached.pm
+
+Memcached.pm is licensed under the Perl license.
+
+Oracle may use, redistribute and/or modify this code under the terms of
+either:
+
+        a) the GNU General Public License as published by the Free Software
+Foundation; either version 1, or (at your option) any later version, or
+
+        b) the "Artistic License" which comes with the Expect/pr code.
+
+Oracle elects to use the Artistic license for all versions of MySQL
+
+A copy of the GPLv2 and the Artistic License (Perl) 1.0 must be included with
+any distribution.
+
+This component is licensed under
+the GNU GPL license, version 2.0.
+
+This component is licensed under
+Artistic License (Perl) 1.0.
+
+   ======================================================================
+   ======================================================================
+
+nt_servc (Windows NT Service class library)
+
+Windows NT Service class library
+Copyright Abandoned 1998 Irena Pancirov - Irnet Snc
+This file is public domain and comes with NO WARRANTY of any kind
+
+   ======================================================================
+   ======================================================================
+
+OpenSSL 3.0
+
+You may be receiving a copy of OpenSSL 3.0 as part of this product in
+object code form.
+The terms of the Oracle license do NOT apply to OpenSSL 3.0.
+OpenSSL 3.0 is licensed under the Apache 2.0 license, separate from
+the Oracle product.
+If you do not wish to install this library, you may remove it, but
+the Oracle program might not operate properly or at all without it.
+
+/*
+ * Copyright 2003-2022 The OpenSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License 2.0 (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://www.openssl.org/source/license.html
+*/
+
+See Apache License v2.0, January 2004 in the
+'Standard Licenses' section.
+
+   ======================================================================
+   ======================================================================
+
+Percona Multiple I/O Threads Patch
+
+Copyright (c) 2008, 2009 Percona Inc
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the
+following conditions are met:
+
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of Percona Inc. nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission of Percona Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+   ======================================================================
+   ======================================================================
+
+RapidJSON v1.1.0
+
+Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip.  All
+rights reserved.
+
+If you have downloaded a copy of the RapidJSON binary from Tencent, please
+note that the RapidJSON binary is licensed under the MIT License.
+If you have downloaded a copy of the RapidJSON source code from Tencent,
+please note that RapidJSON source code is licensed under the MIT License,
+except for the third-party components listed below which are subject to
+different license terms.  Your integration of RapidJSON into your own
+projects may require compliance with the MIT License, as well as the other
+licenses applicable to the third-party components included within RapidJSON.
+To avoid the problematic JSON license in your own projects, it's sufficient
+to exclude the bin/jsonchecker/ directory, as it's the only code under the
+JSON license.
+A copy of the MIT License is included in this file.
+
+Other dependencies and licenses:
+
+Open Source Software Licensed Under the BSD License:
+--------------------------------------------------------------------
+
+The msinttypes r29
+Copyright (c) 2006-2013 Alexander Chemeris
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+* Neither the name of  copyright holder nor the names of its contributors may
+be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE REGENTS AND CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Open Source Software Licensed Under the JSON License:
+--------------------------------------------------------------------
+
+json.org
+Copyright (c) 2002 JSON.org
+All Rights Reserved.
+
+JSON_checker
+Copyright (c) 2002 JSON.org
+All Rights Reserved.
+
+
+Terms of the JSON License:
+---------------------------------------------------
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+The Software shall be used for Good, not Evil.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Terms of the MIT License:
+--------------------------------------------------------------------
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+   ======================================================================
+   ======================================================================
+
+Richard A. O'Keefe String Library
+
+The Richard O'Keefe String Library is subject to the following notice:
+
+These files are in the public domain.  This includes getopt.c, which
+is the work of Henry Spencer, University of Toronto Zoology, who
+says of it "None of this software is derived from Bell software. I
+had no access to the source for Bell's versions at the time I wrote
+it.  This software is hereby explicitly placed in the public domain.
+It may be used for any purpose on any machine by anyone." I would
+greatly prefer it if *my* material received no military use.
+
+The t_ctype.h file is subject to the following notice:
+
+Copyright (C) 1998, 1999 by Pruet Boonma, all rights reserved.
+Copyright (C) 1998 by Theppitak Karoonboonyanan, all rights reserved.
+
+  Permission to use, copy, modify, distribute and sell this software and its
+  documentation for any purpose is hereby granted without fee, provided that the
+  above copyright notice appear in all copies.
+
+  Smaphan Raruenrom and Pruet Boonma makes no representations about
+the suitability of this software for any purpose. It is provided
+"as is" without express or implied warranty.
+
+   ======================================================================
+   ======================================================================
+
+Time Zone Information
+
+Unless specified below, all files in the tz code and data (including this
+LICENSE file) are in the public domain. If the files date.c,
+newstrftime.3, and strftime.c are present, they contain material derived
+from BSD and use the BSD 3-clause license. tzdata:
+    # This file is in the public domain, so clarified as of
+    # 2009-05-17 by Arthur David Olson.
+/* Copyright 1985, 1987, 1988 The Regents of the University of California.
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+   3. Neither the name of the University nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+   THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS" AND
+   ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+   OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+   LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+   OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+   SUCH DAMAGE.  */
+
+   ======================================================================
+   ======================================================================
+
+Unicode Data Files
+
+# unidata-5.2.0.txt
+# Date: 2009-09-22, 16:23:42 PDT [KW]
+#
+# This file defines the Default Unicode Collation Element Table
+#   (DUCET) for the Unicode Collation Algorithm
+#
+# Copyright (c) 2001-2009 Unicode, Inc.
+# For terms of use, see http://www.unicode.org/terms_of_use.html
+#
+# See UTS #10, Unicode Collation Algorithm, for more information.
+#
+# Diagnostic weight ranges
+# Primary weight range:   0200..3ACA (14539)
+# Secondary weight range: 0020..0192 (371)
+# Variant secondaries:    0159..015E (6)
+# Digit secondaries:      015F..0192 (52)
+# Tertiary weight range:  0002..001F (30)
+#
+@version 5.2.0
+
+=== http://www.unicode.org/terms_of_use.html
+For the general privacy policy governing access to this site, see the
+Unicode Privacy Policy.
+
+Unicode Copyright
+    Copyright (c) 1991-2020 Unicode, Inc. All rights reserved.
+Definitions
+Unicode Data Files ("DATA FILES") include all data files under the
+directories:
+https://www.unicode.org/Public/
+https://www.unicode.org/reports/
+https://www.unicode.org/ivd/data/
+Unicode Data Files do not include PDF online code charts under the directory:
+https://www.unicode.org/Public/
+Unicode Software ("SOFTWARE") includes any source code published in the
+Unicode Standard
+or any source code or compiled code under the directories:
+https://www.unicode.org/Public/PROGRAMS/
+https://www.unicode.org/Public/cldr/
+http://site.icu-project.org/download/
+
+Terms of Use
+Certain documents and files on this website contain a legend indicating that
+"Modification is permitted." Any person is hereby authorized, without fee, to
+modify such documents and files to create derivative works conforming to the
+Unicode(R) Standard, subject to Terms and Conditions herein.
+Any person is hereby authorized, without fee, to view, use, reproduce, and
+distribute all documents and files, subject to the Terms and Conditions
+herein.
+Further specifications of rights and restrictions pertaining to the use of
+the Unicode DATA FILES and SOFTWARE can be found in the Unicode Data Files
+and Software License.
+Each version of the Unicode Standard has further specifications of rights and
+restrictions of use. For the book editions (Unicode 5.0 and earlier), these
+are found on the back of the title page.
+The Unicode PDF online code charts carry specific restrictions. Those
+restrictions are incorporated as the first page of each PDF code chart.
+All other files, including online documentation of the core specification for
+Unicode 6.0 and later, are covered under these general Terms of Use.
+No license is granted to "mirror" the Unicode website where a fee is charged
+for access to the "mirror" site.
+Modification is not permitted with respect to this document. All copies of
+this document must be verbatim.
+
+Restricted Rights Legend
+Any technical data or software which is licensed to the United States of
+America, its agencies and/or instrumentalities under this Agreement is
+commercial technical data or commercial computer software developed
+exclusively at private expense as defined in FAR 2.101, or DFARS 252.227-7014
+(June 1995), as applicable. For technical data, use, duplication, or
+disclosure by the Government is subject to restrictions as set forth in DFARS
+202.227-7015 Technical Data, Commercial and Items (Nov 1995) and this
+Agreement. For Software, in accordance with FAR 12-212 or DFARS 227-7202, as
+applicable, use, duplication or disclosure by the Government is subject to
+the restrictions set forth in this Agreement.
+
+Warranties and Disclaimers
+This publication and/or website may include technical or typographical errors
+or other inaccuracies. Changes are periodically added to the information
+herein; these changes will be incorporated in new editions of the publication
+and/or website. Unicode, Inc. may make improvements and/or changes in the
+product(s) and/or program(s) described in this publication and/or website at
+any time.
+If this file has been purchased on magnetic or optical media from Unicode,
+Inc. the sole and exclusive remedy for any claim will be exchange of the
+defective media within ninety (90) days of original purchase.
+
+EXCEPT AS PROVIDED IN SECTION E.2, THIS PUBLICATION AND/OR SOFTWARE IS
+PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND EITHER EXPRESS, IMPLIED, OR
+STATUTORY, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT. UNICODE, INC. AND ITS
+LICENSORS ASSUME NO RESPONSIBILITY FOR ERRORS OR OMISSIONS IN THIS
+PUBLICATION AND/OR SOFTWARE OR OTHER DOCUMENTS WHICH ARE REFERENCED BY OR
+LINKED TO THIS PUBLICATION OR THE UNICODE WEBSITE.
+
+Waiver of Damages
+In no event shall Unicode, Inc. or its licensors be liable for any special,
+incidental, indirect or consequential damages of any kind, or any damages
+whatsoever, whether or not Unicode, Inc. was advised of the possibility of
+the damage, including, without limitation, those resulting from the
+following: loss of use, data or profits, in connection with the use,
+modification or distribution of this information or its derivatives.
+
+Trademarks & Logos
+The Unicode Word Mark and the Unicode Logo are trademarks of Unicode, Inc.
+¿The Unicode Consortium¿ and ¿Unicode, Inc.¿ are trade names of Unicode, Inc.
+Use of the information and materials found on this website indicates your
+acknowledgement of Unicode, Inc.¿s exclusive worldwide rights in the Unicode
+Word Mark, the Unicode Logo, and the Unicode trade names.
+The Unicode Consortium Name and Trademark Usage Policy (¿Trademark Policy¿)
+are incorporated herein by reference and you agree to abide by the provisions
+of the Trademark Policy, which may be changed from time to time in the sole
+discretion of Unicode, Inc.
+All third party trademarks referenced herein are the property of their
+respective owners.
+
+Miscellaneous
+Jurisdiction and Venue. This website is operated from a location in the State
+of California, United States of America. Unicode, Inc. makes no
+representation that the materials are appropriate for use in other locations.
+If you access this website from other locations, you are responsible for
+compliance with local laws. This Agreement, all use of this website and any
+claims and damages resulting from use of this website are governed solely by
+the laws of the State of California without regard to any principles which
+would apply the laws of a different jurisdiction. The user agrees that any
+disputes regarding this website shall be resolved solely in the courts
+located in Santa Clara County, California. The user agrees said courts have
+personal jurisdiction and agree to waive any right to transfer the dispute to
+any other forum.
+
+Modification by Unicode, Inc. Unicode, Inc. shall have the right to modify
+this Agreement at any time by posting it to this website. The user may not
+assign any part of this Agreement without Unicode, Inc.¿s prior written
+consent.
+
+Taxes. The user agrees to pay any taxes arising from access to this website
+or use of the information herein, except for those based on Unicode¿s net
+income.
+
+Severability.  If any provision of this Agreement is declared invalid or
+unenforceable, the remaining provisions of this Agreement shall remain in
+effect.
+
+Entire Agreement. This Agreement constitutes the entire agreement between the
+parties.
+
+   ======================================================================
+   ======================================================================
+
+Unicode Data Files
+
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+Unicode Data Files include all data files under the directories
+http://www.unicode.org/Public/, http://www.unicode.org/reports/,
+http://www.unicode.org/cldr/data/, http://source.icu-project.org/repos/icu/,
+and http://www.unicode.org/utility/trac/browser/.
+
+Unicode Data Files do not include PDF online code charts under the
+directory http://www.unicode.org/Public/.
+
+Software includes any source code published in the Unicode Standard
+or under the directories http://www.unicode.org/Public/,
+http://www.unicode.org/reports/, http://www.unicode.org/cldr/data/,
+http://source.icu-project.org/repos/icu/, and
+http://www.unicode.org/utility/trac/browser/.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1991-2016 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in http://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the Unicode data files and any associated documentation (the "Data Files")
+or Unicode software and any associated documentation (the "Software") to deal
+in the Data Files or Software without restriction, including without
+limitation the rights to use, copy, modify, merge, publish, distribute,
+and/or sell copies of the Data Files or Software, and to permit persons to
+whom the Data Files or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS
+INCLUDED IN THIS NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR
+CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written authorization
+of the copyright holder.
+
+=========================================================================
+
+ICU-LICENSE
+-----------
+ICU License - ICU 1.8.1 and later
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright (c) 1995-2016 International Business Machines Corporation and
+others
+
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+provided that the above copyright notice(s) and this permission notice appear
+in all copies of the Software and that both the above copyright notice(s) and
+this permission notice appear in supporting documentation.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE BE
+LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES, OR
+ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER
+IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not
+be used in advertising or otherwise to promote the sale, use or other
+dealings in this Software without prior written authorization of the
+copyright holder.
+
+All trademarks and registered trademarks mentioned herein are the property of
+their respective owners.
+
+   ======================================================================
+   ======================================================================
+
+unordered_dense
+
+Copyright (c) 2022 Martin Leitner-Ankerl
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+   ======================================================================
+   ======================================================================
+
+xxHash
+
+Copyright (c) 2012-2021 Yann Collet
+All rights reserved.
+BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Some source files include the above license with different copyright years:
+Copyright (C) 2012-2023 Yann Collet
+Copyright (C) 2020-2024 Yann Collet
+
+   ======================================================================
+   ======================================================================
+
+zlib
+
+Oracle gratefully acknowledges the contributions of Jean-loup Gailly
+and Mark Adler in creating the zlib general purpose compression
+library which is used in this product.
+
+Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
+
+If you use the zlib library in a product, we would appreciate *not* receiving
+lengthy legal documents to sign.  The sources are provided for free but without
+warranty of any kind.  The library has been entirely written by Jean-loup
+Gailly and Mark Adler; it does not include third-party code.
+
+If you redistribute modified sources, we would appreciate that you include in
+the file ChangeLog history information documenting your changes.  Please read
+the FAQ for more information on the distribution of modified source versions.
+
+   ======================================================================
+   ======================================================================
+
+ZSTD (Zstandard)
+
+Zstandard is dual-licensed under [BSD](LICENSE) and [GPLv2](COPYING).
+
+ /*
+ * This source code is licensed under both the BSD-style license (found in
+ * the LICENSE file in the root directory of this source tree) and the GPLv2
+ * (found in the COPYING file in the root directory of this source tree).
+ * You may select, at your option, one of the above-listed licenses.
+ */
+
+Oracle elects the BSD license
+
+LICENSE:
+Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+Copyright (C) 2012-2016, Yann Collet.
+Copyright (c) 2003-2008 Yuta Mori All Rights Reserved.
+Copyright (c) 2016 Tino Reichardt
+Copyright (c) 2016-present, Przemyslaw Skibinski, Yann Collet, Facebook, Inc.
+Copyright (c) 2016-present, Yann Collet, Facebook, Inc.
+Copyright (c) 2018-present, Facebook, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The following is from the COPYING file and is included for completeness:
+-------------------------------
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.
+
+   ======================================================================
+   ======================================================================
+
+Standard Licenses
+
+GNU Lesser General Public License v2.1, February 1999
+
+The following applies to all products licensed under the
+GNU Lesser General Public License, Version 2.1: You may
+not use the identified files except in compliance with
+the GNU Lesser General Public License, Version 2.1 (the
+"License"). You may obtain a copy of the License at
+http://www.gnu.org/licenses/lgpl-2.1.html. A copy of the
+license is also reproduced below. Unless required by
+applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing
+permissions and limitations under the License.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it
+becomes a de-facto standard.  To achieve this, non-free programs
+must be allowed to use the library.  A more frequent case is that
+a free library does the same job as widely used non-free libraries.
+In this case, there is little to gain by limiting the free library
+to free software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control
+compilation and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended
+to apply, and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms
+of the ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.
+It is safest to attach them to the start of each source file to most
+effectively convey the exclusion of warranty; and each file should
+have at least the "copyright" line and a pointer to where the full
+notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+    02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James
+  Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+   ======================================================================
+   ======================================================================
+
+Artistic License (Perl) 1.0
+
+The "Artistic License"
+
+Preamble
+
+The intent of this document is to state the conditions under which a
+Package may be copied, such that the Copyright Holder maintains some
+semblance of artistic control over the development of the package,
+while giving the users of the package the right to use and distribute
+the Package in a more-or-less customary fashion, plus the right to make
+reasonable modifications.
+
+Definitions:
+
+        "Package" refers to the collection of files distributed by the
+        Copyright Holder, and derivatives of that collection of files
+        created through textual modification.
+
+        "Standard Version" refers to such a Package if it has not been
+        modified, or has been modified in accordance with the wishes
+        of the Copyright Holder as specified below.
+
+        "Copyright Holder" is whoever is named in the copyright or
+        copyrights for the package.
+
+        "You" is you, if you're thinking about copying or distributing
+        this Package.
+
+        "Reasonable copying fee" is whatever you can justify on the
+        basis of media cost, duplication charges, time of people involved,
+        and so on.  (You will not be required to justify it to the
+        Copyright Holder, but only to the computing community at large
+        as a market that must bear the fee.)
+
+        "Freely Available" means that no fee is charged for the item
+        itself, though there may be fees involved in handling the item.
+        It also means that recipients of the item may redistribute it
+        under the same conditions they received it.
+
+1. You may make and give away verbatim copies of the source form of the
+Standard Version of this Package without restriction, provided that you
+duplicate all of the original copyright notices and associated disclaimers.
+
+2. You may apply bug fixes, portability fixes and other modifications
+derived from the Public Domain or from the Copyright Holder.  A Package
+modified in such a way shall still be considered the Standard Version.
+
+3. You may otherwise modify your copy of this Package in any way, provided
+that you insert a prominent notice in each changed file stating how and
+when you changed that file, and provided that you do at least ONE of the
+following:
+
+    a) place your modifications in the Public Domain or otherwise make them
+    Freely Available, such as by posting said modifications to Usenet or
+    an equivalent medium, or placing the modifications on a major archive
+    site such as uunet.uu.net, or by allowing the Copyright Holder to include
+    your modifications in the Standard Version of the Package.
+
+    b) use the modified Package only within your corporation or organization.
+
+    c) rename any non-standard executables so the names do not conflict
+    with standard executables, which must also be provided, and provide
+    a separate manual page for each non-standard executable that clearly
+    documents how it differs from the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+4. You may distribute the programs of this Package in object code or
+executable form, provided that you do at least ONE of the following:
+
+    a) distribute a Standard Version of the executables and library files,
+    together with instructions (in the manual page or equivalent) on where
+    to get the Standard Version.
+
+    b) accompany the distribution with the machine-readable source of
+    the Package with your modifications.
+
+    c) give non-standard executables non-standard names, and clearly
+    document the differences in manual pages (or equivalent), together
+    with instructions on where to get the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+5. You may charge a reasonable copying fee for any distribution of this
+Package.  You may charge any fee you choose for support of this
+Package.  You may not charge a fee for this Package itself.  However,
+you may distribute this Package in aggregate with other (possibly
+commercial) programs as part of a larger (possibly commercial) software
+distribution provided that you do not advertise this Package as a
+product of your own.  You may embed this Package's interpreter within
+an executable of yours (by linking); this shall be construed as a mere
+form of aggregation, provided that the complete Standard Version of the
+interpreter is so embedded.
+
+6. The scripts and library files supplied as input to or produced as
+output from the programs of this Package do not automatically fall
+under the copyright of this Package, but belong to whoever generated
+them, and may be sold commercially, and may be aggregated with this
+Package.  If such scripts or library files are aggregated with this
+Package via the so-called "undump" or "unexec" methods of producing a
+binary executable image, then distribution of such an image shall
+neither be construed as a distribution of this Package nor shall it
+fall under the restrictions of Paragraphs 3 and 4, provided that you do
+not represent such an executable image as a Standard Version of this
+Package.
+
+7. C subroutines (or comparably compiled subroutines in other
+languages) supplied by you and linked into this Package in order to
+emulate subroutines and variables of the language defined by this
+Package shall not be considered part of this Package, but are the
+equivalent of input as in Paragraph 6, provided these subroutines do
+not change the language in any way that would cause it to fail the
+regression tests for the language.
+
+8. Aggregation of this Package with a commercial distribution is always
+permitted provided that the use of this Package is embedded; that is,
+when no overt attempt is made to make this Package's interfaces visible
+to the end user of the commercial distribution.  Such use shall not be
+construed as a distribution of this Package.
+
+9. The name of the Copyright Holder may not be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+10. THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+                                The End
+
+   ======================================================================
+   ======================================================================
+
+Apache License v2.0, January 2004
+
+The following applies to all products licensed under the Apache 2.0
+License: You may not use the identified files except in compliance
+with the Apache License, Version 2.0 (the "License.") You may obtain a
+copy of the License at http://www.apache.org/licenses/LICENSE-2.0. A
+copy of the license is also reproduced below. Unless required by
+applicable law or agreed to in writing, software distributed under the
+License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for
+the specific language governing permissions and limitations under the
+License.
+
+Apache License Version 2.0, January 2004 http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control
+with that entity. For the purposes of this definition, "control" means
+(i) the power, direct or indirect, to cause the direction or
+management of such entity, whether by contract or otherwise, or (ii)
+ownership of fifty percent (50%) or more of the outstanding shares, or
+(iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but not
+limited to compiled object code, generated documentation, and
+conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object
+form, made available under the License, as indicated by a copyright
+notice that is included in or attached to the work (an example is
+provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the
+purposes of this License, Derivative Works shall not include works
+that remain separable from, or merely link (or bind by name) to the
+interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the
+original version of the Work and any modifications or additions to
+that Work or Derivative Works thereof, that is intentionally submitted
+to Licensor for inclusion in the Work by the copyright owner or by an
+individual or Legal Entity authorized to submit on behalf of the
+copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent to
+the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control
+systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work,
+but excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of, publicly
+display, publicly perform, sublicense, and distribute the Work and
+such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except
+as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such
+Contributor that are necessarily infringed by their Contribution(s)
+alone or by combination of their Contribution(s) with the Work to
+which such Contribution(s) was submitted. If You institute patent
+litigation against any entity (including a cross-claim or counterclaim
+in a lawsuit) alleging that the Work or a Contribution incorporated
+within the Work constitutes direct or contributory patent
+infringement, then any patent licenses granted to You under this
+License for that Work shall terminate as of the date such litigation
+is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work
+or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You meet
+the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works
+a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that
+You distribute, all copyright, patent, trademark, and attribution
+notices from the Source form of the Work, excluding those notices that
+do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+
+within such NOTICE file, excluding those notices that do not pertain
+to any part of the Derivative Works, in at least one of the following
+places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the
+Derivative Works, if and wherever such third-party notices normally
+appear. The contents of the NOTICE file are for informational purposes
+only and do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside or as
+an addendum to the NOTICE text from the Work, provided that such
+additional attribution notices cannot be construed as modifying the
+License.
+
+You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated
+in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work by
+You to the Licensor shall be under the terms and conditions of this
+License, without any additional terms or conditions.  Notwithstanding
+the above, nothing herein shall supersede or modify the terms of any
+separate license agreement you may have executed with Licensor
+regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed
+to in writing, Licensor provides the Work (and each Contributor
+provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely
+responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your
+exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise, unless
+required by applicable law (such as deliberate and grossly negligent
+acts) or agreed to in writing, shall any Contributor be liable to You
+for damages, including any direct, indirect, special, incidental, or
+consequential damages of any character arising as a result of this
+License or out of the use or inability to use the Work (including but
+not limited to damages for loss of goodwill, work stoppage, computer
+failure or malfunction, or any and all other commercial damages or
+losses), even if such Contributor has been advised of the possibility
+of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer, and
+charge a fee for, acceptance of support, warranty, indemnity, or other
+liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only on
+Your own behalf and on Your sole responsibility, not on behalf of any
+other Contributor, and only if You agree to indemnify, defend, and
+hold each Contributor harmless for any liability incurred by, or
+claims asserted against, such Contributor by reason of your accepting
+any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included
+on the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+   ======================================================================
+   ======================================================================
+
+Written Offer for Source Code
+
+   For any software that you receive from Oracle in binary form which is
+   licensed under an open source license that gives you the right to
+   receive the source code for that binary, you can obtain a copy of the
+   applicable source code by visiting
+   http://www.oracle.com/goto/opensourcecode. If the source code for the
+   binary was not provided to you with the binary, you can also receive a
+   copy of the source code on physical media by submitting a written
+   request to the address listed below or by sending an email to Oracle
+   using the following link:
+   http://www.oracle.com/goto/opensourcecode/request.
+
+  Oracle America, Inc.
+  Attn: Senior Vice President
+  Development and Engineering Legal
+  500 Oracle Parkway, 10th Floor
+  Redwood Shores, CA 94065
+
+   Your request should include:
+
+     * The name of the binary for which you are requesting the source code
+
+     * The name and version number of the Oracle product containing the
+       binary
+
+     * The date you received the Oracle product
+
+     * Your name
+
+     * Your company name (if applicable)
+
+     * Your return mailing address and email, and
+
+     * A telephone number in the event we need to reach you.
+
+
+   We may charge you a fee to cover the cost of physical media and
+   processing.
+
+   Your request must be sent
+
+    a. within three (3) years of the date you received the Oracle product
+       that included the binary that is the subject of your request, or
+
+    b. in the case of code licensed under the GPL v3 for as long as Oracle
+       offers spare parts or customer support for that product model.

--- a/release/artifacts/recipes/mysql/NOTICE
+++ b/release/artifacts/recipes/mysql/NOTICE
@@ -1,0 +1,20 @@
+Copyright (c) 2000, 2026, Oracle and/or its affiliates.
+
+This is a release of MySQL, an SQL database server.
+
+License information can be found in the LICENSE file.
+
+In test packages where this file is renamed README-test, the license
+file is renamed LICENSE-test.
+
+This distribution may include materials developed by third parties.
+For license and attribution notices for these materials,
+please refer to the LICENSE file.
+
+For further information on MySQL or additional documentation, visit
+  http://dev.mysql.com/doc/
+
+For additional downloads and the source of MySQL, visit
+  http://dev.mysql.com/downloads/
+
+MySQL is brought to you by the MySQL team at Oracle.

--- a/release/artifacts/recipes/mysql/build.sh
+++ b/release/artifacts/recipes/mysql/build.sh
@@ -12,7 +12,7 @@ RECORD_DIR=${PV_ARTIFACT_RECORD_DIR:-"$ROOT/release/artifacts/records"}
 PV_COMMIT=${PV_COMMIT:-}
 BUILD_RUN_ID=${PV_BUILD_RUN_ID:-local-mysql}
 BUILD_JOBS=${PV_BUILD_JOBS:-}
-DEPLOYMENT_TARGET=${PV_MACOSX_DEPLOYMENT_TARGET:-13.0}
+DEPLOYMENT_TARGET=13.0
 recipe_dir="$ROOT/release/artifacts/recipes/mysql"
 
 need cargo

--- a/release/artifacts/recipes/mysql/build.sh
+++ b/release/artifacts/recipes/mysql/build.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/../../../.." && pwd)
+# shellcheck source=/dev/null
+. "$ROOT/release/artifacts/recipes/common.sh"
+
+TRACK=${PV_RECIPE_TRACK:-8.4}
+PLATFORM=${PV_RECIPE_PLATFORM:-darwin-arm64}
+OUT_DIR=${PV_ARTIFACT_OUT_DIR:-"$ROOT/release/artifacts/out"}
+RECORD_DIR=${PV_ARTIFACT_RECORD_DIR:-"$ROOT/release/artifacts/records"}
+PV_COMMIT=${PV_COMMIT:-}
+BUILD_RUN_ID=${PV_BUILD_RUN_ID:-local-mysql}
+BUILD_JOBS=${PV_BUILD_JOBS:-}
+DEPLOYMENT_TARGET=${PV_MACOSX_DEPLOYMENT_TARGET:-13.0}
+recipe_dir="$ROOT/release/artifacts/recipes/mysql"
+
+need cargo
+need cmake
+need curl
+need dirname
+need find
+need git
+need make
+need readlink
+need shasum
+need tar
+
+case "$PLATFORM" in
+  darwin-arm64 | darwin-amd64) ;;
+  *) die "unsupported MySQL artifact platform: $PLATFORM" ;;
+esac
+
+if [ -z "$PV_COMMIT" ]; then
+  PV_COMMIT=$(git -C "$ROOT" rev-parse HEAD)
+fi
+
+if [ -z "$BUILD_JOBS" ]; then
+  BUILD_JOBS=$(sysctl -n hw.ncpu 2>/dev/null || printf '%s\n' 2)
+fi
+
+download_source() {
+  source_archive=$1
+
+  mkdir -p "$(dirname "$source_archive")"
+  curl -L --fail --show-error --silent \
+    --retry 3 --retry-delay 2 --retry-all-errors \
+    --connect-timeout 20 --max-time 1200 \
+    "$PV_SOURCE_URL" -o "$source_archive"
+  require_sha256 "$source_archive" "$PV_SOURCE_SHA256"
+}
+
+extract_source() {
+  source_archive=$1
+  source_extract_dir=$2
+
+  rm -rf "$source_extract_dir"
+  mkdir -p "$source_extract_dir"
+  tar -xzf "$source_archive" -C "$source_extract_dir"
+
+  source_entry_count=0
+  source_dir=
+  for source_entry in "$source_extract_dir"/* "$source_extract_dir"/.[!.]* "$source_extract_dir"/..?*; do
+    [ -d "$source_entry" ] || [ -f "$source_entry" ] || [ -L "$source_entry" ] || continue
+    source_entry_count=$((source_entry_count + 1))
+    source_dir=$source_entry
+  done
+  [ "$source_entry_count" -eq 1 ] || die "MySQL source archive must contain exactly one top-level source directory"
+  [ -d "$source_dir" ] || die "MySQL source archive top-level entry is not a directory"
+  printf '%s\n' "$source_dir"
+}
+
+copy_install_tree() {
+  install_dir=$1
+  root_dir=$2
+
+  mkdir -p "$root_dir"
+  tar -cf - -C "$install_dir" . | tar -xf - -C "$root_dir"
+  find "$root_dir" -type l -exec sh -c '
+    for path do
+      target=$(readlink "$path") || exit 1
+      case "$target" in
+        /*) source=$target ;;
+        *) source=$(dirname "$path")/$target ;;
+      esac
+      tmp=$path.pv-copy.$$
+      rm "$path" || exit 1
+      cp -p "$source" "$tmp" || exit 1
+      mv "$tmp" "$path" || exit 1
+    done
+  ' sh {} +
+  find "$root_dir" -type f -links +1 -exec sh -c '
+    for path do
+      tmp=$path.pv-copy.$$
+      cp -p "$path" "$tmp" || exit 1
+      mv "$tmp" "$path" || exit 1
+    done
+  ' sh {} +
+  rewrite_macho_install_names "$root_dir" "$install_dir"
+  pv_recipe_ad_hoc_sign_macho_tree "$root_dir"
+  for binary in mysqld mysql mysqladmin; do
+    [ -x "$root_dir/bin/$binary" ] || die "MySQL artifact missing bin/$binary"
+    pv_recipe_validate_macho_binary "$root_dir/bin/$binary" "$PLATFORM" "$DEPLOYMENT_TARGET"
+  done
+  if [ -d "$root_dir/lib" ]; then
+    find "$root_dir/lib" -type f \( -name '*.dylib' -o -name '*.so' \) | while IFS= read -r library; do
+      pv_recipe_validate_macho_binary "$library" "$PLATFORM" "$DEPLOYMENT_TARGET"
+    done
+  fi
+  cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
+  cp "$recipe_dir/NOTICE" "$root_dir/NOTICE"
+}
+
+env_file="$OUT_DIR/work/mysql-$TRACK-$PLATFORM.env"
+mkdir -p "$(dirname "$env_file")"
+cargo run -p pv-release -- print-recipe-env \
+  --mysql "$recipe_dir/recipe.toml" \
+  --resource mysql \
+  --track "$TRACK" \
+  --platform "$PLATFORM" >"$env_file"
+# shellcheck source=/dev/null
+. "$env_file"
+export PV_UPSTREAM_VERSION
+
+artifact_basename=$(artifact_basename mysql "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+work_dir="$OUT_DIR/work/$artifact_basename"
+source_archive="$OUT_DIR/sources/mysql-$PV_UPSTREAM_VERSION.tar.gz"
+source_extract_dir="$OUT_DIR/sources/mysql-$PV_UPSTREAM_VERSION-source"
+build_dir="$work_dir/build"
+install_dir="$work_dir/install"
+root_dir="$work_dir/$artifact_basename"
+archive="$OUT_DIR/$artifact_basename.tar.gz"
+record=$(artifact_record_path "$RECORD_DIR" mysql "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+object_key=$(artifact_object_key mysql "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+
+rm -rf "$work_dir"
+mkdir -p "$work_dir" "$OUT_DIR"
+download_source "$source_archive"
+source_dir=$(extract_source "$source_archive" "$source_extract_dir")
+
+export MACOSX_DEPLOYMENT_TARGET="$DEPLOYMENT_TARGET"
+cmake -S "$source_dir" -B "$build_dir" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$install_dir" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET="$DEPLOYMENT_TARGET" \
+  -DINSTALL_LAYOUT=STANDALONE \
+  -DMYSQL_DATADIR="$install_dir/data" \
+  -DWITH_EDITLINE=bundled \
+  -DWITH_ICU=bundled \
+  -DWITH_LZ4=bundled \
+  -DWITH_NDB=OFF \
+  -DWITH_PROTOBUF=bundled \
+  -DWITH_ROUTER=OFF \
+  -DWITH_SSL=bundled \
+  -DWITH_UNIT_TESTS=OFF \
+  -DWITH_ZLIB=bundled \
+  -DWITH_ZSTD=bundled
+cmake --build "$build_dir" --parallel "$BUILD_JOBS"
+cmake --install "$build_dir"
+
+copy_install_tree "$install_dir" "$root_dir"
+COPYFILE_DISABLE=1 tar -czf "$archive" -C "$work_dir" "$artifact_basename"
+write_record "$record" mysql "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/mysql/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
+
+PV_UPSTREAM_VERSION="$PV_UPSTREAM_VERSION" \
+  cargo run -p pv-release -- validate-archive --archive "$archive" --record "$record" --smoke-hook "$recipe_dir/smoke.sh"
+printf '%s\n' "$archive"

--- a/release/artifacts/recipes/mysql/recipe.toml
+++ b/release/artifacts/recipes/mysql/recipe.toml
@@ -1,0 +1,17 @@
+[recipe]
+resources = ["mysql"]
+default_track = "8.4"
+platforms = ["darwin-arm64", "darwin-amd64"]
+minimum_pv_version = "0.1.0"
+pv_build_revision = "pv1"
+license_files = ["LICENSE"]
+notice_files = ["NOTICE"]
+
+[artifact]
+payload_paths = ["bin/mysqld", "bin/mysql", "bin/mysqladmin"]
+
+[[tracks]]
+name = "8.4"
+upstream_version = "8.4.9"
+source_url = "https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9.tar.gz"
+source_sha256 = "e4aa8b39e42d1fe078f33bbd73695fac2b54dbc7bb137f0bdbe63f7be1a02d6b"

--- a/release/artifacts/recipes/mysql/smoke.sh
+++ b/release/artifacts/recipes/mysql/smoke.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+set -eu
+
+artifact_root=$1
+mysqld="$artifact_root/bin/mysqld"
+mysql="$artifact_root/bin/mysql"
+mysqladmin="$artifact_root/bin/mysqladmin"
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf '%s\n' "missing required command: $1" >&2
+    exit 42
+  }
+}
+
+available_port() {
+  python3 - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+}
+
+[ -x "$mysqld" ] || {
+  printf '%s\n' "missing executable $mysqld" >&2
+  exit 42
+}
+[ -x "$mysql" ] || {
+  printf '%s\n' "missing executable $mysql" >&2
+  exit 42
+}
+[ -x "$mysqladmin" ] || {
+  printf '%s\n' "missing executable $mysqladmin" >&2
+  exit 42
+}
+
+need grep
+need mktemp
+need python3
+
+tmpdir=$(mktemp -d)
+datadir="$tmpdir/data"
+socket_path="$tmpdir/mysql.sock"
+pid_file="$tmpdir/mysqld.pid"
+port=$(available_port)
+server_pid=
+
+trap 'if [ -n "$server_pid" ]; then "$mysqladmin" --protocol=socket --socket="$socket_path" --user=root shutdown >/dev/null 2>&1 || true; wait "$server_pid" 2>/dev/null || true; fi; rm -rf "$tmpdir"' 0 1 2 3 15
+
+"$mysqld" \
+  --no-defaults \
+  --initialize-insecure \
+  --basedir="$artifact_root" \
+  --datadir="$datadir" \
+  --log-error="$tmpdir/init.err"
+
+"$mysqld" \
+  --no-defaults \
+  --basedir="$artifact_root" \
+  --datadir="$datadir" \
+  --socket="$socket_path" \
+  --port="$port" \
+  --bind-address=127.0.0.1 \
+  --pid-file="$pid_file" \
+  --mysqlx=OFF \
+  --log-error="$tmpdir/mysqld.err" &
+server_pid=$!
+
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+  if "$mysqladmin" --protocol=socket --socket="$socket_path" --user=root ping >/dev/null 2>&1; then
+    select_output=$("$mysql" --protocol=socket --socket="$socket_path" --user=root --batch --skip-column-names -e 'SELECT 1')
+    printf '%s\n' "$select_output" | grep -Fx 1 >/dev/null || {
+      printf '%s\n' "MySQL SELECT 1 smoke returned: $select_output" >&2
+      exit 43
+    }
+    "$mysqladmin" --protocol=socket --socket="$socket_path" --user=root shutdown
+    wait "$server_pid"
+    server_pid=
+    exit 0
+  fi
+  sleep 1
+done
+
+printf '%s\n' "MySQL smoke failed to become ready; log follows:" >&2
+if [ -f "$tmpdir/mysqld.err" ]; then
+  cat "$tmpdir/mysqld.err" >&2
+fi
+exit 44

--- a/release/artifacts/recipes/mysql/smoke.sh
+++ b/release/artifacts/recipes/mysql/smoke.sh
@@ -47,7 +47,7 @@ pid_file="$tmpdir/mysqld.pid"
 port=$(available_port)
 server_pid=
 
-trap 'if [ -n "$server_pid" ]; then "$mysqladmin" --protocol=socket --socket="$socket_path" --user=root shutdown >/dev/null 2>&1 || true; wait "$server_pid" 2>/dev/null || true; fi; rm -rf "$tmpdir"' 0 1 2 3 15
+trap 'if [ -n "$server_pid" ]; then "$mysqladmin" --protocol=tcp --host=127.0.0.1 --port="$port" --user=root shutdown >/dev/null 2>&1 || true; wait "$server_pid" 2>/dev/null || true; fi; rm -rf "$tmpdir"' 0 1 2 3 15
 
 "$mysqld" \
   --no-defaults \
@@ -69,13 +69,13 @@ trap 'if [ -n "$server_pid" ]; then "$mysqladmin" --protocol=socket --socket="$s
 server_pid=$!
 
 for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
-  if "$mysqladmin" --protocol=socket --socket="$socket_path" --user=root ping >/dev/null 2>&1; then
-    select_output=$("$mysql" --protocol=socket --socket="$socket_path" --user=root --batch --skip-column-names -e 'SELECT 1')
+  if "$mysqladmin" --protocol=tcp --host=127.0.0.1 --port="$port" --user=root ping >/dev/null 2>&1; then
+    select_output=$("$mysql" --protocol=tcp --host=127.0.0.1 --port="$port" --user=root --batch --skip-column-names -e 'SELECT 1')
     printf '%s\n' "$select_output" | grep -Fx 1 >/dev/null || {
       printf '%s\n' "MySQL SELECT 1 smoke returned: $select_output" >&2
       exit 43
     }
-    "$mysqladmin" --protocol=socket --socket="$socket_path" --user=root shutdown
+    "$mysqladmin" --protocol=tcp --host=127.0.0.1 --port="$port" --user=root shutdown
     wait "$server_pid"
     server_pid=
     exit 0

--- a/release/artifacts/recipes/postgres/LICENSE
+++ b/release/artifacts/recipes/postgres/LICENSE
@@ -1,0 +1,23 @@
+PostgreSQL Database Management System
+(also known as Postgres, formerly known as Postgres95)
+
+Portions Copyright (c) 1996-2026, PostgreSQL Global Development Group
+
+Portions Copyright (c) 1994, The Regents of the University of California
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement
+is hereby granted, provided that the above copyright notice and this
+paragraph and the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/release/artifacts/recipes/postgres/NOTICE
+++ b/release/artifacts/recipes/postgres/NOTICE
@@ -1,0 +1,23 @@
+PostgreSQL Database Management System
+(also known as Postgres, formerly known as Postgres95)
+
+Portions Copyright (c) 1996-2026, PostgreSQL Global Development Group
+
+Portions Copyright (c) 1994, The Regents of the University of California
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement
+is hereby granted, provided that the above copyright notice and this
+paragraph and the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/release/artifacts/recipes/postgres/build.sh
+++ b/release/artifacts/recipes/postgres/build.sh
@@ -1,0 +1,162 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/../../../.." && pwd)
+# shellcheck source=/dev/null
+. "$ROOT/release/artifacts/recipes/common.sh"
+
+TRACK=${PV_RECIPE_TRACK:-18}
+PLATFORM=${PV_RECIPE_PLATFORM:-darwin-arm64}
+OUT_DIR=${PV_ARTIFACT_OUT_DIR:-"$ROOT/release/artifacts/out"}
+RECORD_DIR=${PV_ARTIFACT_RECORD_DIR:-"$ROOT/release/artifacts/records"}
+PV_COMMIT=${PV_COMMIT:-}
+BUILD_RUN_ID=${PV_BUILD_RUN_ID:-local-postgres}
+BUILD_JOBS=${PV_BUILD_JOBS:-}
+DEPLOYMENT_TARGET=${PV_MACOSX_DEPLOYMENT_TARGET:-13.0}
+recipe_dir="$ROOT/release/artifacts/recipes/postgres"
+
+need cargo
+need curl
+need dirname
+need find
+need git
+need make
+need readlink
+need shasum
+need tar
+
+case "$PLATFORM" in
+  darwin-arm64 | darwin-amd64) ;;
+  *) die "unsupported Postgres artifact platform: $PLATFORM" ;;
+esac
+
+if [ -z "$PV_COMMIT" ]; then
+  PV_COMMIT=$(git -C "$ROOT" rev-parse HEAD)
+fi
+
+if [ -z "$BUILD_JOBS" ]; then
+  BUILD_JOBS=$(sysctl -n hw.ncpu 2>/dev/null || printf '%s\n' 2)
+fi
+
+download_source() {
+  source_archive=$1
+
+  mkdir -p "$(dirname "$source_archive")"
+  curl -L --fail --show-error --silent \
+    --retry 3 --retry-delay 2 --retry-all-errors \
+    --connect-timeout 20 --max-time 600 \
+    "$PV_SOURCE_URL" -o "$source_archive"
+  require_sha256 "$source_archive" "$PV_SOURCE_SHA256"
+}
+
+extract_source() {
+  source_archive=$1
+  source_extract_dir=$2
+
+  rm -rf "$source_extract_dir"
+  mkdir -p "$source_extract_dir"
+  tar -xzf "$source_archive" -C "$source_extract_dir"
+
+  source_entry_count=0
+  source_dir=
+  for source_entry in "$source_extract_dir"/* "$source_extract_dir"/.[!.]* "$source_extract_dir"/..?*; do
+    [ -d "$source_entry" ] || [ -f "$source_entry" ] || [ -L "$source_entry" ] || continue
+    source_entry_count=$((source_entry_count + 1))
+    source_dir=$source_entry
+  done
+  [ "$source_entry_count" -eq 1 ] || die "Postgres source archive must contain exactly one top-level source directory"
+  [ -d "$source_dir" ] || die "Postgres source archive top-level entry is not a directory"
+  printf '%s\n' "$source_dir"
+}
+
+copy_install_tree() {
+  install_dir=$1
+  root_dir=$2
+
+  mkdir -p "$root_dir"
+  tar -cf - -C "$install_dir" . | tar -xf - -C "$root_dir"
+  find "$root_dir" -type l -exec sh -c '
+    for path do
+      target=$(readlink "$path") || exit 1
+      case "$target" in
+        /*) source=$target ;;
+        *) source=$(dirname "$path")/$target ;;
+      esac
+      tmp=$path.pv-copy.$$
+      rm "$path" || exit 1
+      cp -p "$source" "$tmp" || exit 1
+      mv "$tmp" "$path" || exit 1
+    done
+  ' sh {} +
+  find "$root_dir" -type f -links +1 -exec sh -c '
+    for path do
+      tmp=$path.pv-copy.$$
+      cp -p "$path" "$tmp" || exit 1
+      mv "$tmp" "$path" || exit 1
+    done
+  ' sh {} +
+  rewrite_macho_install_names "$root_dir" "$install_dir"
+  pv_recipe_ad_hoc_sign_macho_tree "$root_dir"
+  for binary in postgres initdb pg_ctl psql; do
+    [ -x "$root_dir/bin/$binary" ] || die "Postgres artifact missing bin/$binary"
+    pv_recipe_validate_macho_binary "$root_dir/bin/$binary" "$PLATFORM" "$DEPLOYMENT_TARGET"
+  done
+  if [ -d "$root_dir/lib" ]; then
+    find "$root_dir/lib" -type f \( -name '*.dylib' -o -name '*.so' \) | while IFS= read -r library; do
+      pv_recipe_validate_macho_binary "$library" "$PLATFORM" "$DEPLOYMENT_TARGET"
+    done
+  fi
+  cp "$recipe_dir/LICENSE" "$root_dir/LICENSE"
+  cp "$recipe_dir/NOTICE" "$root_dir/NOTICE"
+}
+
+env_file="$OUT_DIR/work/postgres-$TRACK-$PLATFORM.env"
+mkdir -p "$(dirname "$env_file")"
+cargo run -p pv-release -- print-recipe-env \
+  --postgres "$recipe_dir/recipe.toml" \
+  --resource postgres \
+  --track "$TRACK" \
+  --platform "$PLATFORM" >"$env_file"
+# shellcheck source=/dev/null
+. "$env_file"
+export PV_UPSTREAM_VERSION
+
+artifact_basename=$(artifact_basename postgres "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+work_dir="$OUT_DIR/work/$artifact_basename"
+source_archive="$OUT_DIR/sources/postgresql-$PV_UPSTREAM_VERSION.tar.gz"
+source_extract_dir="$OUT_DIR/sources/postgresql-$PV_UPSTREAM_VERSION-source"
+build_dir="$work_dir/build"
+install_dir="$work_dir/install"
+root_dir="$work_dir/$artifact_basename"
+archive="$OUT_DIR/$artifact_basename.tar.gz"
+record=$(artifact_record_path "$RECORD_DIR" postgres "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+object_key=$(artifact_object_key postgres "$PV_TRACK" "$PV_ARTIFACT_VERSION" "$PV_PLATFORM")
+
+rm -rf "$work_dir"
+mkdir -p "$work_dir" "$build_dir" "$install_dir" "$OUT_DIR"
+download_source "$source_archive"
+source_dir=$(extract_source "$source_archive" "$source_extract_dir")
+
+export CFLAGS="${CFLAGS:-} -mmacosx-version-min=$DEPLOYMENT_TARGET"
+export LDFLAGS="${LDFLAGS:-} -mmacosx-version-min=$DEPLOYMENT_TARGET"
+(
+  cd "$source_dir"
+  ./configure \
+    --prefix="$install_dir" \
+    --without-icu \
+    --without-llvm \
+    --without-lz4 \
+    --without-readline \
+    --without-zlib \
+    --without-zstd
+  make -j "$BUILD_JOBS"
+  make install
+)
+
+copy_install_tree "$install_dir" "$root_dir"
+COPYFILE_DISABLE=1 tar -czf "$archive" -C "$work_dir" "$artifact_basename"
+write_record "$record" postgres "$PV_TRACK" "$PV_UPSTREAM_VERSION" "$PV_PV_BUILD_REVISION" "$PV_PLATFORM" "$object_key" "$archive" "$PV_SOURCE_URL" "$PV_SOURCE_SHA256" release/artifacts/recipes/postgres/build.sh "$PV_COMMIT" "$BUILD_RUN_ID" "$PV_MINIMUM_PV_VERSION"
+
+PV_UPSTREAM_VERSION="$PV_UPSTREAM_VERSION" \
+  cargo run -p pv-release -- validate-archive --archive "$archive" --record "$record" --smoke-hook "$recipe_dir/smoke.sh"
+printf '%s\n' "$archive"

--- a/release/artifacts/recipes/postgres/build.sh
+++ b/release/artifacts/recipes/postgres/build.sh
@@ -12,7 +12,7 @@ RECORD_DIR=${PV_ARTIFACT_RECORD_DIR:-"$ROOT/release/artifacts/records"}
 PV_COMMIT=${PV_COMMIT:-}
 BUILD_RUN_ID=${PV_BUILD_RUN_ID:-local-postgres}
 BUILD_JOBS=${PV_BUILD_JOBS:-}
-DEPLOYMENT_TARGET=${PV_MACOSX_DEPLOYMENT_TARGET:-13.0}
+DEPLOYMENT_TARGET=13.0
 recipe_dir="$ROOT/release/artifacts/recipes/postgres"
 
 need cargo

--- a/release/artifacts/recipes/postgres/recipe.toml
+++ b/release/artifacts/recipes/postgres/recipe.toml
@@ -1,0 +1,17 @@
+[recipe]
+resources = ["postgres"]
+default_track = "18"
+platforms = ["darwin-arm64", "darwin-amd64"]
+minimum_pv_version = "0.1.0"
+pv_build_revision = "pv1"
+license_files = ["LICENSE"]
+notice_files = ["NOTICE"]
+
+[artifact]
+payload_paths = ["bin/postgres", "bin/initdb", "bin/pg_ctl", "bin/psql"]
+
+[[tracks]]
+name = "18"
+upstream_version = "18.3"
+source_url = "https://ftp.postgresql.org/pub/source/v18.3/postgresql-18.3.tar.gz"
+source_sha256 = "9e054ffd6e013da2c2c9a1bfd6e062c98875d340df080516551c96b9b0926a59"

--- a/release/artifacts/recipes/postgres/smoke.sh
+++ b/release/artifacts/recipes/postgres/smoke.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -eu
+
+artifact_root=$1
+postgres="$artifact_root/bin/postgres"
+initdb="$artifact_root/bin/initdb"
+pg_ctl="$artifact_root/bin/pg_ctl"
+psql="$artifact_root/bin/psql"
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf '%s\n' "missing required command: $1" >&2
+    exit 42
+  }
+}
+
+available_port() {
+  python3 - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+}
+
+[ -x "$postgres" ] || {
+  printf '%s\n' "missing executable $postgres" >&2
+  exit 42
+}
+[ -x "$initdb" ] || {
+  printf '%s\n' "missing executable $initdb" >&2
+  exit 42
+}
+[ -x "$pg_ctl" ] || {
+  printf '%s\n' "missing executable $pg_ctl" >&2
+  exit 42
+}
+[ -x "$psql" ] || {
+  printf '%s\n' "missing executable $psql" >&2
+  exit 42
+}
+
+need id
+need mktemp
+need python3
+
+tmpdir=$(mktemp -d)
+datadir="$tmpdir/data"
+socket_dir="$tmpdir/socket"
+log_file="$tmpdir/postgres.log"
+port=$(available_port)
+user=$(id -un)
+started=false
+
+trap 'if [ "$started" = true ]; then "$pg_ctl" -D "$datadir" -m fast stop >/dev/null 2>&1 || true; fi; rm -rf "$tmpdir"' 0 1 2 3 15
+
+mkdir -p "$socket_dir"
+"$initdb" -D "$datadir" --username="$user" --no-locale --encoding=UTF8 >/dev/null
+"$pg_ctl" -D "$datadir" -l "$log_file" -o "-h 127.0.0.1 -p $port -k $socket_dir" start >/dev/null
+started=true
+
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+  if "$psql" -h 127.0.0.1 -p "$port" -U "$user" -d postgres -At -c 'SELECT 1' >"$tmpdir/select.out" 2>"$tmpdir/select.err"; then
+    select_output=$(cat "$tmpdir/select.out")
+    [ "$select_output" = "1" ] || {
+      printf '%s\n' "Postgres SELECT 1 smoke returned: $select_output" >&2
+      exit 43
+    }
+    "$pg_ctl" -D "$datadir" -m fast stop >/dev/null
+    started=false
+    exit 0
+  fi
+  sleep 1
+done
+
+printf '%s\n' "Postgres smoke failed to become ready; log follows:" >&2
+if [ -f "$log_file" ]; then
+  cat "$log_file" >&2
+fi
+if [ -f "$tmpdir/select.err" ]; then
+  cat "$tmpdir/select.err" >&2
+fi
+exit 44


### PR DESCRIPTION
## Summary
- Adds MySQL default track `8.4` artifact recipes.
- Adds Postgres default track `18` artifact recipes.
- Adds SQL resource metadata, legal files, build/smoke scripts, fixture coverage, and default-track integration.

## Stack
4/5. Base: `feat/pr25-mailpit-rustfs-recipes-stack`. Next: `feat/pr25-publish-matrix`.

## Test Plan
- `cargo nextest run -p pv-release --locked` (90/90 passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo fmt --all --check`
- `actionlint .github/workflows/artifact-publication.yml .github/workflows/artifact-recipes.yml .github/workflows/ci.yml`
- `shellcheck release/artifacts/recipes/common.sh release/artifacts/recipes/php/*.sh release/artifacts/recipes/composer/*.sh release/artifacts/recipes/redis/*.sh release/artifacts/recipes/mysql/*.sh release/artifacts/recipes/postgres/*.sh release/artifacts/recipes/mailpit/*.sh release/artifacts/recipes/rustfs/*.sh`
- `git diff --check`
- no pending `.snap.new`; no conflict markers

## Remaining Release Evidence
Draft until native Artifact Recipes and R2 publication verification are recorded under Solo todo 72. MySQL native runtime evidence still needs a macOS runner with `cmake` available.