### PR TITLE
PR Runtime: shared Managed Resource runtime foundation

### DIFF
--- a/crates/cli/src/commands/artifact_resource.rs
+++ b/crates/cli/src/commands/artifact_resource.rs
@@ -3,16 +3,18 @@
     reason = "adapter command modules reuse this private helper in follow-up PRs"
 )]
 
+use std::collections::BTreeMap;
 use std::io;
 use std::io::Write;
 use std::process::ExitCode;
 
 use camino::Utf8PathBuf;
 use resources::{
-    ManagedResourceCommands, ManagedResourceUninstallOptions, ResourceHttpClient, ResourceName,
-    TargetPlatform, TrackName, TrackSelector, UreqResourceHttpClient,
+    ManagedResourceCommands, ManagedResourceTrack, ManagedResourceUninstallOptions,
+    ResourceHttpClient, ResourceKind, ResourceName, TargetPlatform, TrackName, TrackSelector,
+    UreqResourceHttpClient,
 };
-use state::{PvPaths, StateError};
+use state::{PortAssignment, PortOwner, PvPaths, RuntimeObservedStatus, StateError};
 
 use crate::environment::Environment;
 use crate::error::ExecuteError;
@@ -91,6 +93,9 @@ pub(crate) fn uninstall(
     let paths = pv_paths(environment)?;
     let resource_name = ResourceName::new(spec.resource_name)?;
     let track = TrackName::new(track)?;
+    if prune && !force && !confirm_prune(&spec, track.as_str(), environment, stdout)? {
+        return Ok(ExitCode::SUCCESS);
+    }
     let options = ManagedResourceUninstallOptions::new()
         .prune(prune)
         .force(force);
@@ -118,9 +123,15 @@ pub(crate) fn list(
     let commands = resource_commands(&paths, environment);
     let tracks = commands.list(Some(&resource_name))?;
     let mut output = Output::new(stdout, OutputMode::plain());
+    let descriptor = resources::registry::resolve_canonical(spec.resource_name)?;
 
     if tracks.is_empty() {
         output.line(&format!("No {} tracks installed", spec.display_name))?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    if descriptor.kind() == ResourceKind::BackingService {
+        write_backing_resource_list(&paths, spec.resource_name, &tracks, &mut output)?;
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -136,6 +147,126 @@ pub(crate) fn list(
     }
 
     Ok(ExitCode::SUCCESS)
+}
+
+fn confirm_prune(
+    spec: &ArtifactResourceCommandSpec,
+    track: &str,
+    environment: &impl Environment,
+    stdout: &mut impl Write,
+) -> Result<bool, ExecuteError> {
+    let mut output = Output::new(stdout, OutputMode::plain());
+
+    if !environment.stdin_is_terminal() {
+        output.line(&format!(
+            "Refusing to prune {} track {track} without an interactive confirmation.",
+            spec.display_name
+        ))?;
+        output.line(&format!(
+            "Rerun with `pv {}:uninstall {track} --prune --force` to prune non-interactively.",
+            spec.resource_name
+        ))?;
+
+        return Ok(false);
+    }
+
+    output.line(&format!(
+        "Prune PV-owned data for {} track {track}?",
+        spec.display_name
+    ))?;
+    output.line("Type `yes` to continue.")?;
+
+    if environment.read_line()?.trim() == "yes" {
+        return Ok(true);
+    }
+
+    output.line("Prune cancelled.")?;
+
+    Ok(false)
+}
+
+fn write_backing_resource_list(
+    paths: &PvPaths,
+    resource_name: &str,
+    tracks: &[ManagedResourceTrack],
+    output: &mut Output<'_, impl Write>,
+) -> Result<(), ExecuteError> {
+    let database = state::Database::open(paths)?;
+    let runtime_statuses = database
+        .runtime_observed_states()?
+        .into_iter()
+        .filter_map(|state| match state.subject {
+            state::RuntimeSubject::Resource { name, track } if name == resource_name => {
+                Some((track, state.status))
+            }
+            _ => None,
+        })
+        .collect::<BTreeMap<_, _>>();
+    let assignments = database.assigned_ports()?;
+
+    output.line("Track  Status  Ports  Projects  Version  Path")?;
+    for track in tracks {
+        let track_name = track.track().as_str();
+        let status = runtime_statuses.get(track_name).copied();
+        let ports = if status == Some(RuntimeObservedStatus::Running) {
+            backing_resource_ports(&assignments, resource_name, track_name)
+        } else {
+            "-".to_string()
+        };
+
+        output.line(&format!(
+            "{}  {}  {}  {}  {}  {}",
+            track.track(),
+            runtime_status_label(status),
+            ports,
+            track.usage_count(),
+            track.installed_version(),
+            track.current_artifact_path()
+        ))?;
+    }
+
+    Ok(())
+}
+
+fn backing_resource_ports(
+    assignments: &[PortAssignment],
+    resource_name: &str,
+    track: &str,
+) -> String {
+    let ports = assignments
+        .iter()
+        .filter_map(|assignment| match &assignment.owner {
+            PortOwner::Resource {
+                name,
+                track: owner_track,
+                port,
+            } if name == resource_name && owner_track == track => {
+                Some((port.clone(), assignment.port))
+            }
+            _ => None,
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    if ports.is_empty() {
+        return "-".to_string();
+    }
+
+    ports
+        .into_iter()
+        .map(|(name, port)| format!("{name}={port}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn runtime_status_label(status: Option<RuntimeObservedStatus>) -> &'static str {
+    match status {
+        Some(RuntimeObservedStatus::Pending) => "pending",
+        Some(RuntimeObservedStatus::Running) => "running",
+        Some(RuntimeObservedStatus::Degraded) => "degraded",
+        Some(RuntimeObservedStatus::Failed) => "failed",
+        Some(RuntimeObservedStatus::Stopped) => "stopped",
+        None => "not-running",
+    }
 }
 
 fn pv_paths(environment: &impl Environment) -> Result<PvPaths, ExecuteError> {
@@ -211,4 +342,261 @@ fn daemon_is_unavailable(error: &io::Error) -> bool {
         error.kind(),
         io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+    use std::ffi::OsString;
+    use std::io;
+    use std::path::PathBuf;
+
+    use camino::Utf8Path;
+    use camino_tempfile::tempdir;
+    use insta::{Settings, assert_debug_snapshot};
+    use state::{
+        Database, LinkProjectInput, ManagedResourceDesiredState, ManagedResourceTrackRecord,
+        PortRequest, ProjectManagedResourceInput, PvPaths, RuntimeObservedStatus, RuntimeSubject,
+    };
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct TestEnvironment {
+        home: PathBuf,
+        stdin_is_terminal: bool,
+        lines: RefCell<VecDeque<String>>,
+    }
+
+    impl TestEnvironment {
+        fn new(home: &Utf8Path) -> Self {
+            Self {
+                home: home.as_std_path().to_path_buf(),
+                stdin_is_terminal: false,
+                lines: RefCell::new(VecDeque::new()),
+            }
+        }
+    }
+
+    impl Environment for TestEnvironment {
+        fn var_os(&self, _key: &str) -> Option<OsString> {
+            None
+        }
+
+        fn home_dir(&self) -> Option<PathBuf> {
+            Some(self.home.clone())
+        }
+
+        fn current_dir(&self) -> io::Result<PathBuf> {
+            Ok(self.home.clone())
+        }
+
+        fn current_exe(&self) -> io::Result<PathBuf> {
+            Ok(PathBuf::from("/bin/pv"))
+        }
+
+        fn stdin_is_terminal(&self) -> bool {
+            self.stdin_is_terminal
+        }
+
+        fn read_line(&self) -> io::Result<String> {
+            Ok(self.lines.borrow_mut().pop_front().unwrap_or_default())
+        }
+
+        fn open_url(&self, _url: &str) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn uninstall_prune_refuses_noninteractive_without_force() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let environment = TestEnvironment::new(paths.home());
+        let mut database = Database::open(&paths)?;
+        let release = paths
+            .resources()
+            .join("redis")
+            .join("7.2")
+            .join("releases")
+            .join("7.2.5-pv1");
+
+        database.record_managed_resource_track_installed("redis", "7.2", "7.2.5-pv1", &release)?;
+        let mut stdout = Vec::new();
+
+        let exit_code = uninstall(redis_spec(), "7.2", true, false, &environment, &mut stdout)?;
+        let record = database.managed_resource_track("redis", "7.2")?;
+
+        assert_eq!(exit_code, ExitCode::SUCCESS);
+        assert_eq!(record.desired_state, ManagedResourceDesiredState::Installed);
+        assert!(!record.removal_prune);
+        assert!(!record.removal_force);
+        with_tempdir_filters(tempdir.path(), || {
+            assert_debug_snapshot!((
+                RunOutput::from_stdout(exit_code, stdout)?,
+                resource_record_snapshot(&record, tempdir.path())?,
+            ));
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn backing_resource_list_reports_running_state_ports_and_usage() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let project_path = tempdir.path().join("project");
+        let environment = TestEnvironment::new(paths.home());
+        let mut database = Database::open(&paths)?;
+        let release = paths
+            .resources()
+            .join("mailpit")
+            .join("1")
+            .join("releases")
+            .join("1.20.0-pv1");
+
+        database.record_managed_resource_track_installed("mailpit", "1", "1.20.0-pv1", &release)?;
+        let project = database
+            .link_project(LinkProjectInput {
+                path: project_path.clone(),
+                original_path: project_path.clone(),
+                primary_hostname: "acme.test".to_string(),
+                config_path: project_path.join("pv.yml"),
+                desired_php_track: None,
+                additional_hostnames: Vec::new(),
+            })?
+            .project;
+        database.replace_project_managed_resources(
+            &project.id,
+            &[ProjectManagedResourceInput {
+                resource_name: "mailpit".to_string(),
+                track: "1".to_string(),
+            }],
+        )?;
+        database.assign_port(
+            PortRequest::resource_port("mailpit", "1", "smtp", 1025, 45000, 48999),
+            |_| true,
+        )?;
+        database.assign_port(
+            PortRequest::resource_port("mailpit", "1", "dashboard", 8025, 45000, 48999),
+            |_| true,
+        )?;
+        database.record_runtime_observed_snapshot(
+            RuntimeSubject::Resource {
+                name: "mailpit".to_string(),
+                track: "1".to_string(),
+            },
+            RuntimeObservedStatus::Running,
+            Some("Managed Resource runtime is ready"),
+        )?;
+        let mut stdout = Vec::new();
+
+        let exit_code = list(mailpit_spec(), &environment, &mut stdout)?;
+
+        assert_eq!(exit_code, ExitCode::SUCCESS);
+        with_tempdir_filters(tempdir.path(), || {
+            assert_debug_snapshot!(RunOutput::from_stdout(exit_code, stdout)?);
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+
+    #[derive(Debug)]
+    #[expect(
+        dead_code,
+        reason = "snapshot-only structure is read through derived Debug"
+    )]
+    struct RunOutput {
+        exit_code: ExitCode,
+        stdout: String,
+    }
+
+    impl RunOutput {
+        fn from_stdout(exit_code: ExitCode, stdout: Vec<u8>) -> anyhow::Result<Self> {
+            Ok(Self {
+                exit_code,
+                stdout: String::from_utf8(stdout)?,
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    #[expect(
+        dead_code,
+        reason = "snapshot-only structure is read through derived Debug"
+    )]
+    struct ResourceRecordSnapshot {
+        resource_name: String,
+        track: String,
+        desired_state: String,
+        installed_version: Option<String>,
+        current_artifact_path: Option<String>,
+        usage_count: i64,
+        removal_prune: bool,
+        removal_force: bool,
+    }
+
+    fn resource_record_snapshot(
+        record: &ManagedResourceTrackRecord,
+        root: &Utf8Path,
+    ) -> anyhow::Result<ResourceRecordSnapshot> {
+        Ok(ResourceRecordSnapshot {
+            resource_name: record.resource_name.clone(),
+            track: record.track.clone(),
+            desired_state: format!("{:?}", record.desired_state),
+            installed_version: record.installed_version.clone(),
+            current_artifact_path: record
+                .current_artifact_path
+                .as_ref()
+                .map(|path| path.strip_prefix(root).map(Utf8Path::to_string))
+                .transpose()?,
+            usage_count: record.usage_count,
+            removal_prune: record.removal_prune,
+            removal_force: record.removal_force,
+        })
+    }
+
+    fn redis_spec() -> ArtifactResourceCommandSpec {
+        ArtifactResourceCommandSpec {
+            resource_name: "redis",
+            display_name: "Redis",
+            adapter: resources::composer_adapter,
+        }
+    }
+
+    fn mailpit_spec() -> ArtifactResourceCommandSpec {
+        ArtifactResourceCommandSpec {
+            resource_name: "mailpit",
+            display_name: "Mailpit",
+            adapter: resources::composer_adapter,
+        }
+    }
+
+    fn with_tempdir_filters(
+        tempdir: &Utf8Path,
+        f: impl FnOnce() -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        let mut settings = Settings::clone_current();
+        settings.add_filter(&regex_literal(tempdir.as_str()), "<tempdir>");
+        settings.bind(f)
+    }
+
+    fn regex_literal(input: &str) -> String {
+        let mut escaped = String::with_capacity(input.len());
+
+        for character in input.chars() {
+            if matches!(
+                character,
+                '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
+            ) {
+                escaped.push('\\');
+            }
+            escaped.push(character);
+        }
+
+        escaped
+    }
 }

--- a/crates/cli/src/commands/artifact_resource.rs
+++ b/crates/cli/src/commands/artifact_resource.rs
@@ -1,0 +1,214 @@
+#![expect(
+    dead_code,
+    reason = "adapter command modules reuse this private helper in follow-up PRs"
+)]
+
+use std::io;
+use std::io::Write;
+use std::process::ExitCode;
+
+use camino::Utf8PathBuf;
+use resources::{
+    ManagedResourceCommands, ManagedResourceUninstallOptions, ResourceHttpClient, ResourceName,
+    TargetPlatform, TrackName, TrackSelector, UreqResourceHttpClient,
+};
+use state::{PvPaths, StateError};
+
+use crate::environment::Environment;
+use crate::error::ExecuteError;
+use crate::output::{Output, OutputMode};
+
+const DEFAULT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json";
+const RECONCILE_KIND: &str = "reconcile";
+const SYSTEM_SCOPE: &str = "system";
+
+pub(crate) struct ArtifactResourceCommandSpec {
+    pub resource_name: &'static str,
+    pub display_name: &'static str,
+    pub adapter: fn() -> resources::Result<resources::RuntimeArtifactAdapter>,
+}
+
+pub(crate) fn install(
+    spec: ArtifactResourceCommandSpec,
+    track: Option<&str>,
+    environment: &impl Environment,
+    stdout: &mut impl Write,
+) -> Result<ExitCode, ExecuteError> {
+    let paths = pv_paths(environment)?;
+    let selector = match track {
+        Some(track) => TrackSelector::parse(track)?,
+        None => TrackSelector::Latest,
+    };
+    let adapter = (spec.adapter)()?;
+    let commands = resource_commands(&paths, environment);
+    let installed = with_resource_http_client(environment, |client| {
+        commands.install(&adapter, selector, client)
+    })?;
+    let mut output = Output::new(stdout, OutputMode::plain());
+
+    super::write_revoked_latest_warning(&installed, &mut output)?;
+    output.line(&format!(
+        "Installed {} track {}",
+        spec.display_name,
+        installed.track()
+    ))?;
+    request_system_reconciliation(&paths, &mut output)?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn update(
+    spec: ArtifactResourceCommandSpec,
+    environment: &impl Environment,
+    stdout: &mut impl Write,
+) -> Result<ExitCode, ExecuteError> {
+    let paths = pv_paths(environment)?;
+    let adapter = (spec.adapter)()?;
+    let commands = resource_commands(&paths, environment);
+    let updated =
+        with_resource_http_client(environment, |client| commands.update(&adapter, client))?;
+    let mut output = Output::new(stdout, OutputMode::plain());
+
+    super::write_revoked_latest_warnings(updated.installs(), &mut output)?;
+    output.line(&format!(
+        "Updated {} {} track(s)",
+        updated.installs().len(),
+        spec.display_name
+    ))?;
+    request_system_reconciliation(&paths, &mut output)?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn uninstall(
+    spec: ArtifactResourceCommandSpec,
+    track: &str,
+    prune: bool,
+    force: bool,
+    environment: &impl Environment,
+    stdout: &mut impl Write,
+) -> Result<ExitCode, ExecuteError> {
+    let paths = pv_paths(environment)?;
+    let resource_name = ResourceName::new(spec.resource_name)?;
+    let track = TrackName::new(track)?;
+    let options = ManagedResourceUninstallOptions::new()
+        .prune(prune)
+        .force(force);
+    let commands = resource_commands(&paths, environment);
+    let removal = commands.uninstall(&resource_name, &track, options)?;
+    let mut output = Output::new(stdout, OutputMode::plain());
+
+    output.line(&format!(
+        "Queued removal for {} track {}",
+        spec.display_name,
+        removal.track()
+    ))?;
+    request_system_reconciliation(&paths, &mut output)?;
+
+    Ok(ExitCode::SUCCESS)
+}
+
+pub(crate) fn list(
+    spec: ArtifactResourceCommandSpec,
+    environment: &impl Environment,
+    stdout: &mut impl Write,
+) -> Result<ExitCode, ExecuteError> {
+    let paths = pv_paths(environment)?;
+    let resource_name = ResourceName::new(spec.resource_name)?;
+    let commands = resource_commands(&paths, environment);
+    let tracks = commands.list(Some(&resource_name))?;
+    let mut output = Output::new(stdout, OutputMode::plain());
+
+    if tracks.is_empty() {
+        output.line(&format!("No {} tracks installed", spec.display_name))?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    output.line("Track  Projects  Version  Path")?;
+    for track in tracks {
+        output.line(&format!(
+            "{}  {}  {}  {}",
+            track.track(),
+            track.usage_count(),
+            track.installed_version(),
+            track.current_artifact_path()
+        ))?;
+    }
+
+    Ok(ExitCode::SUCCESS)
+}
+
+fn pv_paths(environment: &impl Environment) -> Result<PvPaths, ExecuteError> {
+    let home = environment.home_dir().ok_or(StateError::MissingHome)?;
+    let home = Utf8PathBuf::from_path_buf(home).map_err(|path| StateError::NonUtf8Home { path })?;
+
+    Ok(PvPaths::for_home(home))
+}
+
+fn resource_commands(paths: &PvPaths, environment: &impl Environment) -> ManagedResourceCommands {
+    ManagedResourceCommands::new(
+        paths.clone(),
+        environment
+            .artifact_manifest_url()
+            .unwrap_or_else(|| DEFAULT_MANIFEST_URL.to_string()),
+        target_platform(environment),
+    )
+}
+
+fn target_platform(environment: &impl Environment) -> TargetPlatform {
+    environment
+        .target_platform()
+        .unwrap_or_else(current_target_platform)
+}
+
+fn current_target_platform() -> TargetPlatform {
+    if cfg!(target_arch = "aarch64") {
+        TargetPlatform::DarwinArm64
+    } else {
+        TargetPlatform::DarwinAmd64
+    }
+}
+
+fn with_resource_http_client<T>(
+    environment: &impl Environment,
+    operation: impl FnOnce(&dyn ResourceHttpClient) -> Result<T, resources::ManagedResourceCommandError>,
+) -> Result<T, ExecuteError> {
+    if let Some(client) = environment.resource_http_client() {
+        return Ok(operation(client)?);
+    }
+
+    let client = UreqResourceHttpClient::default();
+    Ok(operation(&client)?)
+}
+
+fn request_system_reconciliation(
+    paths: &PvPaths,
+    output: &mut Output<'_, impl Write>,
+) -> Result<(), ExecuteError> {
+    match daemon::submit_job_blocking(paths.clone(), RECONCILE_KIND, SYSTEM_SCOPE) {
+        Ok(job) => output.line(&format!("System reconciliation requested: {}", job.id))?,
+        Err(daemon::DaemonError::Io(error)) if daemon_is_unavailable(&error) => {
+            write_daemon_unavailable_warning(output)?
+        }
+        Err(error) => return Err(error.into()),
+    }
+
+    Ok(())
+}
+
+fn write_daemon_unavailable_warning(
+    output: &mut Output<'_, impl Write>,
+) -> Result<(), ExecuteError> {
+    output.line(
+        "warning: PV daemon is not running; reconciliation will run after `pv setup` starts it",
+    )?;
+
+    Ok(())
+}
+
+fn daemon_is_unavailable(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::NotFound | io::ErrorKind::ConnectionRefused
+    )
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ use crate::environment::Environment;
 use crate::error::ExecuteError;
 use crate::output::Output;
 
+mod artifact_resource;
 mod ca;
 mod completions;
 mod composer;

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -104,7 +104,7 @@ pub(crate) fn unlink(
         "Unlinked {} -> {}",
         project.primary_hostname, project.path
     ))?;
-    request_project_reconciliation(&paths, &project, &mut output)?;
+    request_system_reconciliation(&paths, &mut output)?;
 
     Ok(ExitCode::SUCCESS)
 }
@@ -225,6 +225,21 @@ fn request_project_reconciliation(
             "Queued reconciliation {} for {}",
             job.id, project.primary_hostname
         ))?,
+        Err(daemon::DaemonError::Io(error)) if daemon_is_unavailable(&error) => output.line(
+            "warning: PV daemon is not running; reconciliation will run after `pv setup` starts it",
+        )?,
+        Err(error) => return Err(error.into()),
+    }
+
+    Ok(())
+}
+
+fn request_system_reconciliation(
+    paths: &PvPaths,
+    output: &mut Output<'_, impl Write>,
+) -> Result<(), ExecuteError> {
+    match daemon::submit_job_blocking(paths.clone(), "reconcile", "system") {
+        Ok(job) => output.line(&format!("System reconciliation requested: {}", job.id))?,
         Err(daemon::DaemonError::Io(error)) if daemon_is_unavailable(&error) => output.line(
             "warning: PV daemon is not running; reconciliation will run after `pv setup` starts it",
         )?,

--- a/crates/cli/src/commands/snapshots/cli__commands__artifact_resource__tests__backing_resource_list_reports_running_state_ports_and_usage.snap
+++ b/crates/cli/src/commands/snapshots/cli__commands__artifact_resource__tests__backing_resource_list_reports_running_state_ports_and_usage.snap
@@ -1,0 +1,12 @@
+---
+source: crates/cli/src/commands/artifact_resource.rs
+expression: "RunOutput::from_stdout(exit_code, stdout)?"
+---
+RunOutput {
+    exit_code: ExitCode(
+        unix_exit_status(
+            0,
+        ),
+    ),
+    stdout: "Track  Status  Ports  Projects  Version  Path\n1  running  dashboard=8025,smtp=1025  1  1.20.0-pv1  <tempdir>/home/.pv/resources/mailpit/1/releases/1.20.0-pv1\n",
+}

--- a/crates/cli/src/commands/snapshots/cli__commands__artifact_resource__tests__uninstall_prune_refuses_noninteractive_without_force.snap
+++ b/crates/cli/src/commands/snapshots/cli__commands__artifact_resource__tests__uninstall_prune_refuses_noninteractive_without_force.snap
@@ -1,0 +1,28 @@
+---
+source: crates/cli/src/commands/artifact_resource.rs
+expression: "(RunOutput::from_stdout(exit_code, stdout)?,\nresource_record_snapshot(&record, tempdir.path())?,)"
+---
+(
+    RunOutput {
+        exit_code: ExitCode(
+            unix_exit_status(
+                0,
+            ),
+        ),
+        stdout: "Refusing to prune Redis track 7.2 without an interactive confirmation.\nRerun with `pv redis:uninstall 7.2 --prune --force` to prune non-interactively.\n",
+    },
+    ResourceRecordSnapshot {
+        resource_name: "redis",
+        track: "7.2",
+        desired_state: "Installed",
+        installed_version: Some(
+            "7.2.5-pv1",
+        ),
+        current_artifact_path: Some(
+            "home/.pv/resources/redis/7.2/releases/7.2.5-pv1",
+        ),
+        usage_count: 0,
+        removal_prune: false,
+        removal_force: false,
+    },
+)

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -83,12 +83,29 @@ pub enum DaemonError {
     UnsupportedManagedResourceRuntime { resource: String },
 
     #[error(
+        "Managed Resource runtime `{name}` is listening but no PV-owned process could be verified"
+    )]
+    NonPvManagedResourceRuntimeListener { name: String },
+
+    #[error(
         "Managed Resource runtime `{resource}` track `{track}` is missing installed artifact path"
     )]
     ManagedResourceArtifactMissing { resource: String, track: String },
 
+    #[error("Managed Resource runtime `{resource}` track `{track}` is marked removed")]
+    ManagedResourceTrackRemoved { resource: String, track: String },
+
     #[error("Managed Resource runtime `{resource}` track `{track}` is missing port `{port}`")]
     ManagedResourcePortMissing {
+        resource: String,
+        track: String,
+        port: String,
+    },
+
+    #[error(
+        "Managed Resource runtime `{resource}` track `{track}` uses reserved port name `{port}`"
+    )]
+    ManagedResourcePortNameReserved {
         resource: String,
         track: String,
         port: String,

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -4,7 +4,7 @@ use config::ConfigError;
 use hickory_proto::ProtoError;
 use hickory_proto::serialize::binary::DecodeError;
 use protocol::ProtocolError;
-use resources::ResourcesError;
+use resources::{ManagedResourceCommandError, ResourcesError};
 use serde_json::Error as JsonError;
 use state::StateError;
 use thiserror::Error;
@@ -63,6 +63,9 @@ pub enum DaemonError {
     #[error("Managed Resource error: {0}")]
     Resources(#[from] ResourcesError),
 
+    #[error("Managed Resource command failed: {0}")]
+    ManagedResourceCommand(#[from] ManagedResourceCommandError),
+
     #[error("daemon task failed: {0}")]
     Task(#[from] JoinError),
 
@@ -74,6 +77,21 @@ pub enum DaemonError {
         check: String,
         timeout_ms: u128,
         last_error: Option<String>,
+    },
+
+    #[error("Managed Resource runtime `{resource}` is not supported yet")]
+    UnsupportedManagedResourceRuntime { resource: String },
+
+    #[error(
+        "Managed Resource runtime `{resource}` track `{track}` is missing installed artifact path"
+    )]
+    ManagedResourceArtifactMissing { resource: String, track: String },
+
+    #[error("Managed Resource runtime `{resource}` track `{track}` is missing port `{port}`")]
+    ManagedResourcePortMissing {
+        resource: String,
+        track: String,
+        port: String,
     },
 
     #[error("time formatting failed: {0}")]

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -1,6 +1,7 @@
 use crate::DaemonError;
 use crate::gateway::{FRANKENPHP_NOT_INSTALLED, reconcile_gateway_runtimes};
 use crate::ipc::LocalStream;
+use crate::managed_resources::reconcile_system_resources;
 use crate::project_env::reconcile_project_env;
 use crate::reconciliation::{EnqueueResult, ReconciliationQueue, ReconciliationScope};
 use protocol::{DaemonEvent, DaemonResponse, DaemonTransport, write_line};
@@ -267,6 +268,7 @@ async fn complete_system_reconciliation(
     job_id: &str,
 ) -> Result<String, DaemonError> {
     let project_report = reconcile_system_projects(paths).await?;
+    reconcile_system_resources(paths).await?;
     let gateway_summary = reconcile_gateway_runtimes(paths).await?;
     let summary = system_reconciliation_summary(&project_report, &gateway_summary);
     let mut database = Database::open(paths)?;

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -207,14 +207,18 @@ fn abandon_reconciliation_job(paths: &PvPaths, job_id: &str) -> Result<(), Daemo
     Ok(())
 }
 
-fn complete_stub_reconciliation(
+async fn complete_managed_resource_reconciliation(
     paths: &PvPaths,
     job_id: &str,
-) -> Result<&'static str, DaemonError> {
+    name: &crate::reconciliation::ReconciliationScopeComponent,
+    track: &crate::reconciliation::ReconciliationScopeComponent,
+) -> Result<String, DaemonError> {
+    let project_report = reconcile_system_projects(paths).await?;
+    let summary =
+        managed_resource_reconciliation_summary(name.as_str(), track.as_str(), &project_report);
     let mut database = Database::open(paths)?;
-    let summary = "stub job completed";
 
-    database.complete_job(job_id, summary)?;
+    database.complete_job(job_id, &summary)?;
 
     Ok(summary)
 }
@@ -229,8 +233,8 @@ async fn complete_reconciliation_job(
         ReconciliationScope::Resource { name, .. } if gateway_runtime_resource(name.as_str()) => {
             complete_gateway_reconciliation(paths, job_id).await
         }
-        ReconciliationScope::Resource { .. } => {
-            complete_stub_reconciliation(paths, job_id).map(str::to_string)
+        ReconciliationScope::Resource { name, track } => {
+            complete_managed_resource_reconciliation(paths, job_id, name, track).await
         }
         ReconciliationScope::Project { id } => {
             complete_project_reconciliation(paths, job_id, id).await
@@ -262,7 +266,7 @@ async fn complete_system_reconciliation(
     paths: &PvPaths,
     job_id: &str,
 ) -> Result<String, DaemonError> {
-    let project_report = reconcile_system_projects(paths)?;
+    let project_report = reconcile_system_projects(paths).await?;
     let gateway_summary = reconcile_gateway_runtimes(paths).await?;
     let summary = system_reconciliation_summary(&project_report, &gateway_summary);
     let mut database = Database::open(paths)?;
@@ -277,7 +281,7 @@ async fn complete_project_reconciliation(
     job_id: &str,
     id: &crate::reconciliation::ReconciliationScopeComponent,
 ) -> Result<String, DaemonError> {
-    let project_env_summary = reconcile_project_env(paths, id.as_str())?;
+    let project_env_summary = reconcile_project_env(paths, id.as_str()).await?;
     let gateway_summary = reconcile_gateway_runtimes(paths).await?;
     let summary = if gateway_summary == FRANKENPHP_NOT_INSTALLED {
         project_env_summary.as_str().to_string()
@@ -299,7 +303,7 @@ struct SystemProjectReconciliationReport {
     failures: Vec<String>,
 }
 
-fn reconcile_system_projects(
+async fn reconcile_system_projects(
     paths: &PvPaths,
 ) -> Result<SystemProjectReconciliationReport, DaemonError> {
     let projects = linked_projects(paths)?;
@@ -309,7 +313,7 @@ fn reconcile_system_projects(
     };
 
     for project in projects {
-        match reconcile_project_env(paths, &project.id) {
+        match reconcile_project_env(paths, &project.id).await {
             Ok(summary) => {
                 report.succeeded += 1;
                 report.summaries.push(summary.as_str().to_owned());
@@ -370,11 +374,20 @@ fn system_project_summary(report: &SystemProjectReconciliationReport) -> Option<
     ))
 }
 
+fn managed_resource_reconciliation_summary(
+    resource_name: &str,
+    track: &str,
+    project_report: &SystemProjectReconciliationReport,
+) -> String {
+    let Some(project_summary) = system_project_summary(project_report) else {
+        return format!("Managed Resource {resource_name} track {track} reconciled");
+    };
+
+    format!("Managed Resource {resource_name} track {track} reconciled; {project_summary}")
+}
+
 fn reconciliation_progress_message(scope: &ReconciliationScope, summary: &str) -> String {
     match scope {
-        ReconciliationScope::Resource { name, .. } if !gateway_runtime_resource(name.as_str()) => {
-            "stub job completed without reconciliation work".to_string()
-        }
         ReconciliationScope::System
         | ReconciliationScope::Resource { .. }
         | ReconciliationScope::Project { .. } => summary.to_string(),
@@ -388,7 +401,7 @@ fn reconciliation_started_message(scope: &ReconciliationScope) -> &'static str {
         ReconciliationScope::Resource { name, .. } if gateway_runtime_resource(name.as_str()) => {
             "Gateway runtime reconciliation started"
         }
-        ReconciliationScope::Resource { .. } => "stub job started",
+        ReconciliationScope::Resource { .. } => "Managed Resource runtime reconciliation started",
     }
 }
 

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -382,10 +382,14 @@ fn managed_resource_reconciliation_summary(
     project_report: &SystemProjectReconciliationReport,
 ) -> String {
     let Some(project_summary) = system_project_summary(project_report) else {
-        return format!("Managed Resource {resource_name} track {track} reconciled");
+        return format!(
+            "Managed Resource {resource_name} track {track} standalone reconciliation deferred"
+        );
     };
 
-    format!("Managed Resource {resource_name} track {track} reconciled; {project_summary}")
+    format!(
+        "Managed Resource {resource_name} track {track} standalone reconciliation deferred; {project_summary}"
+    )
 }
 
 fn reconciliation_progress_message(scope: &ReconciliationScope, summary: &str) -> String {

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -5,6 +5,7 @@ pub mod gateway;
 pub mod gateway_config;
 mod ipc;
 mod jobs;
+mod managed_resources;
 mod project_env;
 mod reconciliation;
 mod server;

--- a/crates/daemon/src/managed_resources/fake.rs
+++ b/crates/daemon/src/managed_resources/fake.rs
@@ -13,12 +13,10 @@ const FAKE_MAILPIT_PORTS: &[ManagedResourcePortSpec] = &[
     ManagedResourcePortSpec {
         name: "smtp",
         preferred_port: 1025,
-        env_key: "smtp_port",
     },
     ManagedResourcePortSpec {
         name: "dashboard",
         preferred_port: 8025,
-        env_key: "dashboard_port",
     },
 ];
 
@@ -31,6 +29,7 @@ pub(crate) struct FakeMailpitRuntimeAdapter {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum FakeMailpitReadiness {
     Smtp,
+    ExitAfterDashboardReadiness,
     UnservedDashboardPort { timeout: Duration },
 }
 
@@ -54,6 +53,16 @@ impl FakeMailpitRuntimeAdapter {
             readiness: FakeMailpitReadiness::UnservedDashboardPort {
                 timeout: Duration::from_millis(100),
             },
+        })
+    }
+
+    pub(crate) fn exits_after_readiness() -> Result<Self, DaemonError> {
+        Ok(Self {
+            artifact_adapter: ManagedResourceArtifactAdapter::new(
+                "mailpit",
+                "bin/pv-fake-mailpit",
+            )?,
+            readiness: FakeMailpitReadiness::ExitAfterDashboardReadiness,
         })
     }
 }
@@ -113,6 +122,11 @@ impl ManagedResourceRuntimeAdapter for FakeMailpitRuntimeAdapter {
                 host: RESOURCE_HOST.to_string(),
                 port: required_port(context, "smtp")?,
             }),
+            FakeMailpitReadiness::ExitAfterDashboardReadiness => Ok(ReadinessCheck::Http {
+                host: RESOURCE_HOST.to_string(),
+                port: required_port(context, "dashboard")?,
+                path: "/ready".to_string(),
+            }),
             FakeMailpitReadiness::UnservedDashboardPort { .. } => Ok(ReadinessCheck::Http {
                 host: RESOURCE_HOST.to_string(),
                 port: required_port(context, "dashboard")?,
@@ -124,6 +138,7 @@ impl ManagedResourceRuntimeAdapter for FakeMailpitRuntimeAdapter {
     fn readiness_timeout(&self) -> Duration {
         match self.readiness {
             FakeMailpitReadiness::Smtp => Duration::from_secs(15),
+            FakeMailpitReadiness::ExitAfterDashboardReadiness => Duration::from_secs(15),
             FakeMailpitReadiness::UnservedDashboardPort { timeout } => timeout,
         }
     }

--- a/crates/daemon/src/managed_resources/fake.rs
+++ b/crates/daemon/src/managed_resources/fake.rs
@@ -108,15 +108,17 @@ impl ManagedResourceRuntimeAdapter for FakeMailpitRuntimeAdapter {
         &self,
         context: &ManagedResourceRuntimeContext,
     ) -> Result<ReadinessCheck, DaemonError> {
-        let port_name = match self.readiness {
-            FakeMailpitReadiness::Smtp => "smtp",
-            FakeMailpitReadiness::UnservedDashboardPort { .. } => "dashboard",
-        };
-
-        Ok(ReadinessCheck::Tcp {
-            host: RESOURCE_HOST.to_string(),
-            port: required_port(context, port_name)?,
-        })
+        match self.readiness {
+            FakeMailpitReadiness::Smtp => Ok(ReadinessCheck::Tcp {
+                host: RESOURCE_HOST.to_string(),
+                port: required_port(context, "smtp")?,
+            }),
+            FakeMailpitReadiness::UnservedDashboardPort { .. } => Ok(ReadinessCheck::Http {
+                host: RESOURCE_HOST.to_string(),
+                port: required_port(context, "dashboard")?,
+                path: "/__pv_unready_fixture__".to_string(),
+            }),
+        }
     }
 
     fn readiness_timeout(&self) -> Duration {

--- a/crates/daemon/src/managed_resources/fake.rs
+++ b/crates/daemon/src/managed_resources/fake.rs
@@ -1,0 +1,160 @@
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use state::{EnvContextValues, PvPaths};
+
+use crate::managed_resources::{
+    ManagedResourceArtifactAdapter, ManagedResourcePortSpec, ManagedResourceRuntimeAdapter,
+    ManagedResourceRuntimeContext, RESOURCE_HOST,
+};
+use crate::{DaemonError, ProcessSpec, ReadinessCheck};
+
+const FAKE_MAILPIT_PORTS: &[ManagedResourcePortSpec] = &[
+    ManagedResourcePortSpec {
+        name: "smtp",
+        preferred_port: 1025,
+        env_key: "smtp_port",
+    },
+    ManagedResourcePortSpec {
+        name: "dashboard",
+        preferred_port: 8025,
+        env_key: "dashboard_port",
+    },
+];
+
+#[derive(Clone, Debug)]
+pub(crate) struct FakeMailpitRuntimeAdapter {
+    artifact_adapter: ManagedResourceArtifactAdapter,
+    readiness: FakeMailpitReadiness,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FakeMailpitReadiness {
+    Smtp,
+    UnservedDashboardPort { timeout: Duration },
+}
+
+impl FakeMailpitRuntimeAdapter {
+    pub(crate) fn new() -> Result<Self, DaemonError> {
+        Ok(Self {
+            artifact_adapter: ManagedResourceArtifactAdapter::new(
+                "mailpit",
+                "bin/pv-fake-mailpit",
+            )?,
+            readiness: FakeMailpitReadiness::Smtp,
+        })
+    }
+
+    pub(crate) fn unready() -> Result<Self, DaemonError> {
+        Ok(Self {
+            artifact_adapter: ManagedResourceArtifactAdapter::new(
+                "mailpit",
+                "bin/pv-fake-mailpit",
+            )?,
+            readiness: FakeMailpitReadiness::UnservedDashboardPort {
+                timeout: Duration::from_millis(100),
+            },
+        })
+    }
+}
+
+impl ManagedResourceRuntimeAdapter for FakeMailpitRuntimeAdapter {
+    fn resource_name(&self) -> &'static str {
+        "mailpit"
+    }
+
+    fn artifact_adapter(&self) -> Result<ManagedResourceArtifactAdapter, DaemonError> {
+        Ok(self.artifact_adapter.clone())
+    }
+
+    fn port_specs(&self) -> &'static [ManagedResourcePortSpec] {
+        FAKE_MAILPIT_PORTS
+    }
+
+    fn build_process_spec(
+        &self,
+        paths: &PvPaths,
+        context: &ManagedResourceRuntimeContext,
+    ) -> Result<ProcessSpec, DaemonError> {
+        let smtp_port = required_port(context, "smtp")?;
+        let dashboard_port = required_port(context, "dashboard")?;
+        let config_path = paths.resource_runtime_config(&context.resource_name, &context.track);
+        let config = serde_json::json!({
+            "resource": context.resource_name,
+            "track": context.track,
+            "smtp_port": smtp_port,
+            "dashboard_port": dashboard_port,
+            "data_dir": context.data_dir.as_str(),
+        });
+
+        state::fs::write_sensitive_file(&config_path, &serde_json::to_string_pretty(&config)?)?;
+
+        Ok(ProcessSpec {
+            name: format!("{}-{}", context.resource_name, context.track),
+            command: self
+                .artifact_adapter
+                .executable_path(&context.artifact_path),
+            arguments: vec![smtp_port.to_string(), dashboard_port.to_string()],
+            config_path,
+            log_path: paths.resource_log(&context.resource_name, &context.track),
+            pid_path: paths.resource_pid(&context.resource_name, &context.track),
+            metadata_path: paths.resource_runtime_metadata(&context.resource_name, &context.track),
+            resource_name: context.resource_name.clone(),
+            track: context.track.clone(),
+        })
+    }
+
+    fn readiness(
+        &self,
+        context: &ManagedResourceRuntimeContext,
+    ) -> Result<ReadinessCheck, DaemonError> {
+        let port_name = match self.readiness {
+            FakeMailpitReadiness::Smtp => "smtp",
+            FakeMailpitReadiness::UnservedDashboardPort { .. } => "dashboard",
+        };
+
+        Ok(ReadinessCheck::Tcp {
+            host: RESOURCE_HOST.to_string(),
+            port: required_port(context, port_name)?,
+        })
+    }
+
+    fn readiness_timeout(&self) -> Duration {
+        match self.readiness {
+            FakeMailpitReadiness::Smtp => Duration::from_secs(15),
+            FakeMailpitReadiness::UnservedDashboardPort { timeout } => timeout,
+        }
+    }
+
+    fn resource_env(
+        &self,
+        context: &ManagedResourceRuntimeContext,
+    ) -> Result<EnvContextValues, DaemonError> {
+        let smtp_port = required_port(context, "smtp")?;
+        let dashboard_port = required_port(context, "dashboard")?;
+
+        Ok(BTreeMap::from([
+            ("smtp_host".to_string(), RESOURCE_HOST.to_string()),
+            ("smtp_port".to_string(), smtp_port.to_string()),
+            (
+                "dashboard_url".to_string(),
+                format!("http://{RESOURCE_HOST}:{dashboard_port}"),
+            ),
+        ]))
+    }
+}
+
+fn required_port(
+    context: &ManagedResourceRuntimeContext,
+    port_name: &str,
+) -> Result<u16, DaemonError> {
+    context
+        .ports
+        .get(port_name)
+        .copied()
+        .ok_or_else(|| DaemonError::ManagedResourcePortMissing {
+            resource: context.resource_name.clone(),
+            track: context.track.clone(),
+            port: port_name.to_string(),
+        })
+}

--- a/crates/daemon/src/managed_resources/mod.rs
+++ b/crates/daemon/src/managed_resources/mod.rs
@@ -238,6 +238,24 @@ pub(crate) async fn reconcile_project_resources_with_catalog(
     Ok(())
 }
 
+pub(crate) async fn reconcile_system_resources(paths: &PvPaths) -> Result<(), DaemonError> {
+    let catalog = ManagedResourceRuntimeCatalog::production();
+    let mut database = Database::open(paths)?;
+
+    reconcile_system_resources_with_catalog(paths, &mut database, &catalog).await
+}
+
+pub(crate) async fn reconcile_system_resources_with_catalog(
+    paths: &PvPaths,
+    database: &mut Database,
+    catalog: &ManagedResourceRuntimeCatalog,
+) -> Result<(), DaemonError> {
+    let supervisor = ProcessSupervisor::new(paths.clone());
+    let demanded_tracks = BTreeSet::new();
+
+    stop_undemanded_catalog_runtimes(paths, database, catalog, &supervisor, &demanded_tracks).await
+}
+
 async fn reconcile_resource_track(
     paths: &PvPaths,
     database: &mut Database,

--- a/crates/daemon/src/managed_resources/mod.rs
+++ b/crates/daemon/src/managed_resources/mod.rs
@@ -14,9 +14,9 @@ use resources::{
     TrackSelector,
 };
 use state::{
-    Database, EnvContextValues, ManagedResourceTrackRecord, PortOwner, PortRequest, ProjectRecord,
-    PvPaths, RUNTIME_PORT_FALLBACK_END, RUNTIME_PORT_FALLBACK_START, ResourceAllocationRecord,
-    RuntimeObservedStatus, RuntimeSubject, StateError,
+    Database, EnvContextValues, ManagedResourceDesiredState, ManagedResourceTrackRecord, PortOwner,
+    PortRequest, ProjectRecord, PvPaths, RUNTIME_PORT_FALLBACK_END, RUNTIME_PORT_FALLBACK_START,
+    ResourceAllocationRecord, RuntimeObservedStatus, RuntimeSubject, StateError,
 };
 
 use crate::{DaemonError, ProcessSpec, ProcessSupervisor, ReadinessCheck, wait_for_readiness};
@@ -25,18 +25,13 @@ const DEFAULT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json
 const RESOURCE_HOST: &str = "127.0.0.1";
 const RESOURCE_READINESS_TIMEOUT: Duration = Duration::from_secs(15);
 const RESOURCE_STOP_GRACE_PERIOD: Duration = Duration::from_secs(10);
+const RESOURCE_START_ATTEMPTS: usize = 10;
+const RESERVED_RESOURCE_PORT_NAME: &str = "default";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ManagedResourcePortSpec {
     pub name: &'static str,
     pub preferred_port: u16,
-    pub env_key: &'static str,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) struct ManagedResourcePortAssignment {
-    pub name: String,
-    pub port: u16,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -150,7 +145,6 @@ pub(crate) struct ManagedResourceInstallOptions {
 pub(crate) struct ManagedResourceRuntimeCatalog {
     adapters: BTreeMap<&'static str, Box<dyn ManagedResourceRuntimeAdapter>>,
     install_options: ManagedResourceInstallOptions,
-    strict_unsupported_resources: bool,
 }
 
 impl ManagedResourceRuntimeCatalog {
@@ -161,7 +155,6 @@ impl ManagedResourceRuntimeCatalog {
                 manifest_url: DEFAULT_MANIFEST_URL.to_string(),
                 target_platform: current_target_platform(),
             },
-            strict_unsupported_resources: false,
         }
     }
 
@@ -177,20 +170,11 @@ impl ManagedResourceRuntimeCatalog {
         Self {
             adapters,
             install_options,
-            strict_unsupported_resources: true,
         }
     }
 
     fn adapter(&self, resource_name: &str) -> Option<&dyn ManagedResourceRuntimeAdapter> {
         self.adapters.get(resource_name).map(Box::as_ref)
-    }
-
-    fn contains(&self, resource_name: &str) -> bool {
-        self.adapters.contains_key(resource_name)
-    }
-
-    fn should_error_on_unsupported_resource(&self) -> bool {
-        self.strict_unsupported_resources
     }
 }
 
@@ -265,61 +249,81 @@ async fn reconcile_resource_track(
     supervisor: &ProcessSupervisor,
     resource: &state::ProjectManagedResourceInput,
 ) -> Result<(), DaemonError> {
-    let Some(adapter) = catalog.adapter(&resource.resource_name) else {
-        if !catalog.should_error_on_unsupported_resource() {
-            return Ok(());
-        }
-
-        return Err(DaemonError::UnsupportedManagedResourceRuntime {
-            resource: resource.resource_name.clone(),
-        });
-    };
-    let track_record = ensure_track_artifact(paths, database, catalog, adapter, resource).await?;
-    let Some(artifact_path) = track_record.current_artifact_path else {
-        return Err(DaemonError::ManagedResourceArtifactMissing {
-            resource: resource.resource_name.clone(),
-            track: resource.track.clone(),
-        });
-    };
-    let port_assignments =
-        assign_named_ports(database, adapter, &resource.resource_name, &resource.track)?;
-    let ports = port_assignments
-        .into_iter()
-        .map(|assignment| (assignment.name, assignment.port))
-        .collect::<BTreeMap<_, _>>();
-    let context = ManagedResourceRuntimeContext {
-        resource_name: resource.resource_name.clone(),
-        track: resource.track.clone(),
-        artifact_path,
-        data_dir: paths.resource_data_dir(&resource.resource_name, &resource.track),
-        ports,
-    };
     let subject = RuntimeSubject::Resource {
         name: resource.resource_name.clone(),
         track: resource.track.clone(),
     };
-    let result = async {
-        let spec = adapter.build_process_spec(paths, &context)?;
-        let readiness = adapter.readiness(&context)?;
-        let readiness_timeout = adapter_readiness_timeout(adapter);
+    let Some(adapter) = catalog.adapter(&resource.resource_name) else {
+        if unsupported_resource_has_seeded_env_context(database, resource)? {
+            return Ok(());
+        }
 
-        start_or_adopt_runtime(supervisor, spec, readiness, readiness_timeout).await?;
-
-        let env = adapter.resource_env(&context)?;
-        database.record_managed_resource_track_env_context(
-            &resource.resource_name,
-            &resource.track,
-            &env,
-        )?;
-        let allocations = desired_allocations(database, project, plan, resource)?;
-        adapter.reconcile_allocations(paths, database, &context, &allocations)?;
+        let error = DaemonError::UnsupportedManagedResourceRuntime {
+            resource: resource.resource_name.clone(),
+        };
         database.record_runtime_observed_snapshot(
-            subject.clone(),
-            RuntimeObservedStatus::Running,
-            Some("Managed Resource runtime is ready"),
+            subject,
+            RuntimeObservedStatus::Failed,
+            Some(&error.to_string()),
         )?;
 
-        Ok::<(), DaemonError>(())
+        return Err(error);
+    };
+    let result = async {
+        let track_record =
+            ensure_track_artifact(paths, database, catalog, adapter, resource).await?;
+        let Some(artifact_path) = track_record.current_artifact_path else {
+            return Err(DaemonError::ManagedResourceArtifactMissing {
+                resource: resource.resource_name.clone(),
+                track: resource.track.clone(),
+            });
+        };
+        let mut attempt = 0;
+
+        loop {
+            attempt += 1;
+            let ports =
+                assign_named_ports(database, adapter, &resource.resource_name, &resource.track)?;
+            if ports_occupied_without_recorded_runtime(paths, supervisor, resource, &ports)?
+                && attempt < RESOURCE_START_ATTEMPTS
+            {
+                cleanup_resource_runtime_files(paths, resource)?;
+                release_resource_track_ports(database, &resource.resource_name, &resource.track)?;
+
+                continue;
+            }
+            let context = ManagedResourceRuntimeContext {
+                resource_name: resource.resource_name.clone(),
+                track: resource.track.clone(),
+                artifact_path: artifact_path.clone(),
+                data_dir: paths.resource_data_dir(&resource.resource_name, &resource.track),
+                ports,
+            };
+            let mut runtime_attempt = ResourceRuntimeAttempt {
+                paths,
+                database,
+                project,
+                plan,
+                adapter,
+                supervisor,
+                resource,
+                subject: &subject,
+            };
+            let result = runtime_attempt.run(&context).await;
+
+            if matches!(
+                result,
+                Err(DaemonError::NonPvManagedResourceRuntimeListener { .. })
+            ) && attempt < RESOURCE_START_ATTEMPTS
+            {
+                cleanup_resource_runtime_files(paths, resource)?;
+                release_resource_track_ports(database, &resource.resource_name, &resource.track)?;
+
+                continue;
+            }
+
+            break result;
+        }
     }
     .await;
 
@@ -332,6 +336,61 @@ async fn reconcile_resource_track(
     }
 
     result
+}
+
+struct ResourceRuntimeAttempt<'a> {
+    paths: &'a PvPaths,
+    database: &'a mut Database,
+    project: &'a ProjectRecord,
+    plan: &'a crate::project_env::ProjectResourcePlan,
+    adapter: &'a dyn ManagedResourceRuntimeAdapter,
+    supervisor: &'a ProcessSupervisor,
+    resource: &'a state::ProjectManagedResourceInput,
+    subject: &'a RuntimeSubject,
+}
+
+impl ResourceRuntimeAttempt<'_> {
+    async fn run(&mut self, context: &ManagedResourceRuntimeContext) -> Result<(), DaemonError> {
+        let spec = self.adapter.build_process_spec(self.paths, context)?;
+        let readiness = self.adapter.readiness(context)?;
+        let readiness_timeout = adapter_readiness_timeout(self.adapter);
+
+        start_or_adopt_runtime(self.supervisor, spec, readiness, readiness_timeout).await?;
+
+        let env = self.adapter.resource_env(context)?;
+        self.database.record_managed_resource_track_env_context(
+            &self.resource.resource_name,
+            &self.resource.track,
+            &env,
+        )?;
+        let allocations =
+            desired_allocations(self.database, self.project, self.plan, self.resource)?;
+        self.adapter
+            .reconcile_allocations(self.paths, self.database, context, &allocations)?;
+        self.database.record_runtime_observed_snapshot(
+            self.subject.clone(),
+            RuntimeObservedStatus::Running,
+            Some("Managed Resource runtime is ready"),
+        )?;
+
+        Ok(())
+    }
+}
+
+fn unsupported_resource_has_seeded_env_context(
+    database: &Database,
+    resource: &state::ProjectManagedResourceInput,
+) -> Result<bool, DaemonError> {
+    let has_context = database
+        .managed_resource_tracks()?
+        .into_iter()
+        .any(|track| {
+            track.resource_name == resource.resource_name
+                && track.track == resource.track
+                && !track.env.is_empty()
+        });
+
+    Ok(has_context)
 }
 
 async fn ensure_track_artifact(
@@ -375,16 +434,25 @@ fn installed_track(
     resource_name: &str,
     track: &str,
 ) -> Result<Option<ManagedResourceTrackRecord>, DaemonError> {
-    let record = database
+    let Some(record) = database
         .managed_resource_tracks()?
         .into_iter()
-        .find(|record| {
-            record.resource_name == resource_name
-                && record.track == track
-                && record.current_artifact_path.is_some()
-        });
+        .find(|record| record.resource_name == resource_name && record.track == track)
+    else {
+        return Ok(None);
+    };
 
-    Ok(record)
+    if record.current_artifact_path.is_none() {
+        return Ok(None);
+    }
+    if record.desired_state == ManagedResourceDesiredState::Removed {
+        return Err(DaemonError::ManagedResourceTrackRemoved {
+            resource: resource_name.to_string(),
+            track: track.to_string(),
+        });
+    }
+
+    Ok(Some(record))
 }
 
 fn install_missing_track_blocking(
@@ -420,10 +488,33 @@ fn assign_named_ports(
     adapter: &dyn ManagedResourceRuntimeAdapter,
     resource_name: &str,
     track: &str,
-) -> Result<Vec<ManagedResourcePortAssignment>, DaemonError> {
-    let mut assignments = Vec::new();
+) -> Result<BTreeMap<String, u16>, DaemonError> {
+    let result = assign_named_ports_inner(database, adapter, resource_name, track);
+
+    if result.is_err() {
+        release_resource_track_ports(database, resource_name, track)?;
+    }
+
+    result
+}
+
+fn assign_named_ports_inner(
+    database: &mut Database,
+    adapter: &dyn ManagedResourceRuntimeAdapter,
+    resource_name: &str,
+    track: &str,
+) -> Result<BTreeMap<String, u16>, DaemonError> {
+    let mut assignments = BTreeMap::new();
 
     for port_spec in adapter.port_specs() {
+        if port_spec.name == RESERVED_RESOURCE_PORT_NAME {
+            return Err(DaemonError::ManagedResourcePortNameReserved {
+                resource: resource_name.to_string(),
+                track: track.to_string(),
+                port: port_spec.name.to_string(),
+            });
+        }
+
         let assignment = database.assign_port(
             PortRequest::resource_port(
                 resource_name,
@@ -436,13 +527,30 @@ fn assign_named_ports(
             local_loopback_port_available,
         )?;
 
-        assignments.push(ManagedResourcePortAssignment {
-            name: port_spec.name.to_string(),
-            port: assignment.port,
-        });
+        assignments.insert(port_spec.name.to_string(), assignment.port);
     }
 
     Ok(assignments)
+}
+
+fn ports_occupied_without_recorded_runtime(
+    paths: &PvPaths,
+    supervisor: &ProcessSupervisor,
+    resource: &state::ProjectManagedResourceInput,
+    ports: &BTreeMap<String, u16>,
+) -> Result<bool, DaemonError> {
+    if ports
+        .values()
+        .all(|port| local_loopback_port_available(*port))
+    {
+        return Ok(false);
+    }
+    let recorded_runtime = supervisor.adopt_recorded(
+        &paths.resource_pid(&resource.resource_name, &resource.track),
+        &paths.resource_runtime_metadata(&resource.resource_name, &resource.track),
+    )?;
+
+    Ok(recorded_runtime.is_none())
 }
 
 async fn start_or_adopt_runtime(
@@ -460,12 +568,7 @@ async fn start_or_adopt_runtime(
         .await
         .is_ok()
     {
-        return Err(DaemonError::UnexpectedProtocolResponse {
-            reason: format!(
-                "runtime `{}` is listening but no PV-owned process could be verified",
-                spec.name
-            ),
-        });
+        return Err(DaemonError::NonPvManagedResourceRuntimeListener { name: spec.name });
     }
 
     let mut process = supervisor.start(spec.clone()).await?;
@@ -475,7 +578,10 @@ async fn start_or_adopt_runtime(
 
         return Err(error);
     }
+    tokio::time::sleep(Duration::from_millis(25)).await;
     if process.has_exited()? {
+        cleanup_started_runtime_files(&spec)?;
+
         return Err(DaemonError::UnexpectedProtocolResponse {
             reason: format!(
                 "runtime `{}` exited before readiness was verified",
@@ -545,18 +651,16 @@ async fn stop_undemanded_catalog_runtimes(
     let tracks = database.managed_resource_tracks()?;
 
     for track in tracks {
-        if !catalog.contains(&track.resource_name)
-            || track.usage_count > 0
+        let Some(_adapter) = catalog.adapter(&track.resource_name) else {
+            continue;
+        };
+        if track.usage_count > 0
             || demanded_tracks.contains(&(track.resource_name.clone(), track.track.clone()))
         {
             continue;
         }
 
-        let Some(adapter) = catalog.adapter(&track.resource_name) else {
-            continue;
-        };
-
-        stop_resource_runtime(paths, database, supervisor, adapter, &track).await?;
+        stop_resource_runtime(paths, database, supervisor, &track).await?;
     }
 
     Ok(())
@@ -566,7 +670,6 @@ async fn stop_resource_runtime(
     paths: &PvPaths,
     database: &mut Database,
     supervisor: &ProcessSupervisor,
-    adapter: &dyn ManagedResourceRuntimeAdapter,
     track: &ManagedResourceTrackRecord,
 ) -> Result<(), DaemonError> {
     if let Some(adopted) = supervisor.adopt_recorded(
@@ -583,7 +686,7 @@ async fn stop_resource_runtime(
         RuntimeObservedStatus::Stopped,
         Some("Managed Resource runtime stopped; no Projects require this track"),
     )?;
-    cleanup_resource_runtime(paths, database, adapter, track)?;
+    cleanup_resource_runtime(paths, database, track)?;
 
     Ok(())
 }
@@ -591,19 +694,57 @@ async fn stop_resource_runtime(
 fn cleanup_resource_runtime(
     paths: &PvPaths,
     database: &mut Database,
-    adapter: &dyn ManagedResourceRuntimeAdapter,
     track: &ManagedResourceTrackRecord,
 ) -> Result<(), DaemonError> {
-    delete_optional_file(&paths.resource_pid(&track.resource_name, &track.track))?;
-    delete_optional_file(&paths.resource_runtime_metadata(&track.resource_name, &track.track))?;
-    delete_optional_file(&paths.resource_runtime_config(&track.resource_name, &track.track))?;
+    cleanup_resource_runtime_files_for_track(paths, &track.resource_name, &track.track)?;
+    release_resource_track_ports(database, &track.resource_name, &track.track)?;
 
-    for port_spec in adapter.port_specs() {
-        database.release_port(PortOwner::Resource {
-            name: track.resource_name.clone(),
-            track: track.track.clone(),
-            port: port_spec.name.to_string(),
-        })?;
+    Ok(())
+}
+
+fn cleanup_resource_runtime_files(
+    paths: &PvPaths,
+    resource: &state::ProjectManagedResourceInput,
+) -> Result<(), DaemonError> {
+    cleanup_resource_runtime_files_for_track(paths, &resource.resource_name, &resource.track)
+}
+
+fn cleanup_resource_runtime_files_for_track(
+    paths: &PvPaths,
+    resource_name: &str,
+    track: &str,
+) -> Result<(), DaemonError> {
+    delete_optional_file(&paths.resource_pid(resource_name, track))?;
+    delete_optional_file(&paths.resource_runtime_metadata(resource_name, track))?;
+    delete_optional_file(&paths.resource_runtime_config(resource_name, track))?;
+
+    Ok(())
+}
+
+fn release_resource_track_ports(
+    database: &mut Database,
+    resource_name: &str,
+    track: &str,
+) -> Result<(), DaemonError> {
+    let port_owners = database
+        .assigned_ports()?
+        .into_iter()
+        .filter_map(|assignment| match assignment.owner {
+            PortOwner::Resource {
+                name,
+                track: owner_track,
+                port,
+            } if name == resource_name && owner_track == track => Some(PortOwner::Resource {
+                name,
+                track: owner_track,
+                port,
+            }),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    for owner in port_owners {
+        database.release_port(owner)?;
     }
 
     Ok(())

--- a/crates/daemon/src/managed_resources/mod.rs
+++ b/crates/daemon/src/managed_resources/mod.rs
@@ -1,0 +1,657 @@
+#[cfg(test)]
+mod fake;
+#[cfg(test)]
+mod tests;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::io;
+use std::net::TcpListener;
+use std::time::Duration;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use resources::{
+    ManagedResourceCommands, ResourceAdapter, ResourceName, ResourcesError, TrackName,
+    TrackSelector,
+};
+use state::{
+    Database, EnvContextValues, ManagedResourceTrackRecord, PortOwner, PortRequest, ProjectRecord,
+    PvPaths, RUNTIME_PORT_FALLBACK_END, RUNTIME_PORT_FALLBACK_START, ResourceAllocationRecord,
+    RuntimeObservedStatus, RuntimeSubject, StateError,
+};
+
+use crate::{DaemonError, ProcessSpec, ProcessSupervisor, ReadinessCheck, wait_for_readiness};
+
+const DEFAULT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json";
+const RESOURCE_HOST: &str = "127.0.0.1";
+const RESOURCE_READINESS_TIMEOUT: Duration = Duration::from_secs(15);
+const RESOURCE_STOP_GRACE_PERIOD: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ManagedResourcePortSpec {
+    pub name: &'static str,
+    pub preferred_port: u16,
+    pub env_key: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ManagedResourcePortAssignment {
+    pub name: String,
+    pub port: u16,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ManagedResourceRuntimeContext {
+    pub resource_name: String,
+    pub track: String,
+    pub artifact_path: camino::Utf8PathBuf,
+    pub data_dir: camino::Utf8PathBuf,
+    pub ports: BTreeMap<String, u16>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ManagedResourceArtifactAdapter {
+    resource_name: ResourceName,
+    executable_relative_path: Utf8PathBuf,
+}
+
+impl ManagedResourceArtifactAdapter {
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "production adapter modules construct daemon Managed Resource artifact adapters in follow-up PRs"
+        )
+    )]
+    pub(crate) fn new(
+        resource_name: &str,
+        executable_relative_path: impl Into<Utf8PathBuf>,
+    ) -> Result<Self, DaemonError> {
+        Ok(Self {
+            resource_name: ResourceName::new(resource_name)?,
+            executable_relative_path: executable_relative_path.into(),
+        })
+    }
+
+    pub(crate) fn executable_path(&self, release: &Utf8Path) -> Utf8PathBuf {
+        release.join(&self.executable_relative_path)
+    }
+}
+
+impl ResourceAdapter for ManagedResourceArtifactAdapter {
+    fn resource_name(&self) -> &ResourceName {
+        &self.resource_name
+    }
+
+    fn validate_installation(&self, root: &Utf8Path) -> resources::Result<()> {
+        let executable_path = self.executable_path(root);
+        if path_is_file(&executable_path)? {
+            return Ok(());
+        }
+
+        Err(ResourcesError::InvalidArtifactLayout {
+            resource: self.resource_name.as_str().to_string(),
+            reason: format!("missing executable `{}`", self.executable_relative_path),
+        })
+    }
+}
+
+pub(crate) trait ManagedResourceRuntimeAdapter: Send + Sync {
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "production adapter catalog registration uses resource names in follow-up PRs"
+        )
+    )]
+    fn resource_name(&self) -> &'static str;
+
+    fn artifact_adapter(&self) -> Result<ManagedResourceArtifactAdapter, DaemonError>;
+
+    fn port_specs(&self) -> &'static [ManagedResourcePortSpec];
+
+    fn build_process_spec(
+        &self,
+        paths: &PvPaths,
+        context: &ManagedResourceRuntimeContext,
+    ) -> Result<ProcessSpec, DaemonError>;
+
+    fn readiness(
+        &self,
+        context: &ManagedResourceRuntimeContext,
+    ) -> Result<ReadinessCheck, DaemonError>;
+
+    #[cfg(test)]
+    fn readiness_timeout(&self) -> Duration {
+        RESOURCE_READINESS_TIMEOUT
+    }
+
+    fn resource_env(
+        &self,
+        context: &ManagedResourceRuntimeContext,
+    ) -> Result<EnvContextValues, DaemonError>;
+
+    fn reconcile_allocations(
+        &self,
+        _paths: &PvPaths,
+        _database: &mut Database,
+        _context: &ManagedResourceRuntimeContext,
+        _allocations: &[ResourceAllocationRecord],
+    ) -> Result<(), DaemonError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ManagedResourceInstallOptions {
+    pub manifest_url: String,
+    pub target_platform: resources::TargetPlatform,
+}
+
+pub(crate) struct ManagedResourceRuntimeCatalog {
+    adapters: BTreeMap<&'static str, Box<dyn ManagedResourceRuntimeAdapter>>,
+    install_options: ManagedResourceInstallOptions,
+    strict_unsupported_resources: bool,
+}
+
+impl ManagedResourceRuntimeCatalog {
+    pub(crate) fn production() -> Self {
+        Self {
+            adapters: BTreeMap::new(),
+            install_options: ManagedResourceInstallOptions {
+                manifest_url: DEFAULT_MANIFEST_URL.to_string(),
+                target_platform: current_target_platform(),
+            },
+            strict_unsupported_resources: false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_adapter(
+        install_options: ManagedResourceInstallOptions,
+        adapter: impl ManagedResourceRuntimeAdapter + 'static,
+    ) -> Self {
+        let mut adapters: BTreeMap<&'static str, Box<dyn ManagedResourceRuntimeAdapter>> =
+            BTreeMap::new();
+        adapters.insert(adapter.resource_name(), Box::new(adapter));
+
+        Self {
+            adapters,
+            install_options,
+            strict_unsupported_resources: true,
+        }
+    }
+
+    fn adapter(&self, resource_name: &str) -> Option<&dyn ManagedResourceRuntimeAdapter> {
+        self.adapters.get(resource_name).map(Box::as_ref)
+    }
+
+    fn contains(&self, resource_name: &str) -> bool {
+        self.adapters.contains_key(resource_name)
+    }
+
+    fn should_error_on_unsupported_resource(&self) -> bool {
+        self.strict_unsupported_resources
+    }
+}
+
+pub(crate) async fn reconcile_project_resources(
+    paths: &PvPaths,
+    database: &mut Database,
+    project: &ProjectRecord,
+    plan: &crate::project_env::ProjectResourcePlan,
+) -> Result<(), DaemonError> {
+    let catalog = ManagedResourceRuntimeCatalog::production();
+
+    reconcile_project_resources_with_catalog(paths, database, project, plan, &catalog).await
+}
+
+pub(crate) async fn reconcile_project_resources_with_catalog(
+    paths: &PvPaths,
+    database: &mut Database,
+    project: &ProjectRecord,
+    plan: &crate::project_env::ProjectResourcePlan,
+    catalog: &ManagedResourceRuntimeCatalog,
+) -> Result<(), DaemonError> {
+    let supervisor = ProcessSupervisor::new(paths.clone());
+    let demanded_tracks = plan
+        .resources
+        .iter()
+        .map(|resource| (resource.resource_name.clone(), resource.track.clone()))
+        .collect::<BTreeSet<_>>();
+
+    stop_undemanded_catalog_runtimes(paths, database, catalog, &supervisor, &demanded_tracks)
+        .await?;
+
+    for resource in &plan.resources {
+        reconcile_resource_track(
+            paths,
+            database,
+            project,
+            plan,
+            catalog,
+            &supervisor,
+            resource,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+async fn reconcile_resource_track(
+    paths: &PvPaths,
+    database: &mut Database,
+    project: &ProjectRecord,
+    plan: &crate::project_env::ProjectResourcePlan,
+    catalog: &ManagedResourceRuntimeCatalog,
+    supervisor: &ProcessSupervisor,
+    resource: &state::ProjectManagedResourceInput,
+) -> Result<(), DaemonError> {
+    let Some(adapter) = catalog.adapter(&resource.resource_name) else {
+        if !catalog.should_error_on_unsupported_resource() {
+            return Ok(());
+        }
+
+        return Err(DaemonError::UnsupportedManagedResourceRuntime {
+            resource: resource.resource_name.clone(),
+        });
+    };
+    let track_record = ensure_track_artifact(paths, database, catalog, adapter, resource).await?;
+    let Some(artifact_path) = track_record.current_artifact_path else {
+        return Err(DaemonError::ManagedResourceArtifactMissing {
+            resource: resource.resource_name.clone(),
+            track: resource.track.clone(),
+        });
+    };
+    let port_assignments =
+        assign_named_ports(database, adapter, &resource.resource_name, &resource.track)?;
+    let ports = port_assignments
+        .into_iter()
+        .map(|assignment| (assignment.name, assignment.port))
+        .collect::<BTreeMap<_, _>>();
+    let context = ManagedResourceRuntimeContext {
+        resource_name: resource.resource_name.clone(),
+        track: resource.track.clone(),
+        artifact_path,
+        data_dir: paths.resource_data_dir(&resource.resource_name, &resource.track),
+        ports,
+    };
+    let subject = RuntimeSubject::Resource {
+        name: resource.resource_name.clone(),
+        track: resource.track.clone(),
+    };
+    let result = async {
+        let spec = adapter.build_process_spec(paths, &context)?;
+        let readiness = adapter.readiness(&context)?;
+        let readiness_timeout = adapter_readiness_timeout(adapter);
+
+        start_or_adopt_runtime(supervisor, spec, readiness, readiness_timeout).await?;
+
+        let env = adapter.resource_env(&context)?;
+        database.record_managed_resource_track_env_context(
+            &resource.resource_name,
+            &resource.track,
+            &env,
+        )?;
+        let allocations = desired_allocations(database, project, plan, resource)?;
+        adapter.reconcile_allocations(paths, database, &context, &allocations)?;
+        database.record_runtime_observed_snapshot(
+            subject.clone(),
+            RuntimeObservedStatus::Running,
+            Some("Managed Resource runtime is ready"),
+        )?;
+
+        Ok::<(), DaemonError>(())
+    }
+    .await;
+
+    if let Err(error) = &result {
+        database.record_runtime_observed_snapshot(
+            subject,
+            RuntimeObservedStatus::Failed,
+            Some(&error.to_string()),
+        )?;
+    }
+
+    result
+}
+
+async fn ensure_track_artifact(
+    paths: &PvPaths,
+    database: &mut Database,
+    catalog: &ManagedResourceRuntimeCatalog,
+    adapter: &dyn ManagedResourceRuntimeAdapter,
+    resource: &state::ProjectManagedResourceInput,
+) -> Result<ManagedResourceTrackRecord, DaemonError> {
+    if let Some(record) = installed_track(database, &resource.resource_name, &resource.track)? {
+        return Ok(record);
+    }
+
+    let artifact_adapter = adapter.artifact_adapter()?;
+    let install_options = catalog.install_options.clone();
+    let install_paths = paths.clone();
+    let resource_name = resource.resource_name.clone();
+    let track = resource.track.clone();
+
+    tokio::task::spawn_blocking(move || {
+        install_missing_track_blocking(
+            install_paths,
+            install_options,
+            artifact_adapter,
+            resource_name,
+            track,
+        )
+    })
+    .await??;
+
+    installed_track(database, &resource.resource_name, &resource.track)?.ok_or_else(|| {
+        DaemonError::ManagedResourceArtifactMissing {
+            resource: resource.resource_name.clone(),
+            track: resource.track.clone(),
+        }
+    })
+}
+
+fn installed_track(
+    database: &Database,
+    resource_name: &str,
+    track: &str,
+) -> Result<Option<ManagedResourceTrackRecord>, DaemonError> {
+    let record = database
+        .managed_resource_tracks()?
+        .into_iter()
+        .find(|record| {
+            record.resource_name == resource_name
+                && record.track == track
+                && record.current_artifact_path.is_some()
+        });
+
+    Ok(record)
+}
+
+fn install_missing_track_blocking(
+    paths: PvPaths,
+    install_options: ManagedResourceInstallOptions,
+    adapter: ManagedResourceArtifactAdapter,
+    resource_name: String,
+    track: String,
+) -> Result<(), DaemonError> {
+    let commands = ManagedResourceCommands::new(
+        paths,
+        install_options.manifest_url,
+        install_options.target_platform,
+    );
+    let client = resources::UreqResourceHttpClient::default();
+    let track = TrackName::new(track)?;
+
+    commands.install(&adapter, TrackSelector::Track(track), &client)?;
+    if adapter.resource_name().as_str() != resource_name {
+        return Err(DaemonError::UnexpectedProtocolResponse {
+            reason: format!(
+                "runtime adapter installed `{}` while reconciling `{resource_name}`",
+                adapter.resource_name()
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+fn assign_named_ports(
+    database: &mut Database,
+    adapter: &dyn ManagedResourceRuntimeAdapter,
+    resource_name: &str,
+    track: &str,
+) -> Result<Vec<ManagedResourcePortAssignment>, DaemonError> {
+    let mut assignments = Vec::new();
+
+    for port_spec in adapter.port_specs() {
+        let assignment = database.assign_port(
+            PortRequest::resource_port(
+                resource_name,
+                track,
+                port_spec.name,
+                port_spec.preferred_port,
+                RUNTIME_PORT_FALLBACK_START,
+                RUNTIME_PORT_FALLBACK_END,
+            ),
+            local_loopback_port_available,
+        )?;
+
+        assignments.push(ManagedResourcePortAssignment {
+            name: port_spec.name.to_string(),
+            port: assignment.port,
+        });
+    }
+
+    Ok(assignments)
+}
+
+async fn start_or_adopt_runtime(
+    supervisor: &ProcessSupervisor,
+    spec: ProcessSpec,
+    readiness: ReadinessCheck,
+    readiness_timeout: Duration,
+) -> Result<(), DaemonError> {
+    if supervisor.adopt(&spec)?.is_some() {
+        wait_for_readiness(readiness, readiness_timeout).await?;
+
+        return Ok(());
+    }
+    if crate::supervisor::probe_readiness_once(&readiness)
+        .await
+        .is_ok()
+    {
+        return Err(DaemonError::UnexpectedProtocolResponse {
+            reason: format!(
+                "runtime `{}` is listening but no PV-owned process could be verified",
+                spec.name
+            ),
+        });
+    }
+
+    let mut process = supervisor.start(spec.clone()).await?;
+    if let Err(error) = wait_for_readiness(readiness, readiness_timeout).await {
+        process.stop(RESOURCE_STOP_GRACE_PERIOD).await?;
+        cleanup_started_runtime_files(&spec)?;
+
+        return Err(error);
+    }
+    if process.has_exited()? {
+        return Err(DaemonError::UnexpectedProtocolResponse {
+            reason: format!(
+                "runtime `{}` exited before readiness was verified",
+                spec.name
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+fn cleanup_started_runtime_files(spec: &ProcessSpec) -> Result<(), DaemonError> {
+    delete_optional_file(&spec.pid_path)?;
+    delete_optional_file(&spec.metadata_path)?;
+    delete_optional_file(&spec.config_path)?;
+
+    Ok(())
+}
+
+fn adapter_readiness_timeout(adapter: &dyn ManagedResourceRuntimeAdapter) -> Duration {
+    #[cfg(test)]
+    {
+        adapter.readiness_timeout()
+    }
+
+    #[cfg(not(test))]
+    {
+        let _adapter = adapter;
+
+        RESOURCE_READINESS_TIMEOUT
+    }
+}
+
+fn desired_allocations(
+    database: &Database,
+    project: &ProjectRecord,
+    plan: &crate::project_env::ProjectResourcePlan,
+    resource: &state::ProjectManagedResourceInput,
+) -> Result<Vec<ResourceAllocationRecord>, DaemonError> {
+    let Some(allocation_plan) = plan.allocations.get(&resource.resource_name) else {
+        return Ok(Vec::new());
+    };
+    let desired_names = allocation_plan
+        .allocations
+        .iter()
+        .map(|allocation| allocation.allocation_name.as_str())
+        .collect::<BTreeSet<_>>();
+    let allocations = database
+        .resource_allocations(&project.id, &resource.resource_name)?
+        .into_iter()
+        .filter(|allocation| {
+            allocation.track == resource.track
+                && desired_names.contains(allocation.allocation_name.as_str())
+        })
+        .collect();
+
+    Ok(allocations)
+}
+
+async fn stop_undemanded_catalog_runtimes(
+    paths: &PvPaths,
+    database: &mut Database,
+    catalog: &ManagedResourceRuntimeCatalog,
+    supervisor: &ProcessSupervisor,
+    demanded_tracks: &BTreeSet<(String, String)>,
+) -> Result<(), DaemonError> {
+    let tracks = database.managed_resource_tracks()?;
+
+    for track in tracks {
+        if !catalog.contains(&track.resource_name)
+            || track.usage_count > 0
+            || demanded_tracks.contains(&(track.resource_name.clone(), track.track.clone()))
+        {
+            continue;
+        }
+
+        let Some(adapter) = catalog.adapter(&track.resource_name) else {
+            continue;
+        };
+
+        stop_resource_runtime(paths, database, supervisor, adapter, &track).await?;
+    }
+
+    Ok(())
+}
+
+async fn stop_resource_runtime(
+    paths: &PvPaths,
+    database: &mut Database,
+    supervisor: &ProcessSupervisor,
+    adapter: &dyn ManagedResourceRuntimeAdapter,
+    track: &ManagedResourceTrackRecord,
+) -> Result<(), DaemonError> {
+    if let Some(adopted) = supervisor.adopt_recorded(
+        &paths.resource_pid(&track.resource_name, &track.track),
+        &paths.resource_runtime_metadata(&track.resource_name, &track.track),
+    )? {
+        adopted.stop(RESOURCE_STOP_GRACE_PERIOD).await?;
+    }
+    database.record_runtime_observed_snapshot(
+        RuntimeSubject::Resource {
+            name: track.resource_name.clone(),
+            track: track.track.clone(),
+        },
+        RuntimeObservedStatus::Stopped,
+        Some("Managed Resource runtime stopped; no Projects require this track"),
+    )?;
+    cleanup_resource_runtime(paths, database, adapter, track)?;
+
+    Ok(())
+}
+
+fn cleanup_resource_runtime(
+    paths: &PvPaths,
+    database: &mut Database,
+    adapter: &dyn ManagedResourceRuntimeAdapter,
+    track: &ManagedResourceTrackRecord,
+) -> Result<(), DaemonError> {
+    delete_optional_file(&paths.resource_pid(&track.resource_name, &track.track))?;
+    delete_optional_file(&paths.resource_runtime_metadata(&track.resource_name, &track.track))?;
+    delete_optional_file(&paths.resource_runtime_config(&track.resource_name, &track.track))?;
+
+    for port_spec in adapter.port_specs() {
+        database.release_port(PortOwner::Resource {
+            name: track.resource_name.clone(),
+            track: track.track.clone(),
+            port: port_spec.name.to_string(),
+        })?;
+    }
+
+    Ok(())
+}
+
+fn delete_optional_file(path: &Utf8Path) -> Result<(), DaemonError> {
+    match state::fs::delete_file(path) {
+        Ok(()) => Ok(()),
+        Err(StateError::Filesystem { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn local_loopback_port_available(port: u16) -> bool {
+    TcpListener::bind((RESOURCE_HOST, port)).is_ok()
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "Managed Resource artifact validation owns direct filesystem metadata checks"
+)]
+fn path_is_file(path: &Utf8Path) -> resources::Result<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(ResourcesError::Filesystem {
+            path: path.to_string(),
+            reason: source.to_string(),
+        }),
+    }
+}
+
+fn current_target_platform() -> resources::TargetPlatform {
+    if cfg!(target_arch = "aarch64") {
+        resources::TargetPlatform::DarwinArm64
+    } else {
+        resources::TargetPlatform::DarwinAmd64
+    }
+}
+
+#[cfg(test)]
+#[doc(hidden)]
+pub(crate) fn fake_runtime_catalog(
+    manifest_url: &str,
+) -> Result<ManagedResourceRuntimeCatalog, DaemonError> {
+    Ok(ManagedResourceRuntimeCatalog::with_adapter(
+        ManagedResourceInstallOptions {
+            manifest_url: manifest_url.to_string(),
+            target_platform: current_target_platform(),
+        },
+        fake::FakeMailpitRuntimeAdapter::new()?,
+    ))
+}
+
+#[cfg(test)]
+#[doc(hidden)]
+pub(crate) fn fake_unready_runtime_catalog(
+    manifest_url: &str,
+) -> Result<ManagedResourceRuntimeCatalog, DaemonError> {
+    Ok(ManagedResourceRuntimeCatalog::with_adapter(
+        ManagedResourceInstallOptions {
+            manifest_url: manifest_url.to_string(),
+            target_platform: current_target_platform(),
+        },
+        fake::FakeMailpitRuntimeAdapter::unready()?,
+    ))
+}

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__cached_fake_multi_port_runtime_stops_when_project_demand_is_removed.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__cached_fake_multi_port_runtime_stops_when_project_demand_is_removed.snap
@@ -1,0 +1,40 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    ManagedResourceTrackRecord {
+        resource_name: "mailpit",
+        track: "1.0",
+        desired_state: Installed,
+        installed_version: Some(
+            "1.0.0-pv1",
+        ),
+        current_artifact_path: Some(
+            "<tempdir>/home/.pv/resources/mailpit/1.0/releases/1.0.0-pv1",
+        ),
+        env: {
+            "dashboard_url": "http://127.0.0.1:<dashboard_port>",
+            "smtp_host": "127.0.0.1",
+            "smtp_port": "<smtp_port>",
+        },
+        usage_count: 0,
+        removal_prune: false,
+        removal_force: false,
+        updated_at: "<timestamp>",
+    },
+    [],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Stopped,
+            message: Some(
+                "Managed Resource runtime stopped; no Projects require this track",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demand_change_stops_previous_runtime_when_new_runtime_readiness_fails.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demand_change_stops_previous_runtime_when_new_runtime_readiness_fails.snap
@@ -3,7 +3,7 @@ source: crates/daemon/src/managed_resources/tests.rs
 expression: snapshot
 ---
 (
-    "Err(\n    ReadinessTimedOut {\n        check: \"tcp:127.0.0.1:<readiness_port>\",\n        timeout_ms: <timeout_ms>,\n        last_error: Some(\n            \"I/O error: Connection refused (os error <code>)\",\n        ),\n    },\n)",
+    "Err(\n    ReadinessTimedOut {\n        check: \"http:127.0.0.1:<readiness_port>/__pv_unready_fixture__\",\n        timeout_ms: <timeout_ms>,\n        last_error: Some(\n            \"I/O error: readiness unavailable\",\n        ),\n    },\n)",
     "# >>> PV MANAGED\nMAILPIT_DASHBOARD=http://127.0.0.1:<dashboard_port>\nMAIL_HOST=127.0.0.1\nMAIL_PORT=<smtp_port>\n# <<< PV MANAGED\n",
     ManagedResourceTrackRecord {
         resource_name: "mailpit",
@@ -80,7 +80,7 @@ expression: snapshot
             },
             status: Failed,
             message: Some(
-                "readiness check `tcp:127.0.0.1:<readiness_port>` timed out after 100ms; last error: Some(\"I/O error: Connection refused (os error <code>)\")",
+                "readiness check `http:127.0.0.1:<readiness_port>/__pv_unready_fixture__` timed out after 100ms; last error: Some(\"I/O error: readiness unavailable\")",
             ),
             observed_at: "<timestamp>",
         },

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demand_change_stops_previous_runtime_when_new_runtime_readiness_fails.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demand_change_stops_previous_runtime_when_new_runtime_readiness_fails.snap
@@ -1,0 +1,88 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    "Err(\n    ReadinessTimedOut {\n        check: \"tcp:127.0.0.1:<readiness_port>\",\n        timeout_ms: <timeout_ms>,\n        last_error: Some(\n            \"I/O error: Connection refused (os error <code>)\",\n        ),\n    },\n)",
+    "# >>> PV MANAGED\nMAILPIT_DASHBOARD=http://127.0.0.1:<dashboard_port>\nMAIL_HOST=127.0.0.1\nMAIL_PORT=<smtp_port>\n# <<< PV MANAGED\n",
+    ManagedResourceTrackRecord {
+        resource_name: "mailpit",
+        track: "1.0",
+        desired_state: Installed,
+        installed_version: Some(
+            "1.0.0-pv1",
+        ),
+        current_artifact_path: Some(
+            "<tempdir>/home/.pv/resources/mailpit/1.0/releases/1.0.0-pv1",
+        ),
+        env: {
+            "dashboard_url": "http://127.0.0.1:<dashboard_port>",
+            "smtp_host": "127.0.0.1",
+            "smtp_port": "<smtp_port>",
+        },
+        usage_count: 0,
+        removal_prune: false,
+        removal_force: false,
+        updated_at: "<timestamp>",
+    },
+    ManagedResourceTrackRecord {
+        resource_name: "mailpit",
+        track: "1.1",
+        desired_state: Installed,
+        installed_version: Some(
+            "1.0.0-pv1",
+        ),
+        current_artifact_path: Some(
+            "<tempdir>/home/.pv/resources/mailpit/1.1/releases/1.0.0-pv1",
+        ),
+        env: {},
+        usage_count: 1,
+        removal_prune: false,
+        removal_force: false,
+        updated_at: "<timestamp>",
+    },
+    [
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.1",
+                port: "dashboard",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.1",
+                port: "smtp",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+    ],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Stopped,
+            message: Some(
+                "Managed Resource runtime stopped; no Projects require this track",
+            ),
+            observed_at: "<timestamp>",
+        },
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.1",
+            },
+            status: Failed,
+            message: Some(
+                "readiness check `tcp:127.0.0.1:<readiness_port>` timed out after 100ms; last error: Some(\"I/O error: Connection refused (os error <code>)\")",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_removed_track_fails_without_starting_runtime.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_removed_track_fails_without_starting_runtime.snap
@@ -3,12 +3,12 @@ source: crates/daemon/src/managed_resources/tests.rs
 expression: snapshot
 ---
 (
-    "Err(\n    ReadinessTimedOut {\n        check: \"http:127.0.0.1:<readiness_port>/__pv_unready_fixture__\",\n        timeout_ms: <timeout_ms>,\n        last_error: Some(\n            \"I/O error: readiness unavailable\",\n        ),\n    },\n)",
+    "Err(\n    ManagedResourceTrackRemoved {\n        resource: \"mailpit\",\n        track: \"1.0\",\n    },\n)",
     None,
     ManagedResourceTrackRecord {
         resource_name: "mailpit",
         track: "1.0",
-        desired_state: Installed,
+        desired_state: Removed,
         installed_version: Some(
             "1.0.0-pv1",
         ),
@@ -18,7 +18,7 @@ expression: snapshot
         env: {},
         usage_count: 1,
         removal_prune: false,
-        removal_force: false,
+        removal_force: true,
         updated_at: "<timestamp>",
     },
     [
@@ -49,22 +49,17 @@ expression: snapshot
             },
             status: Failed,
             message: Some(
-                "readiness check `http:127.0.0.1:<readiness_port>/__pv_unready_fixture__` timed out after 100ms; last error: Some(\"I/O error: readiness unavailable\")",
+                "Managed Resource runtime `mailpit` track `1.0` is marked removed",
             ),
             observed_at: "<timestamp>",
         },
     ],
-    RuntimeFilePresence {
-        pid: false,
-        metadata: false,
-        config: false,
-    },
     Some(
         ProjectEnvObservedStateRecord {
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "readiness check `http:127.0.0.1:<readiness_port>/__pv_unready_fixture__` timed out after 100ms; last error: Some(\"I/O error: readiness unavailable\")",
+                "Managed Resource runtime `mailpit` track `1.0` is marked removed",
             ),
             observed_at: "<timestamp>",
             warnings: [],

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_cleans_runtime_files_when_process_exits_after_readiness.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_cleans_runtime_files_when_process_exits_after_readiness.snap
@@ -3,24 +3,8 @@ source: crates/daemon/src/managed_resources/tests.rs
 expression: snapshot
 ---
 (
-    "Err(\n    ReadinessTimedOut {\n        check: \"http:127.0.0.1:<readiness_port>/__pv_unready_fixture__\",\n        timeout_ms: <timeout_ms>,\n        last_error: Some(\n            \"I/O error: readiness unavailable\",\n        ),\n    },\n)",
+    "Err(\n    UnexpectedProtocolResponse {\n        reason: \"runtime `mailpit-1.0` exited before readiness was verified\",\n    },\n)",
     None,
-    ManagedResourceTrackRecord {
-        resource_name: "mailpit",
-        track: "1.0",
-        desired_state: Installed,
-        installed_version: Some(
-            "1.0.0-pv1",
-        ),
-        current_artifact_path: Some(
-            "<tempdir>/home/.pv/resources/mailpit/1.0/releases/1.0.0-pv1",
-        ),
-        env: {},
-        usage_count: 1,
-        removal_prune: false,
-        removal_force: false,
-        updated_at: "<timestamp>",
-    },
     [
         PortAssignment {
             owner: Resource {
@@ -49,7 +33,7 @@ expression: snapshot
             },
             status: Failed,
             message: Some(
-                "readiness check `http:127.0.0.1:<readiness_port>/__pv_unready_fixture__` timed out after 100ms; last error: Some(\"I/O error: readiness unavailable\")",
+                "daemon protocol error: runtime `mailpit-1.0` exited before readiness was verified",
             ),
             observed_at: "<timestamp>",
         },
@@ -64,7 +48,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "readiness check `http:127.0.0.1:<readiness_port>/__pv_unready_fixture__` timed out after 100ms; last error: Some(\"I/O error: readiness unavailable\")",
+                "daemon protocol error: runtime `mailpit-1.0` exited before readiness was verified",
             ),
             observed_at: "<timestamp>",
             warnings: [],

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_installs_fake_multi_port_runtime_from_cached_fixture_before_env_rendering.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_installs_fake_multi_port_runtime_from_cached_fixture_before_env_rendering.snap
@@ -1,0 +1,60 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    "# >>> PV MANAGED\nMAILPIT_DASHBOARD=http://127.0.0.1:<dashboard_port>\nMAIL_HOST=127.0.0.1\nMAIL_PORT=<smtp_port>\n# <<< PV MANAGED\n",
+    ManagedResourceTrackRecord {
+        resource_name: "mailpit",
+        track: "1.0",
+        desired_state: Installed,
+        installed_version: Some(
+            "1.0.0-pv1",
+        ),
+        current_artifact_path: Some(
+            "<tempdir>/home/.pv/resources/mailpit/1.0/releases/1.0.0-pv1",
+        ),
+        env: {
+            "dashboard_url": "http://127.0.0.1:<dashboard_port>",
+            "smtp_host": "127.0.0.1",
+            "smtp_port": "<smtp_port>",
+        },
+        usage_count: 1,
+        removal_prune: false,
+        removal_force: false,
+        updated_at: "<timestamp>",
+    },
+    [
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "dashboard",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "smtp",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+    ],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Running,
+            message: Some(
+                "Managed Resource runtime is ready",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_reassigns_persisted_port_when_non_pv_listener_occupies_it.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_reassigns_persisted_port_when_non_pv_listener_occupies_it.snap
@@ -1,0 +1,43 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    "Ok(\n    (),\n)",
+    Some(
+        "# >>> PV MANAGED\nMAILPIT_DASHBOARD=http://127.0.0.1:<dashboard_port>\nMAIL_HOST=127.0.0.1\nMAIL_PORT=<smtp_port>\n# <<< PV MANAGED\n",
+    ),
+    [
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "dashboard",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "smtp",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+    ],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Running,
+            message: Some(
+                "Managed Resource runtime is ready",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_records_failed_runtime_when_named_port_assignment_fails.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_records_failed_runtime_when_named_port_assignment_fails.snap
@@ -1,0 +1,33 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    "Err(\n    ManagedResourcePortNameReserved {\n        resource: \"mailpit\",\n        track: \"1.0\",\n        port: \"default\",\n    },\n)",
+    None,
+    [],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Failed,
+            message: Some(
+                "Managed Resource runtime `mailpit` track `1.0` uses reserved port name `default`",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+    Some(
+        ProjectEnvObservedStateRecord {
+            project_id: "<project_id>",
+            status: Failed,
+            message: Some(
+                "Managed Resource runtime `mailpit` track `1.0` uses reserved port name `default`",
+            ),
+            observed_at: "<timestamp>",
+            warnings: [],
+        },
+    ),
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_records_failed_runtime_when_readiness_fails_before_env_rendering.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_records_failed_runtime_when_readiness_fails_before_env_rendering.snap
@@ -1,0 +1,62 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    "Err(\n    ReadinessTimedOut {\n        check: \"tcp:127.0.0.1:<readiness_port>\",\n        timeout_ms: <timeout_ms>,\n        last_error: Some(\n            \"I/O error: Connection refused (os error <code>)\",\n        ),\n    },\n)",
+    None,
+    ManagedResourceTrackRecord {
+        resource_name: "mailpit",
+        track: "1.0",
+        desired_state: Installed,
+        installed_version: Some(
+            "1.0.0-pv1",
+        ),
+        current_artifact_path: Some(
+            "<tempdir>/home/.pv/resources/mailpit/1.0/releases/1.0.0-pv1",
+        ),
+        env: {},
+        usage_count: 1,
+        removal_prune: false,
+        removal_force: false,
+        updated_at: "<timestamp>",
+    },
+    [
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "dashboard",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "smtp",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+    ],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Failed,
+            message: Some(
+                "readiness check `tcp:127.0.0.1:<readiness_port>` timed out after 100ms; last error: Some(\"I/O error: Connection refused (os error <code>)\")",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+    RuntimeFilePresence {
+        pid: false,
+        metadata: false,
+        config: false,
+    },
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_records_failed_runtime_when_readiness_fails_before_env_rendering.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_records_failed_runtime_when_readiness_fails_before_env_rendering.snap
@@ -3,7 +3,7 @@ source: crates/daemon/src/managed_resources/tests.rs
 expression: snapshot
 ---
 (
-    "Err(\n    ReadinessTimedOut {\n        check: \"tcp:127.0.0.1:<readiness_port>\",\n        timeout_ms: <timeout_ms>,\n        last_error: Some(\n            \"I/O error: Connection refused (os error <code>)\",\n        ),\n    },\n)",
+    "Err(\n    ReadinessTimedOut {\n        check: \"http:127.0.0.1:<readiness_port>/__pv_unready_fixture__\",\n        timeout_ms: <timeout_ms>,\n        last_error: Some(\n            \"I/O error: readiness unavailable\",\n        ),\n    },\n)",
     None,
     ManagedResourceTrackRecord {
         resource_name: "mailpit",
@@ -49,7 +49,7 @@ expression: snapshot
             },
             status: Failed,
             message: Some(
-                "readiness check `tcp:127.0.0.1:<readiness_port>` timed out after 100ms; last error: Some(\"I/O error: Connection refused (os error <code>)\")",
+                "readiness check `http:127.0.0.1:<readiness_port>/__pv_unready_fixture__` timed out after 100ms; last error: Some(\"I/O error: readiness unavailable\")",
             ),
             observed_at: "<timestamp>",
         },

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_starts_fake_multi_port_runtime_before_env_rendering.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_starts_fake_multi_port_runtime_before_env_rendering.snap
@@ -1,0 +1,60 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    "# >>> PV MANAGED\nMAILPIT_DASHBOARD=http://127.0.0.1:<dashboard_port>\nMAIL_HOST=127.0.0.1\nMAIL_PORT=<smtp_port>\n# <<< PV MANAGED\n",
+    ManagedResourceTrackRecord {
+        resource_name: "mailpit",
+        track: "1.0",
+        desired_state: Installed,
+        installed_version: Some(
+            "1.0.0-pv1",
+        ),
+        current_artifact_path: Some(
+            "<tempdir>/home/.pv/resources/mailpit/1.0/releases/1.0.0-pv1",
+        ),
+        env: {
+            "dashboard_url": "http://127.0.0.1:<dashboard_port>",
+            "smtp_host": "127.0.0.1",
+            "smtp_port": "<smtp_port>",
+        },
+        usage_count: 1,
+        removal_prune: false,
+        removal_force: false,
+        updated_at: "<timestamp>",
+    },
+    [
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "dashboard",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "smtp",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+    ],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Running,
+            message: Some(
+                "Managed Resource runtime is ready",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__fake_multi_port_runtime_stops_when_project_demand_is_removed.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__fake_multi_port_runtime_stops_when_project_demand_is_removed.snap
@@ -1,0 +1,41 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    "# >>> PV MANAGED\nAPP_URL=https://acme.test\n# <<< PV MANAGED\n",
+    ManagedResourceTrackRecord {
+        resource_name: "mailpit",
+        track: "1.0",
+        desired_state: Installed,
+        installed_version: Some(
+            "1.0.0-pv1",
+        ),
+        current_artifact_path: Some(
+            "<tempdir>/home/.pv/resources/mailpit/1.0/releases/1.0.0-pv1",
+        ),
+        env: {
+            "dashboard_url": "http://127.0.0.1:<dashboard_port>",
+            "smtp_host": "127.0.0.1",
+            "smtp_port": "<smtp_port>",
+        },
+        usage_count: 0,
+        removal_prune: false,
+        removal_force: false,
+        updated_at: "<timestamp>",
+    },
+    [],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Stopped,
+            message: Some(
+                "Managed Resource runtime stopped; no Projects require this track",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__production_demanded_resource_without_adapter_fails_before_env_rendering.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__production_demanded_resource_without_adapter_fails_before_env_rendering.snap
@@ -1,0 +1,41 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    "Err(\n    UnsupportedManagedResourceRuntime {\n        resource: \"mailpit\",\n    },\n)",
+    None,
+    [
+        ProjectManagedResourceRecord {
+            project_id: "<project_id>",
+            resource_name: "mailpit",
+            track: "1.0",
+            created_at: "<timestamp>",
+            updated_at: "<timestamp>",
+        },
+    ],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Failed,
+            message: Some(
+                "Managed Resource runtime `mailpit` is not supported yet",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+    Some(
+        ProjectEnvObservedStateRecord {
+            project_id: "<project_id>",
+            status: Failed,
+            message: Some(
+                "Managed Resource runtime `mailpit` is not supported yet",
+            ),
+            observed_at: "<timestamp>",
+            warnings: [],
+        },
+    ),
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__system_resource_reconciliation_stops_unlinked_project_runtime.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__system_resource_reconciliation_stops_unlinked_project_runtime.snap
@@ -1,0 +1,45 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    ManagedResourceTrackRecord {
+        resource_name: "mailpit",
+        track: "1.0",
+        desired_state: Installed,
+        installed_version: Some(
+            "1.0.0-pv1",
+        ),
+        current_artifact_path: Some(
+            "<tempdir>/home/.pv/resources/mailpit/1.0/releases/1.0.0-pv1",
+        ),
+        env: {
+            "dashboard_url": "http://127.0.0.1:<dashboard_port>",
+            "smtp_host": "127.0.0.1",
+            "smtp_port": "<smtp_port>",
+        },
+        usage_count: 0,
+        removal_prune: false,
+        removal_force: false,
+        updated_at: "<timestamp>",
+    },
+    [],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mailpit",
+                track: "1.0",
+            },
+            status: Stopped,
+            message: Some(
+                "Managed Resource runtime stopped; no Projects require this track",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+    RuntimeFilePresence {
+        pid: false,
+        metadata: false,
+        config: false,
+    },
+)

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -1,0 +1,760 @@
+use std::os::unix::fs::PermissionsExt;
+
+use anyhow::{Result, bail};
+use camino::Utf8Path;
+use camino_tempfile::tempdir;
+use insta::{Settings, assert_debug_snapshot};
+use state::{
+    Database, LinkProjectInput, ProjectRecord, PvPaths, RuntimeObservedStatus, RuntimeSubject,
+    StateError,
+};
+
+const FAKE_MAILPIT_TRACK: &str = "1.0";
+const FAKE_MAILPIT_NEXT_TRACK: &str = "1.1";
+const FAKE_MAILPIT_ARTIFACT_VERSION: &str = "1.0.0-pv1";
+const FAKE_MAILPIT_ARCHIVE_FILE_NAME: &str = "mailpit-1.0.0-pv1-any.tar.gz";
+const OFFLINE_TEST_MANIFEST_URL: &str = "https://127.0.0.1:9/manifest.json";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RuntimeFilePresence {
+    pid: bool,
+    metadata: bool,
+    config: bool,
+}
+
+#[tokio::test]
+async fn demanded_resource_starts_fake_multi_port_runtime_before_env_rendering() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+
+    reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await?;
+    let started_snapshot = {
+        let database = Database::open(&paths)?;
+
+        (
+            read_dotenv(&project)?,
+            database.managed_resource_track("mailpit", FAKE_MAILPIT_TRACK)?,
+            database.assigned_ports()?,
+            database.runtime_observed_states()?,
+        )
+    };
+
+    write_project_config(
+        &project,
+        r#"env:
+  APP_URL: "${project_url}"
+"#,
+    )?;
+    reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await?;
+    let stopped_snapshot = {
+        let database = Database::open(&paths)?;
+
+        (
+            read_dotenv(&project)?,
+            database.managed_resource_track("mailpit", FAKE_MAILPIT_TRACK)?,
+            database.assigned_ports()?,
+            database.runtime_observed_states()?,
+        )
+    };
+
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "demanded_resource_starts_fake_multi_port_runtime_before_env_rendering",
+        started_snapshot,
+    )?;
+
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "fake_multi_port_runtime_stops_when_project_demand_is_removed",
+        stopped_snapshot,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn demanded_resource_installs_fake_multi_port_runtime_from_cached_fixture_before_env_rendering()
+-> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_fake_mailpit_cached_fixture(&paths, tempdir.path())?;
+
+    reconcile_project_env_with_fake_runtime_catalog_and_manifest_url(
+        &paths,
+        &project.id,
+        OFFLINE_TEST_MANIFEST_URL,
+    )
+    .await?;
+    let installed_snapshot = {
+        let database = Database::open(&paths)?;
+
+        (
+            read_dotenv(&project)?,
+            database.managed_resource_track("mailpit", FAKE_MAILPIT_TRACK)?,
+            database.assigned_ports()?,
+            database.runtime_observed_states()?,
+        )
+    };
+
+    write_project_config(
+        &project,
+        r#"env:
+  APP_URL: "${project_url}"
+"#,
+    )?;
+    reconcile_project_env_with_fake_runtime_catalog_and_manifest_url(
+        &paths,
+        &project.id,
+        OFFLINE_TEST_MANIFEST_URL,
+    )
+    .await?;
+    let stopped_snapshot = {
+        let database = Database::open(&paths)?;
+
+        (
+            database.managed_resource_track("mailpit", FAKE_MAILPIT_TRACK)?,
+            database.assigned_ports()?,
+            database.runtime_observed_states()?,
+        )
+    };
+
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "demanded_resource_installs_fake_multi_port_runtime_from_cached_fixture_before_env_rendering",
+        installed_snapshot,
+    )?;
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "cached_fake_multi_port_runtime_stops_when_project_demand_is_removed",
+        stopped_snapshot,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn demanded_resource_records_failed_runtime_when_readiness_fails_before_env_rendering()
+-> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_unready_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+
+    let result = reconcile_project_env_with_unready_fake_runtime_catalog(&paths, &project.id).await;
+    let failure_snapshot = {
+        let database = Database::open(&paths)?;
+        let runtime_states = database.runtime_observed_states()?;
+        let runtime_files = runtime_files_exist(&paths, FAKE_MAILPIT_TRACK)?;
+
+        (
+            format!("{result:#?}"),
+            read_optional_dotenv(&project)?,
+            database.managed_resource_track("mailpit", FAKE_MAILPIT_TRACK)?,
+            database.assigned_ports()?,
+            runtime_states.clone(),
+            runtime_files.clone(),
+        )
+    };
+
+    assert!(
+        result.is_err(),
+        "expected readiness failure, got {result:#?}"
+    );
+    assert_failed_mailpit_runtime(&failure_snapshot.4);
+    assert_eq!(
+        failure_snapshot.5,
+        RuntimeFilePresence {
+            pid: false,
+            metadata: false,
+            config: false,
+        },
+        "expected readiness failure cleanup to remove runtime files"
+    );
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "demanded_resource_records_failed_runtime_when_readiness_fails_before_env_rendering",
+        failure_snapshot,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn demand_change_stops_previous_runtime_when_new_runtime_readiness_fails() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+    reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await?;
+
+    write_project_config(
+        &project,
+        r#"mailpit:
+  version: "1.1"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_unready_fake_mailpit_artifact(&paths, FAKE_MAILPIT_NEXT_TRACK)?;
+
+    let result = reconcile_project_env_with_unready_fake_runtime_catalog(&paths, &project.id).await;
+    let failure_snapshot = {
+        let database = Database::open(&paths)?;
+        let runtime_states = database.runtime_observed_states()?;
+
+        (
+            format!("{result:#?}"),
+            read_dotenv(&project)?,
+            database.managed_resource_track("mailpit", FAKE_MAILPIT_TRACK)?,
+            database.managed_resource_track("mailpit", FAKE_MAILPIT_NEXT_TRACK)?,
+            database.assigned_ports()?,
+            runtime_states.clone(),
+        )
+    };
+    let previous_runtime_stopped = runtime_has_status(
+        &failure_snapshot.5,
+        FAKE_MAILPIT_TRACK,
+        RuntimeObservedStatus::Stopped,
+    );
+
+    if !previous_runtime_stopped {
+        write_project_config(
+            &project,
+            r#"env:
+  APP_URL: "${project_url}"
+"#,
+        )?;
+        let _cleanup_result =
+            reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await;
+    }
+
+    assert!(
+        result.is_err(),
+        "expected readiness failure, got {result:#?}"
+    );
+    assert_runtime_status(
+        &failure_snapshot.5,
+        FAKE_MAILPIT_TRACK,
+        RuntimeObservedStatus::Stopped,
+    );
+    assert_runtime_status(
+        &failure_snapshot.5,
+        FAKE_MAILPIT_NEXT_TRACK,
+        RuntimeObservedStatus::Failed,
+    );
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "demand_change_stops_previous_runtime_when_new_runtime_readiness_fails",
+        failure_snapshot,
+    )?;
+
+    Ok(())
+}
+
+async fn reconcile_project_env_with_fake_runtime_catalog(
+    paths: &PvPaths,
+    project_id: &str,
+) -> Result<()> {
+    reconcile_project_env_with_fake_runtime_catalog_and_manifest_url(
+        paths,
+        project_id,
+        super::DEFAULT_MANIFEST_URL,
+    )
+    .await
+}
+
+async fn reconcile_project_env_with_fake_runtime_catalog_and_manifest_url(
+    paths: &PvPaths,
+    project_id: &str,
+    manifest_url: &str,
+) -> Result<()> {
+    let catalog = super::fake_runtime_catalog(manifest_url)?;
+    let mut database = Database::open(paths)?;
+
+    crate::project_env::reconcile_project_env_with_catalog(
+        paths,
+        &mut database,
+        project_id,
+        &catalog,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn reconcile_project_env_with_unready_fake_runtime_catalog(
+    paths: &PvPaths,
+    project_id: &str,
+) -> Result<()> {
+    let catalog = super::fake_unready_runtime_catalog(super::DEFAULT_MANIFEST_URL)?;
+    let mut database = Database::open(paths)?;
+
+    crate::project_env::reconcile_project_env_with_catalog(
+        paths,
+        &mut database,
+        project_id,
+        &catalog,
+    )
+    .await?;
+
+    Ok(())
+}
+
+fn link_project(
+    paths: &PvPaths,
+    project_path: &Utf8Path,
+    primary_hostname: &str,
+    config_source: &str,
+) -> Result<ProjectRecord> {
+    let config_path = project_path.join("pv.yml");
+
+    state::fs::write_sensitive_file(&config_path, config_source)?;
+
+    let mut database = Database::open(paths)?;
+    let result = database.link_project(LinkProjectInput {
+        path: project_path.to_path_buf(),
+        original_path: project_path.to_path_buf(),
+        primary_hostname: primary_hostname.to_string(),
+        config_path,
+        desired_php_track: None,
+        additional_hostnames: Vec::new(),
+    })?;
+
+    Ok(result.project)
+}
+
+fn write_project_config(project: &ProjectRecord, config_source: &str) -> Result<()> {
+    state::fs::write_sensitive_file(&project.config_path, config_source)?;
+
+    Ok(())
+}
+
+fn read_dotenv(project: &ProjectRecord) -> Result<String> {
+    state::fs::read_to_string(&project.path.join(".env")).map_err(Into::into)
+}
+
+fn read_optional_dotenv(project: &ProjectRecord) -> Result<Option<String>> {
+    match state::fs::read_to_string(&project.path.join(".env")) {
+        Ok(content) => Ok(Some(content)),
+        Err(StateError::Filesystem { source, .. })
+            if source.kind() == std::io::ErrorKind::NotFound =>
+        {
+            Ok(None)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn seed_fake_mailpit_artifact(paths: &PvPaths, track: &str) -> Result<()> {
+    seed_fake_mailpit_artifact_with_script(paths, track, fake_mailpit_script())
+}
+
+fn seed_fake_mailpit_artifact_with_script(
+    paths: &PvPaths,
+    track: &str,
+    script: &str,
+) -> Result<()> {
+    let release_path = paths
+        .resources()
+        .join("mailpit")
+        .join(track)
+        .join(format!("releases/{FAKE_MAILPIT_ARTIFACT_VERSION}"));
+    let executable = release_path.join("bin/pv-fake-mailpit");
+
+    state::fs::write_sensitive_file(&executable, script)?;
+    set_executable(&executable)?;
+    let mut database = Database::open(paths)?;
+    database.record_managed_resource_track_installed(
+        "mailpit",
+        track,
+        FAKE_MAILPIT_ARTIFACT_VERSION,
+        &release_path,
+    )?;
+
+    Ok(())
+}
+
+fn seed_unready_fake_mailpit_artifact(paths: &PvPaths, track: &str) -> Result<()> {
+    seed_fake_mailpit_artifact_with_script(paths, track, unready_fake_mailpit_script())
+}
+
+fn seed_fake_mailpit_cached_fixture(paths: &PvPaths, tempdir: &Utf8Path) -> Result<()> {
+    let archive_path = tempdir.join(FAKE_MAILPIT_ARCHIVE_FILE_NAME);
+
+    create_fake_mailpit_archive(tempdir, &archive_path)?;
+    let sha256 = sha256_file(&archive_path)?;
+    let cache_path = paths
+        .downloads()
+        .join(format!("{sha256}-{FAKE_MAILPIT_ARCHIVE_FILE_NAME}"));
+
+    copy_file(&archive_path, &cache_path)?;
+    let size = file_size(&cache_path)?;
+    let manifest = fake_mailpit_manifest(&sha256, size);
+
+    state::fs::write_sensitive_file(&paths.downloads().join("manifest.json"), &manifest)?;
+
+    Ok(())
+}
+
+fn create_fake_mailpit_archive(tempdir: &Utf8Path, archive_path: &Utf8Path) -> Result<()> {
+    let archive_parent = tempdir.join("archive-root");
+    let root_name = format!("mailpit-{FAKE_MAILPIT_ARTIFACT_VERSION}");
+    let root = archive_parent.join(&root_name);
+    let executable = root.join("bin/pv-fake-mailpit");
+
+    state::fs::write_sensitive_file(&executable, fake_mailpit_script())?;
+    set_executable(&executable)?;
+    run_fixture_command(
+        "/usr/bin/tar",
+        &[
+            "-czf",
+            archive_path.as_str(),
+            "-C",
+            archive_parent.as_str(),
+            &root_name,
+        ],
+    )?;
+
+    Ok(())
+}
+
+fn fake_mailpit_manifest(sha256: &str, size: u64) -> String {
+    let dummy_sha256 = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    format!(
+        r#"{{
+  "schema_version": 1,
+  "minimum_pv_version": "0.1.0",
+  "resources": [
+    {{
+      "name": "mailpit",
+      "default_track": "{FAKE_MAILPIT_TRACK}",
+      "tracks": [
+        {{
+          "name": "{FAKE_MAILPIT_TRACK}",
+          "artifacts": [
+            {{
+              "artifact_version": "{FAKE_MAILPIT_ARTIFACT_VERSION}",
+              "upstream_version": "1.0.0",
+              "pv_build_revision": "1",
+              "platform": "any",
+              "url": "https://artifacts.example.test/{FAKE_MAILPIT_ARCHIVE_FILE_NAME}",
+              "sha256": "{sha256}",
+              "size": {size},
+              "published_at": "2026-06-08T00:00:00Z"
+            }}
+          ]
+        }}
+      ]
+    }},
+    {{
+      "name": "php",
+      "default_track": "8.4",
+      "tracks": [
+        {{
+          "name": "8.4",
+          "artifacts": [
+            {{
+              "artifact_version": "8.4.8-pv1",
+              "upstream_version": "8.4.8",
+              "pv_build_revision": "1",
+              "platform": "any",
+              "url": "https://artifacts.example.test/php-8.4.8-pv1-any.tar.gz",
+              "sha256": "{dummy_sha256}",
+              "size": 1,
+              "published_at": "2026-06-08T00:00:00Z"
+            }}
+          ]
+        }}
+      ]
+    }},
+    {{
+      "name": "frankenphp",
+      "default_track": "8.4",
+      "tracks": [
+        {{
+          "name": "8.4",
+          "artifacts": [
+            {{
+              "artifact_version": "8.4.8-pv1",
+              "upstream_version": "8.4.8",
+              "pv_build_revision": "1",
+              "platform": "any",
+              "url": "https://artifacts.example.test/frankenphp-8.4.8-pv1-any.tar.gz",
+              "sha256": "{dummy_sha256}",
+              "size": 1,
+              "published_at": "2026-06-08T00:00:00Z"
+            }}
+          ]
+        }}
+      ]
+    }}
+  ]
+}}
+"#
+    )
+}
+
+fn fake_mailpit_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+
+smtp_port="$1"
+dashboard_port="$2"
+
+python3 - "$smtp_port" "$dashboard_port" <<'PY'
+import http.server
+import signal
+import socketserver
+import sys
+import threading
+
+class SmtpHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        self.request.sendall(b"220 fake mailpit\r\n")
+
+class TcpServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+
+smtp = TcpServer(("127.0.0.1", int(sys.argv[1])), SmtpHandler)
+dashboard = http.server.ThreadingHTTPServer(("127.0.0.1", int(sys.argv[2])), http.server.SimpleHTTPRequestHandler)
+
+def stop(_signum, _frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGTERM, stop)
+signal.signal(signal.SIGINT, stop)
+
+threading.Thread(target=smtp.serve_forever, daemon=True).start()
+dashboard.serve_forever()
+PY
+"#
+}
+
+fn unready_fake_mailpit_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+
+stop() {
+  exit 0
+}
+
+trap stop TERM INT
+
+while true; do
+  sleep 1
+done
+"#
+}
+
+fn assert_with_normalized_runtime(
+    tempdir: &Utf8Path,
+    name: &'static str,
+    snapshot: impl std::fmt::Debug,
+) -> Result<()> {
+    let mut settings = Settings::clone_current();
+    settings.add_filter(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", "<timestamp>");
+    settings.add_filter(&regex_literal(tempdir.as_str()), "<tempdir>");
+    settings.add_filter(
+        r#"project_id: "[a-z0-9]{10}""#,
+        r#"project_id: "<project_id>""#,
+    );
+    settings.add_filter(
+        r"MAILPIT_DASHBOARD=http://127\.0\.0\.1:\d+",
+        "MAILPIT_DASHBOARD=http://127.0.0.1:<dashboard_port>",
+    );
+    settings.add_filter(r"MAIL_PORT=\d+", "MAIL_PORT=<smtp_port>");
+    settings.add_filter(
+        r#""dashboard_url": "http://127\.0\.0\.1:\d+""#,
+        r#""dashboard_url": "http://127.0.0.1:<dashboard_port>""#,
+    );
+    settings.add_filter(r#""smtp_port": "\d+""#, r#""smtp_port": "<smtp_port>""#);
+    settings.add_filter(r"tcp:127\.0\.0\.1:\d+", "tcp:127.0.0.1:<readiness_port>");
+    settings.add_filter(r"timeout_ms: \d+", "timeout_ms: <timeout_ms>");
+    settings.add_filter(r"os error \d+", "os error <code>");
+    settings.add_filter(r"port: \d+", "port: <port>");
+    settings.bind(|| {
+        assert_debug_snapshot!(name, snapshot);
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
+fn assert_failed_mailpit_runtime(states: &[state::RuntimeObservedStateRecord]) {
+    assert_runtime_status(states, FAKE_MAILPIT_TRACK, RuntimeObservedStatus::Failed);
+}
+
+fn assert_runtime_status(
+    states: &[state::RuntimeObservedStateRecord],
+    track: &str,
+    status: RuntimeObservedStatus,
+) {
+    let found = runtime_has_status(states, track, status);
+    assert!(
+        found,
+        "expected mailpit track {track:?} runtime status {status:?}, got {states:#?}"
+    );
+}
+
+fn runtime_has_status(
+    states: &[state::RuntimeObservedStateRecord],
+    track: &str,
+    status: RuntimeObservedStatus,
+) -> bool {
+    let expected_subject = RuntimeSubject::Resource {
+        name: "mailpit".to_string(),
+        track: track.to_string(),
+    };
+
+    states
+        .iter()
+        .any(|record| record.subject == expected_subject && record.status == status)
+}
+
+fn runtime_files_exist(paths: &PvPaths, track: &str) -> Result<RuntimeFilePresence> {
+    Ok(RuntimeFilePresence {
+        pid: path_exists(&paths.resource_pid("mailpit", track))?,
+        metadata: path_exists(&paths.resource_runtime_metadata("mailpit", track))?,
+        config: path_exists(&paths.resource_runtime_config("mailpit", track))?,
+    })
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "daemon runtime tests assert runtime file cleanup directly"
+)]
+fn path_exists(path: &Utf8Path) -> Result<bool> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn sha256_file(path: &Utf8Path) -> Result<String> {
+    let output = run_fixture_command("/usr/bin/shasum", &["-a", "256", path.as_str()])?;
+    let text = String::from_utf8(output)?;
+    let Some((sha256, _path)) = text.split_once(' ') else {
+        bail!("shasum output did not include a sha256 digest");
+    };
+
+    Ok(sha256.to_string())
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "daemon runtime tests shell out to build archive fixtures without extra dev-dependencies"
+)]
+fn run_fixture_command(program: &str, args: &[&str]) -> Result<Vec<u8>> {
+    let output = std::process::Command::new(program)
+        .env("COPYFILE_DISABLE", "1")
+        .args(args)
+        .output()?;
+    if !output.status.success() {
+        bail!(
+            "fixture command `{program}` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(output.stdout)
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "daemon runtime tests seed cached artifact fixtures directly"
+)]
+fn copy_file(from: &Utf8Path, to: &Utf8Path) -> Result<()> {
+    if let Some(parent) = to.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::copy(from, to)?;
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "daemon runtime tests read fixture archive metadata for manifest size"
+)]
+fn file_size(path: &Utf8Path) -> Result<u64> {
+    Ok(std::fs::metadata(path)?.len())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "daemon runtime tests set fixture executable bits directly"
+)]
+fn set_executable(path: &Utf8Path) -> Result<()> {
+    let mut permissions = std::fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions)?;
+
+    Ok(())
+}
+
+fn regex_literal(value: &str) -> String {
+    let mut literal = String::new();
+
+    for character in value.chars() {
+        if matches!(
+            character,
+            '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
+        ) {
+            literal.push('\\');
+        }
+        literal.push(character);
+    }
+
+    literal
+}

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -86,6 +86,63 @@ async fn demanded_resource_starts_fake_multi_port_runtime_before_env_rendering()
 }
 
 #[tokio::test]
+async fn system_resource_reconciliation_stops_unlinked_project_runtime() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+    reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await?;
+
+    let cleanup_snapshot = {
+        let mut database = Database::open(&paths)?;
+        database.unlink_project(&project.id)?;
+        let catalog = super::fake_runtime_catalog(super::DEFAULT_MANIFEST_URL)?;
+
+        super::reconcile_system_resources_with_catalog(&paths, &mut database, &catalog).await?;
+
+        (
+            database.managed_resource_track("mailpit", FAKE_MAILPIT_TRACK)?,
+            database.assigned_ports()?,
+            database.runtime_observed_states()?,
+            runtime_files_exist(&paths, FAKE_MAILPIT_TRACK)?,
+        )
+    };
+
+    assert_runtime_status(
+        &cleanup_snapshot.2,
+        FAKE_MAILPIT_TRACK,
+        RuntimeObservedStatus::Stopped,
+    );
+    assert_eq!(
+        cleanup_snapshot.3,
+        RuntimeFilePresence {
+            pid: false,
+            metadata: false,
+            config: false,
+        },
+        "expected system cleanup to remove runtime files"
+    );
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "system_resource_reconciliation_stops_unlinked_project_runtime",
+        cleanup_snapshot,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn demanded_resource_installs_fake_multi_port_runtime_from_cached_fixture_before_env_rendering()
 -> Result<()> {
     let tempdir = tempdir()?;

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::net::TcpListener;
 use std::os::unix::fs::PermissionsExt;
 
 use anyhow::{Result, bail};
@@ -6,8 +7,8 @@ use camino::Utf8Path;
 use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
 use state::{
-    Database, LinkProjectInput, ProjectRecord, PvPaths, RuntimeObservedStatus, RuntimeSubject,
-    StateError,
+    Database, LinkProjectInput, PortRequest, ProjectRecord, PvPaths, RuntimeObservedStatus,
+    RuntimeSubject, StateError,
 };
 
 use crate::{ReadinessCheck, managed_resources::ManagedResourceRuntimeAdapter};
@@ -42,7 +43,9 @@ async fn demanded_resource_starts_fake_multi_port_runtime_before_env_rendering()
 "#,
     )?;
     seed_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+    let mailpit_port_guards = seed_fake_mailpit_runtime_ports(&paths, FAKE_MAILPIT_TRACK)?;
 
+    drop(mailpit_port_guards);
     reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await?;
     let started_snapshot = {
         let database = Database::open(&paths)?;
@@ -131,6 +134,9 @@ async fn system_resource_reconciliation_stops_unlinked_project_runtime() -> Resu
 "#,
     )?;
     seed_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+    let mailpit_port_guards = seed_fake_mailpit_runtime_ports(&paths, FAKE_MAILPIT_TRACK)?;
+
+    drop(mailpit_port_guards);
     reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await?;
 
     let cleanup_snapshot = {
@@ -189,7 +195,9 @@ async fn demanded_resource_installs_fake_multi_port_runtime_from_cached_fixture_
 "#,
     )?;
     seed_fake_mailpit_cached_fixture(&paths, tempdir.path())?;
+    let mailpit_port_guards = seed_fake_mailpit_runtime_ports(&paths, FAKE_MAILPIT_TRACK)?;
 
+    drop(mailpit_port_guards);
     reconcile_project_env_with_fake_runtime_catalog_and_manifest_url(
         &paths,
         &project.id,
@@ -318,6 +326,9 @@ async fn demand_change_stops_previous_runtime_when_new_runtime_readiness_fails()
 "#,
     )?;
     seed_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+    let mailpit_port_guards = seed_fake_mailpit_runtime_ports(&paths, FAKE_MAILPIT_TRACK)?;
+
+    drop(mailpit_port_guards);
     reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await?;
 
     write_project_config(
@@ -511,6 +522,30 @@ fn seed_fake_mailpit_artifact_with_script(
 
 fn seed_unready_fake_mailpit_artifact(paths: &PvPaths, track: &str) -> Result<()> {
     seed_fake_mailpit_artifact_with_script(paths, track, unready_fake_mailpit_script())
+}
+
+fn seed_fake_mailpit_runtime_ports(paths: &PvPaths, track: &str) -> Result<[TcpListener; 2]> {
+    let smtp_guard = seed_fake_mailpit_runtime_port(paths, track, "smtp")?;
+    let dashboard_guard = seed_fake_mailpit_runtime_port(paths, track, "dashboard")?;
+
+    Ok([smtp_guard, dashboard_guard])
+}
+
+fn seed_fake_mailpit_runtime_port(
+    paths: &PvPaths,
+    track: &str,
+    port_name: &str,
+) -> Result<TcpListener> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let port = listener.local_addr()?.port();
+
+    let mut database = Database::open(paths)?;
+    database.assign_port(
+        PortRequest::resource_port("mailpit", track, port_name, port, port, port),
+        |candidate| candidate == port,
+    )?;
+
+    Ok(listener)
 }
 
 fn seed_fake_mailpit_cached_fixture(paths: &PvPaths, tempdir: &Utf8Path) -> Result<()> {

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -7,17 +7,29 @@ use camino::Utf8Path;
 use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
 use state::{
-    Database, LinkProjectInput, PortRequest, ProjectRecord, PvPaths, RuntimeObservedStatus,
-    RuntimeSubject, StateError,
+    Database, EnvContextValues, LinkProjectInput, PortRequest, ProjectRecord, PvPaths,
+    RuntimeObservedStatus, RuntimeSubject, StateError,
 };
 
-use crate::{ReadinessCheck, managed_resources::ManagedResourceRuntimeAdapter};
+use crate::{
+    DaemonError, ProcessSpec, ReadinessCheck, managed_resources::ManagedResourceRuntimeAdapter,
+};
 
 const FAKE_MAILPIT_TRACK: &str = "1.0";
 const FAKE_MAILPIT_NEXT_TRACK: &str = "1.1";
 const FAKE_MAILPIT_ARTIFACT_VERSION: &str = "1.0.0-pv1";
 const FAKE_MAILPIT_ARCHIVE_FILE_NAME: &str = "mailpit-1.0.0-pv1-any.tar.gz";
 const OFFLINE_TEST_MANIFEST_URL: &str = "https://127.0.0.1:9/manifest.json";
+const INVALID_DEFAULT_PORT_SPECS: &[super::ManagedResourcePortSpec] = &[
+    super::ManagedResourcePortSpec {
+        name: "smtp",
+        preferred_port: 1025,
+    },
+    super::ManagedResourcePortSpec {
+        name: "default",
+        preferred_port: 8025,
+    },
+];
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct RuntimeFilePresence {
@@ -138,6 +150,8 @@ async fn system_resource_reconciliation_stops_unlinked_project_runtime() -> Resu
 
     drop(mailpit_port_guards);
     reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await?;
+    let stale_port_guard = seed_fake_mailpit_runtime_port(&paths, FAKE_MAILPIT_TRACK, "obsolete")?;
+    drop(stale_port_guard);
 
     let cleanup_snapshot = {
         let mut database = Database::open(&paths)?;
@@ -172,6 +186,84 @@ async fn system_resource_reconciliation_stops_unlinked_project_runtime() -> Resu
         tempdir.path(),
         "system_resource_reconciliation_stops_unlinked_project_runtime",
         cleanup_snapshot,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn demanded_resource_reassigns_persisted_port_when_non_pv_listener_occupies_it() -> Result<()>
+{
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+    let stale_smtp_guard = seed_fake_mailpit_runtime_port(&paths, FAKE_MAILPIT_TRACK, "smtp")?;
+    let stale_smtp_port = stale_smtp_guard.local_addr()?.port();
+    let stale_dashboard_guard =
+        seed_fake_mailpit_runtime_port(&paths, FAKE_MAILPIT_TRACK, "dashboard")?;
+    let stale_dashboard_port = stale_dashboard_guard.local_addr()?.port();
+
+    let result = reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await;
+    let reassign_snapshot = {
+        let database = Database::open(&paths)?;
+
+        (
+            format!("{result:#?}"),
+            read_optional_dotenv(&project)?,
+            database.assigned_ports()?,
+            database.runtime_observed_states()?,
+        )
+    };
+    let stale_port_still_assigned = reassign_snapshot.2.iter().any(|assignment| {
+        matches!(
+            &assignment.owner,
+            state::PortOwner::Resource { name, track, port }
+                if name == "mailpit"
+                    && track == FAKE_MAILPIT_TRACK
+                    && ((port == "smtp" && assignment.port == stale_smtp_port)
+                        || (port == "dashboard" && assignment.port == stale_dashboard_port))
+        )
+    });
+
+    if result.is_ok() {
+        write_project_config(
+            &project,
+            r#"env:
+  APP_URL: "${project_url}"
+"#,
+        )?;
+        let _cleanup = reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await;
+    }
+
+    assert!(
+        result.is_ok(),
+        "expected occupied stale port to be reassigned, got {result:#?}"
+    );
+    assert!(
+        !stale_port_still_assigned,
+        "expected stale non-PV listener ports {stale_smtp_port} and {stale_dashboard_port} to be released"
+    );
+    assert_runtime_status(
+        &reassign_snapshot.3,
+        FAKE_MAILPIT_TRACK,
+        RuntimeObservedStatus::Running,
+    );
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "demanded_resource_reassigns_persisted_port_when_non_pv_listener_occupies_it",
+        reassign_snapshot,
     )?;
 
     Ok(())
@@ -283,6 +375,7 @@ async fn demanded_resource_records_failed_runtime_when_readiness_fails_before_en
             database.assigned_ports()?,
             runtime_states.clone(),
             runtime_files.clone(),
+            database.project_env_observed_state(&project.id)?,
         )
     };
 
@@ -303,6 +396,234 @@ async fn demanded_resource_records_failed_runtime_when_readiness_fails_before_en
     assert_with_normalized_runtime(
         tempdir.path(),
         "demanded_resource_records_failed_runtime_when_readiness_fails_before_env_rendering",
+        failure_snapshot,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn demanded_resource_cleans_runtime_files_when_process_exits_after_readiness() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_fast_exit_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+    let mailpit_port_guards = seed_fake_mailpit_runtime_ports(&paths, FAKE_MAILPIT_TRACK)?;
+
+    drop(mailpit_port_guards);
+    let result =
+        reconcile_project_env_with_fast_exit_fake_runtime_catalog(&paths, &project.id).await;
+    let failure_snapshot = {
+        let database = Database::open(&paths)?;
+        let runtime_states = database.runtime_observed_states()?;
+
+        (
+            format!("{result:#?}"),
+            read_optional_dotenv(&project)?,
+            database.assigned_ports()?,
+            runtime_states.clone(),
+            runtime_files_exist(&paths, FAKE_MAILPIT_TRACK)?,
+            database.project_env_observed_state(&project.id)?,
+        )
+    };
+
+    if result.is_ok() {
+        write_project_config(
+            &project,
+            r#"env:
+  APP_URL: "${project_url}"
+"#,
+        )?;
+        let _cleanup = reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await;
+    }
+
+    assert!(
+        result.is_err(),
+        "expected fast-exit runtime failure, got {result:#?}"
+    );
+    assert_failed_mailpit_runtime(&failure_snapshot.3);
+    assert_eq!(
+        failure_snapshot.4,
+        RuntimeFilePresence {
+            pid: false,
+            metadata: false,
+            config: false,
+        },
+        "expected fast-exit failure cleanup to remove runtime files"
+    );
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "demanded_resource_cleans_runtime_files_when_process_exits_after_readiness",
+        failure_snapshot,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn demanded_removed_track_fails_without_starting_runtime() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+    {
+        let mut database = Database::open(&paths)?;
+        database.record_managed_resource_track_removal_intent(
+            "mailpit",
+            FAKE_MAILPIT_TRACK,
+            false,
+            true,
+        )?;
+    }
+    let mailpit_port_guards = seed_fake_mailpit_runtime_ports(&paths, FAKE_MAILPIT_TRACK)?;
+
+    drop(mailpit_port_guards);
+    let result = reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await;
+    let failure_snapshot = {
+        let database = Database::open(&paths)?;
+        let runtime_states = database.runtime_observed_states()?;
+
+        (
+            format!("{result:#?}"),
+            read_optional_dotenv(&project)?,
+            database.managed_resource_track("mailpit", FAKE_MAILPIT_TRACK)?,
+            database.assigned_ports()?,
+            runtime_states.clone(),
+            database.project_env_observed_state(&project.id)?,
+        )
+    };
+
+    if result.is_ok() {
+        write_project_config(
+            &project,
+            r#"env:
+  APP_URL: "${project_url}"
+"#,
+        )?;
+        let _cleanup = reconcile_project_env_with_fake_runtime_catalog(&paths, &project.id).await;
+    }
+
+    assert!(
+        result.is_err(),
+        "expected removed track to fail before runtime start, got {result:#?}"
+    );
+    assert_failed_mailpit_runtime(&failure_snapshot.4);
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "demanded_removed_track_fails_without_starting_runtime",
+        failure_snapshot,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn demanded_resource_records_failed_runtime_when_named_port_assignment_fails() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+"#,
+    )?;
+    seed_fake_mailpit_artifact(&paths, FAKE_MAILPIT_TRACK)?;
+    let catalog = invalid_default_port_runtime_catalog()?;
+    let mut database = Database::open(&paths)?;
+
+    let result = crate::project_env::reconcile_project_env_with_catalog(
+        &paths,
+        &mut database,
+        &project.id,
+        &catalog,
+    )
+    .await;
+    let failure_snapshot = (
+        format!("{result:#?}"),
+        read_optional_dotenv(&project)?,
+        database.assigned_ports()?,
+        database.runtime_observed_states()?,
+        database.project_env_observed_state(&project.id)?,
+    );
+
+    assert!(
+        result.is_err(),
+        "expected named port assignment failure, got {result:#?}"
+    );
+    assert_eq!(
+        failure_snapshot.2,
+        Vec::new(),
+        "expected failed named port assignment to release earlier port rows"
+    );
+    assert_failed_mailpit_runtime(&failure_snapshot.3);
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "demanded_resource_records_failed_runtime_when_named_port_assignment_fails",
+        failure_snapshot,
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn production_demanded_resource_without_adapter_fails_before_env_rendering() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+"#,
+    )?;
+
+    let result = crate::project_env::reconcile_project_env(&paths, &project.id).await;
+    let failure_snapshot = {
+        let database = Database::open(&paths)?;
+
+        (
+            format!("{result:#?}"),
+            read_optional_dotenv(&project)?,
+            database.project_managed_resources(&project.id)?,
+            database.runtime_observed_states()?,
+            database.project_env_observed_state(&project.id)?,
+        )
+    };
+
+    assert!(
+        result.is_err(),
+        "expected unsupported production resource to fail, got {result:#?}"
+    );
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "production_demanded_resource_without_adapter_fails_before_env_rendering",
         failure_snapshot,
     )?;
 
@@ -446,6 +767,45 @@ async fn reconcile_project_env_with_unready_fake_runtime_catalog(
     Ok(())
 }
 
+async fn reconcile_project_env_with_fast_exit_fake_runtime_catalog(
+    paths: &PvPaths,
+    project_id: &str,
+) -> Result<()> {
+    let catalog = super::ManagedResourceRuntimeCatalog::with_adapter(
+        super::ManagedResourceInstallOptions {
+            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            target_platform: super::current_target_platform(),
+        },
+        super::fake::FakeMailpitRuntimeAdapter::exits_after_readiness()?,
+    );
+    let mut database = Database::open(paths)?;
+
+    crate::project_env::reconcile_project_env_with_catalog(
+        paths,
+        &mut database,
+        project_id,
+        &catalog,
+    )
+    .await?;
+
+    Ok(())
+}
+
+fn invalid_default_port_runtime_catalog() -> Result<super::ManagedResourceRuntimeCatalog> {
+    Ok(super::ManagedResourceRuntimeCatalog::with_adapter(
+        super::ManagedResourceInstallOptions {
+            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            target_platform: super::current_target_platform(),
+        },
+        InvalidDefaultPortRuntimeAdapter {
+            artifact_adapter: super::ManagedResourceArtifactAdapter::new(
+                "mailpit",
+                "bin/pv-fake-mailpit",
+            )?,
+        },
+    ))
+}
+
 fn link_project(
     paths: &PvPaths,
     project_path: &Utf8Path,
@@ -522,6 +882,10 @@ fn seed_fake_mailpit_artifact_with_script(
 
 fn seed_unready_fake_mailpit_artifact(paths: &PvPaths, track: &str) -> Result<()> {
     seed_fake_mailpit_artifact_with_script(paths, track, unready_fake_mailpit_script())
+}
+
+fn seed_fast_exit_fake_mailpit_artifact(paths: &PvPaths, track: &str) -> Result<()> {
+    seed_fake_mailpit_artifact_with_script(paths, track, fast_exit_fake_mailpit_script())
 }
 
 fn seed_fake_mailpit_runtime_ports(paths: &PvPaths, track: &str) -> Result<[TcpListener; 2]> {
@@ -717,6 +1081,34 @@ done
 "#
 }
 
+fn fast_exit_fake_mailpit_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+
+dashboard_port="$2"
+
+python3 - "$dashboard_port" <<'PY'
+import http.server
+import os
+import sys
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ready")
+        self.wfile.flush()
+        os._exit(0)
+
+    def log_message(self, _format, *_args):
+        pass
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), Handler)
+server.serve_forever()
+PY
+"#
+}
+
 fn assert_with_normalized_runtime(
     tempdir: &Utf8Path,
     name: &'static str,
@@ -886,4 +1278,51 @@ fn regex_literal(value: &str) -> String {
     }
 
     literal
+}
+
+#[derive(Clone, Debug)]
+struct InvalidDefaultPortRuntimeAdapter {
+    artifact_adapter: super::ManagedResourceArtifactAdapter,
+}
+
+impl ManagedResourceRuntimeAdapter for InvalidDefaultPortRuntimeAdapter {
+    fn resource_name(&self) -> &'static str {
+        "mailpit"
+    }
+
+    fn artifact_adapter(&self) -> Result<super::ManagedResourceArtifactAdapter, DaemonError> {
+        Ok(self.artifact_adapter.clone())
+    }
+
+    fn port_specs(&self) -> &'static [super::ManagedResourcePortSpec] {
+        INVALID_DEFAULT_PORT_SPECS
+    }
+
+    fn build_process_spec(
+        &self,
+        _paths: &PvPaths,
+        _context: &super::ManagedResourceRuntimeContext,
+    ) -> Result<ProcessSpec, DaemonError> {
+        Err(DaemonError::UnexpectedProtocolResponse {
+            reason: "invalid default-port test adapter should fail during port assignment"
+                .to_string(),
+        })
+    }
+
+    fn readiness(
+        &self,
+        _context: &super::ManagedResourceRuntimeContext,
+    ) -> Result<ReadinessCheck, DaemonError> {
+        Err(DaemonError::UnexpectedProtocolResponse {
+            reason: "invalid default-port test adapter should fail during port assignment"
+                .to_string(),
+        })
+    }
+
+    fn resource_env(
+        &self,
+        _context: &super::ManagedResourceRuntimeContext,
+    ) -> Result<EnvContextValues, DaemonError> {
+        Ok(BTreeMap::new())
+    }
 }

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::os::unix::fs::PermissionsExt;
 
 use anyhow::{Result, bail};
@@ -8,6 +9,8 @@ use state::{
     Database, LinkProjectInput, ProjectRecord, PvPaths, RuntimeObservedStatus, RuntimeSubject,
     StateError,
 };
+
+use crate::{ReadinessCheck, managed_resources::ManagedResourceRuntimeAdapter};
 
 const FAKE_MAILPIT_TRACK: &str = "1.0";
 const FAKE_MAILPIT_NEXT_TRACK: &str = "1.1";
@@ -81,6 +84,32 @@ async fn demanded_resource_starts_fake_multi_port_runtime_before_env_rendering()
         "fake_multi_port_runtime_stops_when_project_demand_is_removed",
         stopped_snapshot,
     )?;
+
+    Ok(())
+}
+
+#[test]
+fn unready_fake_runtime_uses_http_readiness_to_avoid_parallel_tcp_collisions() -> Result<()> {
+    let adapter = super::fake::FakeMailpitRuntimeAdapter::unready()?;
+    let context = super::ManagedResourceRuntimeContext {
+        resource_name: "mailpit".to_string(),
+        track: FAKE_MAILPIT_TRACK.to_string(),
+        artifact_path: "/pv/fake/mailpit".into(),
+        data_dir: "/pv/fake/data".into(),
+        ports: BTreeMap::from([
+            ("smtp".to_string(), 18025),
+            ("dashboard".to_string(), 18026),
+        ]),
+    };
+
+    assert_eq!(
+        adapter.readiness(&context)?,
+        ReadinessCheck::Http {
+            host: super::RESOURCE_HOST.to_string(),
+            port: 18026,
+            path: "/__pv_unready_fixture__".to_string(),
+        }
+    );
 
     Ok(())
 }
@@ -676,8 +705,16 @@ fn assert_with_normalized_runtime(
     );
     settings.add_filter(r#""smtp_port": "\d+""#, r#""smtp_port": "<smtp_port>""#);
     settings.add_filter(r"tcp:127\.0\.0\.1:\d+", "tcp:127.0.0.1:<readiness_port>");
+    settings.add_filter(
+        r"http:127\.0\.0\.1:\d+/__pv_unready_fixture__",
+        "http:127.0.0.1:<readiness_port>/__pv_unready_fixture__",
+    );
     settings.add_filter(r"timeout_ms: \d+", "timeout_ms: <timeout_ms>");
     settings.add_filter(r"os error \d+", "os error <code>");
+    settings.add_filter(
+        r"I/O error: Connection refused \(os error <code>\)|I/O error: HTTP readiness returned non-success status",
+        "I/O error: readiness unavailable",
+    );
     settings.add_filter(r"port: \d+", "port: <port>");
     settings.bind(|| {
         assert_debug_snapshot!(name, snapshot);

--- a/crates/daemon/src/project_env.rs
+++ b/crates/daemon/src/project_env.rs
@@ -16,6 +16,7 @@ use state::{
 };
 
 use crate::DaemonError;
+use crate::managed_resources::ManagedResourceRuntimeCatalog;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ProjectEnvReconciliationSummary {
@@ -23,15 +24,15 @@ pub(crate) struct ProjectEnvReconciliationSummary {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct ProjectResourcePlan {
-    resources: Vec<ProjectManagedResourceInput>,
-    allocations: BTreeMap<String, ProjectResourceAllocationPlan>,
+pub(crate) struct ProjectResourcePlan {
+    pub(crate) resources: Vec<ProjectManagedResourceInput>,
+    pub(crate) allocations: BTreeMap<String, ProjectResourceAllocationPlan>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct ProjectResourceAllocationPlan {
-    track: String,
-    allocations: Vec<ResourceAllocationInput>,
+pub(crate) struct ProjectResourceAllocationPlan {
+    pub(crate) track: String,
+    pub(crate) allocations: Vec<ResourceAllocationInput>,
 }
 
 impl ProjectEnvReconciliationSummary {
@@ -40,7 +41,7 @@ impl ProjectEnvReconciliationSummary {
     }
 }
 
-pub(crate) fn reconcile_project_env(
+pub(crate) async fn reconcile_project_env(
     paths: &PvPaths,
     project_id: &str,
 ) -> Result<ProjectEnvReconciliationSummary, DaemonError> {
@@ -52,11 +53,36 @@ pub(crate) fn reconcile_project_env(
                 target: project_id.to_string(),
             })?;
 
-    match reconcile_loaded_project(paths, &mut database, &project) {
+    match reconcile_loaded_project(paths, &mut database, &project, None).await {
         Ok(summary) => Ok(summary),
         Err(error) => {
             let message = error.to_string();
             record_project_env_failure(&mut database, &project.id, &message)?;
+
+            Err(error)
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) async fn reconcile_project_env_with_catalog(
+    paths: &PvPaths,
+    database: &mut Database,
+    project_id: &str,
+    catalog: &ManagedResourceRuntimeCatalog,
+) -> Result<ProjectEnvReconciliationSummary, DaemonError> {
+    let project =
+        database
+            .project_by_id(project_id)?
+            .ok_or_else(|| StateError::ProjectNotFound {
+                target: project_id.to_string(),
+            })?;
+
+    match reconcile_loaded_project(paths, database, &project, Some(catalog)).await {
+        Ok(summary) => Ok(summary),
+        Err(error) => {
+            let message = error.to_string();
+            record_project_env_failure(database, &project.id, &message)?;
 
             Err(error)
         }
@@ -74,10 +100,11 @@ pub(crate) fn validate_project_config_for_gateway(
     Ok(())
 }
 
-fn reconcile_loaded_project(
+async fn reconcile_loaded_project(
     paths: &PvPaths,
     database: &mut Database,
     project: &ProjectRecord,
+    catalog: Option<&ManagedResourceRuntimeCatalog>,
 ) -> Result<ProjectEnvReconciliationSummary, DaemonError> {
     let config_file = ProjectConfigFile::read_from_root(&project.path)?;
     let plan = validate_project_config_and_plan(paths, database, project, &config_file)?;
@@ -86,6 +113,15 @@ fn reconcile_loaded_project(
     let has_env_mappings = config_file.config.has_env_mappings();
 
     apply_project_resource_plan(database, &project.id, &plan)?;
+    if let Some(catalog) = catalog {
+        crate::managed_resources::reconcile_project_resources_with_catalog(
+            paths, database, project, &plan, catalog,
+        )
+        .await?;
+    } else {
+        crate::managed_resources::reconcile_project_resources(paths, database, project, &plan)
+            .await?;
+    }
     if project.desired_php_track.as_deref() != resolved_php_track.as_deref() {
         database.replace_project_desired_php_track(&project.id, resolved_php_track.as_deref())?;
     }

--- a/crates/daemon/src/project_env.rs
+++ b/crates/daemon/src/project_env.rs
@@ -31,7 +31,6 @@ pub(crate) struct ProjectResourcePlan {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct ProjectResourceAllocationPlan {
-    pub(crate) track: String,
     pub(crate) allocations: Vec<ResourceAllocationInput>,
 }
 
@@ -256,7 +255,7 @@ fn project_resource_plan(
 
         allocation_plans.insert(
             resource.clone(),
-            ProjectResourceAllocationPlan { track, allocations },
+            ProjectResourceAllocationPlan { allocations },
         );
     }
 
@@ -354,7 +353,7 @@ fn apply_project_resource_plan(
         database.replace_project_resource_allocations(
             project_id,
             &resource.resource_name,
-            &allocation_plan.track,
+            &resource.track,
             &allocation_plan.allocations,
         )?;
     }

--- a/crates/daemon/tests/snapshots/daemon_foundation__valid_reconciliation_scopes_stream_stub_completion.snap
+++ b/crates/daemon/tests/snapshots/daemon_foundation__valid_reconciliation_scopes_stream_stub_completion.snap
@@ -19,17 +19,17 @@ expression: snapshot
         },
         Object {
             "job_id": String("job_000001"),
-            "message": String("stub job started"),
+            "message": String("Managed Resource runtime reconciliation started"),
             "type": String("log"),
         },
         Object {
             "job_id": String("job_000001"),
-            "message": String("stub job completed without reconciliation work"),
+            "message": String("Managed Resource mysql track 8.4 reconciled"),
             "type": String("progress"),
         },
         Object {
             "job_id": String("job_000001"),
-            "summary": String("stub job completed"),
+            "summary": String("Managed Resource mysql track 8.4 reconciled"),
             "type": String("job_completed"),
         },
     ],
@@ -44,7 +44,7 @@ expression: snapshot
                 "<timestamp>",
             ),
             summary: Some(
-                "stub job completed",
+                "Managed Resource mysql track 8.4 reconciled",
             ),
             error: None,
         },

--- a/crates/daemon/tests/snapshots/daemon_foundation__valid_reconciliation_scopes_stream_stub_completion.snap
+++ b/crates/daemon/tests/snapshots/daemon_foundation__valid_reconciliation_scopes_stream_stub_completion.snap
@@ -24,12 +24,12 @@ expression: snapshot
         },
         Object {
             "job_id": String("job_000001"),
-            "message": String("Managed Resource mysql track 8.4 reconciled"),
+            "message": String("Managed Resource mysql track 8.4 standalone reconciliation deferred"),
             "type": String("progress"),
         },
         Object {
             "job_id": String("job_000001"),
-            "summary": String("Managed Resource mysql track 8.4 reconciled"),
+            "summary": String("Managed Resource mysql track 8.4 standalone reconciliation deferred"),
             "type": String("job_completed"),
         },
     ],
@@ -44,7 +44,7 @@ expression: snapshot
                 "<timestamp>",
             ),
             summary: Some(
-                "Managed Resource mysql track 8.4 reconciled",
+                "Managed Resource mysql track 8.4 standalone reconciliation deferred",
             ),
             error: None,
         },

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__first_allocation_reconciliation_records_desired_state_before_context_failure.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__first_allocation_reconciliation_records_desired_state_before_context_failure.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Project config error: missing Project env context for allocation `mysql.app-db`"),
+            "error": String("Managed Resource runtime `mysql` is not supported yet"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -57,7 +57,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Project config error: missing Project env context for allocation `mysql.app-db`",
+                "Managed Resource runtime `mysql` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -74,7 +74,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Project config error: missing Project env context for allocation `mysql.app-db`",
+            "Managed Resource runtime `mysql` is not supported yet",
         ),
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__missing_context_leaves_dotenv_unchanged_and_records_failure.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__missing_context_leaves_dotenv_unchanged_and_records_failure.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Project config error: missing Project env context for resource `mysql`"),
+            "error": String("Managed Resource runtime `mysql` is not supported yet"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -34,7 +34,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Project config error: missing Project env context for resource `mysql`",
+                "Managed Resource runtime `mysql` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -51,7 +51,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Project config error: missing Project env context for resource `mysql`",
+            "Managed Resource runtime `mysql` is not supported yet",
         ),
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_without_mappings_updates_state_without_dotenv.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_without_mappings_updates_state_without_dotenv.snap
@@ -23,14 +23,9 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
+            "error": String("Managed Resource runtime `mysql` is not supported yet"),
             "job_id": String("job_000001"),
-            "message": String("Project env unchanged; no mappings configured"),
-            "type": String("progress"),
-        },
-        Object {
-            "job_id": String("job_000001"),
-            "summary": String("Project env unchanged; no mappings configured"),
-            "type": String("job_completed"),
+            "type": String("job_failed"),
         },
     ],
     None,
@@ -47,9 +42,9 @@ expression: snapshot
     Some(
         ProjectEnvObservedStateRecord {
             project_id: "<project_id>",
-            status: Rendered,
+            status: Failed,
             message: Some(
-                "no Project env mappings configured",
+                "Managed Resource runtime `mysql` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -59,14 +54,14 @@ expression: snapshot
         id: "job_000001",
         kind: "reconcile",
         scope: "project:<project_id>",
-        status: Succeeded,
+        status: Failed,
         started_at: "<timestamp>",
         finished_at: Some(
             "<timestamp>",
         ),
-        summary: Some(
-            "Project env unchanged; no mappings configured",
+        summary: None,
+        error: Some(
+            "Managed Resource runtime `mysql` is not supported yet",
         ),
-        error: None,
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__resources_and_empty_allocations_without_env_mappings_update_state_without_dotenv.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__resources_and_empty_allocations_without_env_mappings_update_state_without_dotenv.snap
@@ -23,14 +23,9 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
+            "error": String("Managed Resource runtime `mysql` is not supported yet"),
             "job_id": String("job_000001"),
-            "message": String("Project env unchanged; no mappings configured"),
-            "type": String("progress"),
-        },
-        Object {
-            "job_id": String("job_000001"),
-            "summary": String("Project env unchanged; no mappings configured"),
-            "type": String("job_completed"),
+            "type": String("job_failed"),
         },
     ],
     None,
@@ -60,9 +55,9 @@ expression: snapshot
     Some(
         ProjectEnvObservedStateRecord {
             project_id: "<project_id>",
-            status: Rendered,
+            status: Failed,
             message: Some(
-                "no Project env mappings configured",
+                "Managed Resource runtime `mysql` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -72,14 +67,14 @@ expression: snapshot
         id: "job_000001",
         kind: "reconcile",
         scope: "project:<project_id>",
-        status: Succeeded,
+        status: Failed,
         started_at: "<timestamp>",
         finished_at: Some(
             "<timestamp>",
         ),
-        summary: Some(
-            "Project env unchanged; no mappings configured",
+        summary: None,
+        error: Some(
+            "Managed Resource runtime `mysql` is not supported yet",
         ),
-        error: None,
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__root_env_with_resource_waits_for_resource_context_before_dotenv.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__root_env_with_resource_waits_for_resource_context_before_dotenv.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Project config error: missing Project env context for resource `mysql`"),
+            "error": String("Managed Resource runtime `mysql` is not supported yet"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -43,7 +43,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Project config error: missing Project env context for resource `mysql`",
+                "Managed Resource runtime `mysql` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -60,7 +60,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Project config error: missing Project env context for resource `mysql`",
+            "Managed Resource runtime `mysql` is not supported yet",
         ),
     },
 )

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -95,8 +95,14 @@ pub enum GatewayPort {
 pub enum PortOwner {
     Dns,
     Gateway(GatewayPort),
-    PhpWorker { php_track: String },
-    Resource { name: String, track: String },
+    PhpWorker {
+        php_track: String,
+    },
+    Resource {
+        name: String,
+        track: String,
+        port: String,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -288,6 +294,7 @@ pub struct ProjectEnvObservedStateRecord {
 pub enum RuntimeSubject {
     Gateway,
     PhpWorker { php_track: String },
+    Resource { name: String, track: String },
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -322,6 +329,7 @@ struct PortAssignmentRow {
     owner_kind: String,
     owner_id: String,
     owner_track: String,
+    owner_port: String,
     port: u16,
     updated_at: String,
 }
@@ -396,6 +404,7 @@ struct PortIdentity {
     owner_kind: &'static str,
     owner_id: String,
     owner_track: String,
+    owner_port: String,
 }
 
 impl Database {
@@ -1539,21 +1548,55 @@ impl Database {
 
     pub fn release_port(&mut self, owner: PortOwner) -> Result<bool, StateError> {
         let identity = owner.identity()?;
-        let deleted = self.connection.execute(
-            "DELETE FROM ports WHERE owner_kind = ?1 AND owner_id = ?2 AND owner_track = ?3",
-            params![
-                identity.owner_kind,
-                identity.owner_id.as_str(),
-                identity.owner_track.as_str(),
-            ],
-        )?;
+        let deleted = if identity.uses_resource_ports_table() {
+            self.connection.execute(
+                "DELETE FROM resource_ports
+                WHERE resource_name = ?1
+                AND track = ?2
+                AND port_name = ?3",
+                params![
+                    identity.owner_id.as_str(),
+                    identity.owner_track.as_str(),
+                    identity.owner_port.as_str(),
+                ],
+            )?
+        } else {
+            self.connection.execute(
+                "DELETE FROM ports
+                WHERE owner_kind = ?1
+                AND owner_id = ?2
+                AND owner_track = ?3",
+                params![
+                    identity.owner_kind,
+                    identity.owner_id.as_str(),
+                    identity.owner_track.as_str(),
+                ],
+            )?
+        };
 
         Ok(deleted > 0)
     }
 
     pub fn assigned_ports(&self) -> Result<Vec<PortAssignment>, StateError> {
         let mut statement = self.connection.prepare(
-            "SELECT owner_kind, owner_id, owner_track, port, updated_at FROM ports ORDER BY owner_kind, owner_id, owner_track",
+            "SELECT
+                owner_kind,
+                owner_id,
+                owner_track,
+                CASE owner_kind WHEN 'resource' THEN 'default' ELSE '' END AS owner_port,
+                port,
+                updated_at
+            FROM ports
+            UNION ALL
+            SELECT
+                'resource' AS owner_kind,
+                resource_name AS owner_id,
+                track AS owner_track,
+                port_name AS owner_port,
+                port,
+                updated_at
+            FROM resource_ports
+            ORDER BY owner_kind, owner_id, owner_track, owner_port",
         )?;
         let rows = statement.query_map([], port_assignment_from_row)?;
         let mut assignments = Vec::new();
@@ -1747,10 +1790,29 @@ impl PortRequest {
         fallback_start: u16,
         fallback_end: u16,
     ) -> Self {
+        Self::resource_port(
+            name,
+            track,
+            "default",
+            preferred_port,
+            fallback_start,
+            fallback_end,
+        )
+    }
+
+    pub fn resource_port(
+        name: impl Into<String>,
+        track: impl Into<String>,
+        port: impl Into<String>,
+        preferred_port: u16,
+        fallback_start: u16,
+        fallback_end: u16,
+    ) -> Self {
         Self::new(
             PortOwner::Resource {
                 name: name.into(),
                 track: track.into(),
+                port: port.into(),
             },
             preferred_port,
             fallback_start,
@@ -1796,11 +1858,13 @@ impl PortOwner {
                 owner_kind: "dns",
                 owner_id: "dns".to_string(),
                 owner_track: String::new(),
+                owner_port: String::new(),
             }),
             Self::Gateway(gateway_port) => Ok(PortIdentity {
                 owner_kind: "gateway",
                 owner_id: gateway_port.as_str().to_string(),
                 owner_track: String::new(),
+                owner_port: String::new(),
             }),
             Self::PhpWorker { php_track } => {
                 validate_concrete_track(php_track)?;
@@ -1809,16 +1873,19 @@ impl PortOwner {
                     owner_kind: "php_worker",
                     owner_id: "php".to_string(),
                     owner_track: php_track.clone(),
+                    owner_port: String::new(),
                 })
             }
-            Self::Resource { name, track } => {
-                self.validate_component("name", name)?;
-                self.validate_component("track", track)?;
+            Self::Resource { name, track, port } => {
+                validate_managed_resource_identity("name", name)?;
+                validate_concrete_track(track)?;
+                validate_managed_resource_identity("port", port)?;
 
                 Ok(PortIdentity {
                     owner_kind: "resource",
                     owner_id: name.clone(),
                     owner_track: track.clone(),
+                    owner_port: port.clone(),
                 })
             }
         }
@@ -1828,53 +1895,52 @@ impl PortOwner {
         owner_kind: String,
         owner_id: String,
         owner_track: String,
+        owner_port: String,
     ) -> Result<Self, StateError> {
         match owner_kind.as_str() {
-            "dns" if owner_id == "dns" && owner_track.is_empty() => Ok(Self::Dns),
+            "dns" if owner_id == "dns" && owner_track.is_empty() && owner_port.is_empty() => {
+                Ok(Self::Dns)
+            }
             "dns" => Err(StateError::InvalidPortOwner {
-                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track),
-                reason: "dns ports must use owner id `dns` and an empty owner track",
+                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track, &owner_port),
+                reason: "dns ports must use owner id `dns` with empty owner track and port",
             }),
-            "gateway" if owner_track.is_empty() => {
+            "gateway" if owner_track.is_empty() && owner_port.is_empty() => {
                 GatewayPort::from_database(&owner_id).map(Self::Gateway)
             }
             "gateway" => Err(StateError::InvalidPortOwner {
-                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track),
-                reason: "gateway ports must use owner id `http` or `https` and an empty owner track",
+                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track, &owner_port),
+                reason: "gateway ports must use owner id `http` or `https` with empty owner track and port",
             }),
-            "php_worker" if owner_id == "php" && !owner_track.is_empty() => Ok(Self::PhpWorker {
-                php_track: owner_track,
-            }),
+            "php_worker"
+                if owner_id == "php" && !owner_track.is_empty() && owner_port.is_empty() =>
+            {
+                Ok(Self::PhpWorker {
+                    php_track: owner_track,
+                })
+            }
             "php_worker" => Err(StateError::InvalidPortOwner {
-                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track),
-                reason: "php worker ports must use owner id `php` and include a php track",
+                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track, &owner_port),
+                reason: "php worker ports must use owner id `php`, include a php track, and use an empty owner port",
             }),
-            "resource" if !owner_id.is_empty() && !owner_track.is_empty() => Ok(Self::Resource {
-                name: owner_id,
-                track: owner_track,
-            }),
+            "resource"
+                if !owner_id.is_empty() && !owner_track.is_empty() && !owner_port.is_empty() =>
+            {
+                let owner = Self::Resource {
+                    name: owner_id,
+                    track: owner_track,
+                    port: owner_port,
+                };
+                owner.identity()?;
+
+                Ok(owner)
+            }
             "resource" => Err(StateError::InvalidPortOwner {
-                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track),
-                reason: "resource ports must include a resource name and track",
+                owner: describe_port_identity(&owner_kind, &owner_id, &owner_track, &owner_port),
+                reason: "resource ports must include a resource name, track, and port",
             }),
             _ => Err(StateError::UnknownPortOwnerKind { owner_kind }),
         }
-    }
-
-    fn validate_component(&self, component: &'static str, value: &str) -> Result<(), StateError> {
-        if value.is_empty() {
-            return Err(StateError::InvalidPortOwner {
-                owner: self.display_name(),
-                reason: match component {
-                    "php_track" => "php worker port owner php track must not be empty",
-                    "name" => "resource port owner name must not be empty",
-                    "track" => "resource port owner track must not be empty",
-                    _ => "port owner component must not be empty",
-                },
-            });
-        }
-
-        Ok(())
     }
 
     fn display_name(&self) -> String {
@@ -1882,7 +1948,9 @@ impl PortOwner {
             Self::Dns => "dns".to_string(),
             Self::Gateway(gateway_port) => format!("gateway {}", gateway_port.as_str()),
             Self::PhpWorker { php_track } => format!("php worker {php_track:?}"),
-            Self::Resource { name, track } => format!("resource {name:?} track {track:?}"),
+            Self::Resource { name, track, port } => {
+                format!("resource {name:?} track {track:?} port {port:?}")
+            }
         }
     }
 }
@@ -1909,7 +1977,12 @@ impl GatewayPort {
 
 impl PortAssignmentRow {
     fn into_assignment(self) -> Result<PortAssignment, StateError> {
-        let owner = PortOwner::from_database(self.owner_kind, self.owner_id, self.owner_track)?;
+        let owner = PortOwner::from_database(
+            self.owner_kind,
+            self.owner_id,
+            self.owner_track,
+            self.owner_port,
+        )?;
 
         Ok(PortAssignment {
             owner,
@@ -2069,6 +2142,12 @@ impl RuntimeSubject {
 
                 Ok(format!("php_worker:{php_track}"))
             }
+            Self::Resource { name, track } => {
+                validate_managed_resource_identity("name", name)?;
+                validate_concrete_track(track)?;
+
+                Ok(format!("resource:{name}:{track}"))
+            }
         }
     }
 
@@ -2082,6 +2161,18 @@ impl RuntimeSubject {
 
             return Ok(Self::PhpWorker {
                 php_track: php_track.to_string(),
+            });
+        }
+
+        if let Some(resource) = subject_id.strip_prefix("resource:")
+            && let Some((name, track)) = resource.split_once(':')
+        {
+            validate_managed_resource_identity("name", name)?;
+            validate_concrete_track(track)?;
+
+            return Ok(Self::Resource {
+                name: name.to_string(),
+                track: track.to_string(),
             });
         }
 
@@ -2154,8 +2245,17 @@ impl ProjectRow {
 }
 
 impl PortIdentity {
+    fn uses_resource_ports_table(&self) -> bool {
+        self.owner_kind == "resource" && self.owner_port != "default"
+    }
+
     fn display_name(&self) -> String {
-        describe_port_identity(self.owner_kind, &self.owner_id, &self.owner_track)
+        describe_port_identity(
+            self.owner_kind,
+            &self.owner_id,
+            &self.owner_track,
+            &self.owner_port,
+        )
     }
 }
 
@@ -2971,10 +3071,47 @@ fn port_assignment_in_transaction(
     transaction: &Transaction<'_>,
     identity: &PortIdentity,
 ) -> Result<Option<PortAssignment>, StateError> {
+    if identity.uses_resource_ports_table() {
+        let mut statement = transaction.prepare(
+            "SELECT
+                'resource' AS owner_kind,
+                resource_name AS owner_id,
+                track AS owner_track,
+                port_name AS owner_port,
+                port,
+                updated_at
+            FROM resource_ports
+            WHERE resource_name = ?1
+            AND track = ?2
+            AND port_name = ?3",
+        )?;
+        let mut rows = statement.query_map(
+            params![
+                identity.owner_id.as_str(),
+                identity.owner_track.as_str(),
+                identity.owner_port.as_str(),
+            ],
+            port_assignment_from_row,
+        )?;
+
+        return match rows.next() {
+            Some(row) => Ok(Some(row?.into_assignment()?)),
+            None => Ok(None),
+        };
+    }
+
     let mut statement = transaction.prepare(
-        "SELECT owner_kind, owner_id, owner_track, port, updated_at
+        "SELECT
+            owner_kind,
+            owner_id,
+            owner_track,
+            CASE owner_kind WHEN 'resource' THEN 'default' ELSE '' END AS owner_port,
+            port,
+            updated_at
         FROM ports
-        WHERE owner_kind = ?1 AND owner_id = ?2 AND owner_track = ?3",
+        WHERE owner_kind = ?1
+        AND owner_id = ?2
+        AND owner_track = ?3",
     )?;
     let mut rows = statement.query_map(
         params![
@@ -3034,7 +3171,11 @@ fn assign_port_in_transaction(
 fn assigned_port_numbers_in_transaction(
     transaction: &Transaction<'_>,
 ) -> Result<BTreeSet<u16>, StateError> {
-    let mut statement = transaction.prepare("SELECT port FROM ports")?;
+    let mut statement = transaction.prepare(
+        "SELECT port FROM ports
+        UNION
+        SELECT port FROM resource_ports",
+    )?;
     let rows = statement.query_map([], |row| row.get::<_, u16>(0))?;
     let mut assigned_ports = BTreeSet::new();
 
@@ -3049,24 +3190,10 @@ fn assigned_port_numbers_except_in_transaction(
     transaction: &Transaction<'_>,
     identity: &PortIdentity,
 ) -> Result<BTreeSet<u16>, StateError> {
-    let mut statement = transaction.prepare(
-        "SELECT port
-        FROM ports
-        WHERE owner_kind != ?1 OR owner_id != ?2 OR owner_track != ?3
-        ORDER BY port",
-    )?;
-    let rows = statement.query_map(
-        params![
-            identity.owner_kind,
-            identity.owner_id.as_str(),
-            identity.owner_track.as_str(),
-        ],
-        |row| row.get::<_, u16>(0),
-    )?;
-    let mut ports = BTreeSet::new();
+    let mut ports = assigned_port_numbers_in_transaction(transaction)?;
 
-    for row in rows {
-        ports.insert(row?);
+    if let Some(existing) = port_assignment_in_transaction(transaction, identity)? {
+        ports.remove(&existing.port);
     }
 
     Ok(ports)
@@ -3078,20 +3205,37 @@ fn upsert_port_in_transaction(
     port: u16,
     updated_at: &str,
 ) -> rusqlite::Result<()> {
-    transaction.execute(
-        "INSERT INTO ports (owner_kind, owner_id, owner_track, port, updated_at)
-        VALUES (?1, ?2, ?3, ?4, ?5)
-        ON CONFLICT(owner_kind, owner_id, owner_track) DO UPDATE SET
-            port = excluded.port,
-            updated_at = excluded.updated_at",
-        params![
-            identity.owner_kind,
-            identity.owner_id.as_str(),
-            identity.owner_track.as_str(),
-            port,
-            updated_at,
-        ],
-    )?;
+    if identity.uses_resource_ports_table() {
+        transaction.execute(
+            "INSERT INTO resource_ports (resource_name, track, port_name, port, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(resource_name, track, port_name) DO UPDATE SET
+                port = excluded.port,
+                updated_at = excluded.updated_at",
+            params![
+                identity.owner_id.as_str(),
+                identity.owner_track.as_str(),
+                identity.owner_port.as_str(),
+                port,
+                updated_at,
+            ],
+        )?;
+    } else {
+        transaction.execute(
+            "INSERT INTO ports (owner_kind, owner_id, owner_track, port, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(owner_kind, owner_id, owner_track) DO UPDATE SET
+                port = excluded.port,
+                updated_at = excluded.updated_at",
+            params![
+                identity.owner_kind,
+                identity.owner_id.as_str(),
+                identity.owner_track.as_str(),
+                port,
+                updated_at,
+            ],
+        )?;
+    }
 
     Ok(())
 }
@@ -3101,8 +3245,9 @@ fn port_assignment_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PortAss
         owner_kind: row.get(0)?,
         owner_id: row.get(1)?,
         owner_track: row.get(2)?,
-        port: row.get(3)?,
-        updated_at: row.get(4)?,
+        owner_port: row.get(3)?,
+        port: row.get(4)?,
+        updated_at: row.get(5)?,
     })
 }
 
@@ -3318,7 +3463,15 @@ fn validate_env_context(context: &str, env: &EnvContextValues) -> Result<(), Sta
     Ok(())
 }
 
-fn describe_port_identity(owner_kind: &str, owner_id: &str, owner_track: &str) -> String {
+fn describe_port_identity(
+    owner_kind: &str,
+    owner_id: &str,
+    owner_track: &str,
+    owner_port: &str,
+) -> String {
+    if !owner_port.is_empty() {
+        return format!("{owner_kind} {owner_id:?} track {owner_track:?} port {owner_port:?}");
+    }
     if owner_track.is_empty() {
         return format!("{owner_kind} {owner_id:?}");
     }

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -2353,9 +2353,24 @@ fn upsert_managed_resource_track_desired_in_transaction(
         )
         VALUES (?1, ?2, ?3, 0, 0, ?4)
         ON CONFLICT(resource_name, track) DO UPDATE SET
-            desired_state = excluded.desired_state,
-            removal_prune = 0,
-            removal_force = 0,
+            desired_state = CASE
+                WHEN managed_resource_tracks.desired_state = 'removed'
+                    AND managed_resource_tracks.current_artifact_path IS NOT NULL
+                THEN managed_resource_tracks.desired_state
+                ELSE excluded.desired_state
+            END,
+            removal_prune = CASE
+                WHEN managed_resource_tracks.desired_state = 'removed'
+                    AND managed_resource_tracks.current_artifact_path IS NOT NULL
+                THEN managed_resource_tracks.removal_prune
+                ELSE 0
+            END,
+            removal_force = CASE
+                WHEN managed_resource_tracks.desired_state = 'removed'
+                    AND managed_resource_tracks.current_artifact_path IS NOT NULL
+                THEN managed_resource_tracks.removal_force
+                ELSE 0
+            END,
             updated_at = excluded.updated_at",
         params![
             resource_name,

--- a/crates/state/src/migrations.rs
+++ b/crates/state/src/migrations.rs
@@ -13,6 +13,7 @@ const PROJECT_ORIGINAL_PATH_SQL: &str = include_str!("sql/004_project_original_p
 const PROJECT_RESOURCE_REQUIREMENTS_SQL: &str =
     include_str!("sql/005_project_resource_requirements.sql");
 const GLOBAL_PHP_DEFAULT_SQL: &str = include_str!("sql/006_global_php_default.sql");
+const RESOURCE_PORT_ROLES_SQL: &str = include_str!("sql/007_resource_port_roles.sql");
 
 pub(crate) const DEFAULT_MIGRATIONS: &[Migration] = &[
     Migration::new(1, "core_state_schema", CORE_SCHEMA_SQL),
@@ -33,6 +34,7 @@ pub(crate) const DEFAULT_MIGRATIONS: &[Migration] = &[
         PROJECT_RESOURCE_REQUIREMENTS_SQL,
     ),
     Migration::new(6, "global_php_default", GLOBAL_PHP_DEFAULT_SQL),
+    Migration::new(7, "resource_port_roles", RESOURCE_PORT_ROLES_SQL),
 ];
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/crates/state/src/paths.rs
+++ b/crates/state/src/paths.rs
@@ -124,6 +124,11 @@ impl PvPaths {
             .join(format!("workers/php-{php_track}/projects"))
     }
 
+    pub fn resource_runtime_config(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+        self.config()
+            .join(format!("resources/{resource_name}-{track}.json"))
+    }
+
     pub fn certificates(&self) -> &Utf8Path {
         &self.certificates
     }
@@ -144,6 +149,11 @@ impl PvPaths {
         self.logs().join(format!("workers/php-{php_track}.log"))
     }
 
+    pub fn resource_log(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+        self.logs()
+            .join(format!("resources/{resource_name}-{track}.log"))
+    }
+
     pub fn gateway_pid(&self) -> Utf8PathBuf {
         self.run().join("gateway.pid")
     }
@@ -160,12 +170,29 @@ impl PvPaths {
         self.run().join(format!("workers/php-{php_track}.json"))
     }
 
+    pub fn resource_pid(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+        self.run()
+            .join(format!("resources/{resource_name}-{track}.pid"))
+    }
+
+    pub fn resource_runtime_metadata(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+        self.run()
+            .join(format!("resources/{resource_name}-{track}.json"))
+    }
+
     pub fn composer(&self) -> &Utf8Path {
         &self.composer
     }
 
     pub fn resources(&self) -> &Utf8Path {
         &self.resources
+    }
+
+    pub fn resource_data_dir(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+        self.resources()
+            .join(resource_name)
+            .join(track)
+            .join("data")
     }
 
     pub fn layout_directories(&self) -> Vec<(&'static str, &Utf8Path)> {

--- a/crates/state/src/paths.rs
+++ b/crates/state/src/paths.rs
@@ -126,7 +126,7 @@ impl PvPaths {
 
     pub fn resource_runtime_config(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
         self.config()
-            .join(format!("resources/{resource_name}-{track}.json"))
+            .join(format!("resources/{resource_name}/{track}.json"))
     }
 
     pub fn certificates(&self) -> &Utf8Path {
@@ -151,7 +151,7 @@ impl PvPaths {
 
     pub fn resource_log(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
         self.logs()
-            .join(format!("resources/{resource_name}-{track}.log"))
+            .join(format!("resources/{resource_name}/{track}.log"))
     }
 
     pub fn gateway_pid(&self) -> Utf8PathBuf {
@@ -172,12 +172,12 @@ impl PvPaths {
 
     pub fn resource_pid(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
         self.run()
-            .join(format!("resources/{resource_name}-{track}.pid"))
+            .join(format!("resources/{resource_name}/{track}.pid"))
     }
 
     pub fn resource_runtime_metadata(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
         self.run()
-            .join(format!("resources/{resource_name}-{track}.json"))
+            .join(format!("resources/{resource_name}/{track}.json"))
     }
 
     pub fn composer(&self) -> &Utf8Path {

--- a/crates/state/src/sql/007_resource_port_roles.sql
+++ b/crates/state/src/sql/007_resource_port_roles.sql
@@ -1,0 +1,8 @@
+CREATE TABLE resource_ports (
+    resource_name TEXT NOT NULL,
+    track TEXT NOT NULL,
+    port_name TEXT NOT NULL,
+    port INTEGER NOT NULL UNIQUE,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (resource_name, track, port_name)
+);

--- a/crates/state/tests/snapshots/state_foundation__database_runs_migrations_and_exposes_core_schema.snap
+++ b/crates/state/tests/snapshots/state_foundation__database_runs_migrations_and_exposes_core_schema.snap
@@ -13,6 +13,7 @@ DatabaseInspection {
         "004:project_original_path",
         "005:project_resource_requirements",
         "006:global_php_default",
+        "007:resource_port_roles",
     ],
     tables: [
         "global_php_default_track",
@@ -26,5 +27,6 @@ DatabaseInspection {
         "projects",
         "pv_migrations",
         "resource_allocations",
+        "resource_ports",
     ],
 }

--- a/crates/state/tests/snapshots/state_foundation__legacy_port_insert_contract_survives_named_resource_port_migration.snap
+++ b/crates/state/tests/snapshots/state_foundation__legacy_port_insert_contract_survives_named_resource_port_migration.snap
@@ -1,0 +1,54 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: "(legacy_mysql_rows, assigned_smtp, assigned_dashboard,\ndatabase.assigned_ports()?,)"
+---
+(
+    1,
+    PortAssignment {
+        owner: Resource {
+            name: "mailpit",
+            track: "1.0",
+            port: "smtp",
+        },
+        port: 1025,
+        updated_at: "<timestamp>",
+    },
+    PortAssignment {
+        owner: Resource {
+            name: "mailpit",
+            track: "1.0",
+            port: "dashboard",
+        },
+        port: 8025,
+        updated_at: "<timestamp>",
+    },
+    [
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "dashboard",
+            },
+            port: 8025,
+            updated_at: "<timestamp>",
+        },
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "smtp",
+            },
+            port: 1025,
+            updated_at: "<timestamp>",
+        },
+        PortAssignment {
+            owner: Resource {
+                name: "mysql",
+                track: "8.0",
+                port: "default",
+            },
+            port: 3307,
+            updated_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/state/tests/snapshots/state_foundation__port_allocator_persists_reuses_avoids_collisions_and_releases_assignments.snap
+++ b/crates/state/tests/snapshots/state_foundation__port_allocator_persists_reuses_avoids_collisions_and_releases_assignments.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/state/tests/state_foundation.rs
-assertion_line: 500
 expression: "(assigned_mysql, reused_mysql, assigned_redis, released_mysql,\nreassigned_mysql, database.assigned_ports()?,)"
 ---
 (
@@ -8,6 +7,7 @@ expression: "(assigned_mysql, reused_mysql, assigned_redis, released_mysql,\nrea
         owner: Resource {
             name: "mysql",
             track: "8.4",
+            port: "default",
         },
         port: 45000,
         updated_at: "<timestamp>",
@@ -16,6 +16,7 @@ expression: "(assigned_mysql, reused_mysql, assigned_redis, released_mysql,\nrea
         owner: Resource {
             name: "mysql",
             track: "8.4",
+            port: "default",
         },
         port: 45000,
         updated_at: "<timestamp>",
@@ -24,6 +25,7 @@ expression: "(assigned_mysql, reused_mysql, assigned_redis, released_mysql,\nrea
         owner: Resource {
             name: "redis",
             track: "8.6",
+            port: "default",
         },
         port: 45001,
         updated_at: "<timestamp>",
@@ -33,6 +35,7 @@ expression: "(assigned_mysql, reused_mysql, assigned_redis, released_mysql,\nrea
         owner: Resource {
             name: "mysql",
             track: "8.4",
+            port: "default",
         },
         port: 45000,
         updated_at: "<timestamp>",
@@ -42,6 +45,7 @@ expression: "(assigned_mysql, reused_mysql, assigned_redis, released_mysql,\nrea
             owner: Resource {
                 name: "mysql",
                 track: "8.4",
+                port: "default",
             },
             port: 45000,
             updated_at: "<timestamp>",
@@ -50,6 +54,7 @@ expression: "(assigned_mysql, reused_mysql, assigned_redis, released_mysql,\nrea
             owner: Resource {
                 name: "redis",
                 track: "8.6",
+                port: "default",
             },
             port: 45001,
             updated_at: "<timestamp>",

--- a/crates/state/tests/snapshots/state_foundation__resource_port_allocator_distinguishes_named_ports_for_one_track.snap
+++ b/crates/state/tests/snapshots/state_foundation__resource_port_allocator_distinguishes_named_ports_for_one_track.snap
@@ -1,0 +1,45 @@
+---
+source: crates/state/tests/state_foundation.rs
+expression: "(assigned_smtp, assigned_dashboard, reused_smtp, released_dashboard,\ndatabase.assigned_ports()?,)"
+---
+(
+    PortAssignment {
+        owner: Resource {
+            name: "mailpit",
+            track: "1.0",
+            port: "smtp",
+        },
+        port: 1025,
+        updated_at: "<timestamp>",
+    },
+    PortAssignment {
+        owner: Resource {
+            name: "mailpit",
+            track: "1.0",
+            port: "dashboard",
+        },
+        port: 8025,
+        updated_at: "<timestamp>",
+    },
+    PortAssignment {
+        owner: Resource {
+            name: "mailpit",
+            track: "1.0",
+            port: "smtp",
+        },
+        port: 1025,
+        updated_at: "<timestamp>",
+    },
+    true,
+    [
+        PortAssignment {
+            owner: Resource {
+                name: "mailpit",
+                track: "1.0",
+                port: "smtp",
+            },
+            port: 1025,
+            updated_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/state/tests/snapshots/state_foundation__runtime_observed_state_round_trips_through_observed_states.snap
+++ b/crates/state/tests/snapshots/state_foundation__runtime_observed_state_round_trips_through_observed_states.snap
@@ -21,4 +21,15 @@ expression: database.runtime_observed_states()?
         ),
         observed_at: "<timestamp>",
     },
+    RuntimeObservedStateRecord {
+        subject: Resource {
+            name: "mailpit",
+            track: "1.0",
+        },
+        status: Running,
+        message: Some(
+            "mailpit is ready",
+        ),
+        observed_at: "<timestamp>",
+    },
 ]

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -98,23 +98,27 @@ fn pv_paths_include_gateway_and_worker_runtime_artifacts() {
     );
     assert_eq!(
         paths.resource_runtime_config("mailpit", "1.0").as_str(),
-        "/Users/alice/.pv/config/resources/mailpit-1.0.json"
+        "/Users/alice/.pv/config/resources/mailpit/1.0.json"
     );
     assert_eq!(
         paths.resource_log("mailpit", "1.0").as_str(),
-        "/Users/alice/.pv/logs/resources/mailpit-1.0.log"
+        "/Users/alice/.pv/logs/resources/mailpit/1.0.log"
     );
     assert_eq!(
         paths.resource_pid("mailpit", "1.0").as_str(),
-        "/Users/alice/.pv/run/resources/mailpit-1.0.pid"
+        "/Users/alice/.pv/run/resources/mailpit/1.0.pid"
     );
     assert_eq!(
         paths.resource_runtime_metadata("mailpit", "1.0").as_str(),
-        "/Users/alice/.pv/run/resources/mailpit-1.0.json"
+        "/Users/alice/.pv/run/resources/mailpit/1.0.json"
     );
     assert_eq!(
         paths.resource_data_dir("mailpit", "1.0").as_str(),
         "/Users/alice/.pv/resources/mailpit/1.0/data"
+    );
+    assert_ne!(
+        paths.resource_log("a-b", "c"),
+        paths.resource_log("a", "b-c")
     );
 }
 

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -96,6 +96,26 @@ fn pv_paths_include_gateway_and_worker_runtime_artifacts() {
         paths.worker_runtime_metadata("8.4").as_str(),
         "/Users/alice/.pv/run/workers/php-8.4.json"
     );
+    assert_eq!(
+        paths.resource_runtime_config("mailpit", "1.0").as_str(),
+        "/Users/alice/.pv/config/resources/mailpit-1.0.json"
+    );
+    assert_eq!(
+        paths.resource_log("mailpit", "1.0").as_str(),
+        "/Users/alice/.pv/logs/resources/mailpit-1.0.log"
+    );
+    assert_eq!(
+        paths.resource_pid("mailpit", "1.0").as_str(),
+        "/Users/alice/.pv/run/resources/mailpit-1.0.pid"
+    );
+    assert_eq!(
+        paths.resource_runtime_metadata("mailpit", "1.0").as_str(),
+        "/Users/alice/.pv/run/resources/mailpit-1.0.json"
+    );
+    assert_eq!(
+        paths.resource_data_dir("mailpit", "1.0").as_str(),
+        "/Users/alice/.pv/resources/mailpit/1.0/data"
+    );
 }
 
 #[test]
@@ -1548,6 +1568,14 @@ fn runtime_observed_state_round_trips_through_observed_states() -> Result<()> {
         RuntimeObservedStatus::Failed,
         Some("readiness timed out"),
     )?;
+    database.record_runtime_observed_snapshot(
+        RuntimeSubject::Resource {
+            name: "mailpit".to_string(),
+            track: "1.0".to_string(),
+        },
+        RuntimeObservedStatus::Running,
+        Some("mailpit is ready"),
+    )?;
     let updated_gateway = database.record_runtime_observed_snapshot(
         RuntimeSubject::Gateway,
         RuntimeObservedStatus::Degraded,
@@ -2266,6 +2294,7 @@ fn port_allocator_persists_reuses_avoids_collisions_and_releases_assignments() -
     let released_mysql = database.release_port(PortOwner::Resource {
         name: "mysql".to_string(),
         track: "8.4".to_string(),
+        port: "default".to_string(),
     })?;
     let reassigned_mysql = database.assign_port(mysql, |port| port != 3306)?;
 
@@ -2276,6 +2305,91 @@ fn port_allocator_persists_reuses_avoids_collisions_and_releases_assignments() -
             assigned_redis,
             released_mysql,
             reassigned_mysql,
+            database.assigned_ports()?,
+        ));
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn resource_port_allocator_distinguishes_named_ports_for_one_track() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+    let smtp = PortRequest::resource_port("mailpit", "1.0", "smtp", 1025, 45000, 45009);
+    let dashboard = PortRequest::resource_port("mailpit", "1.0", "dashboard", 8025, 45000, 45009);
+
+    let assigned_smtp = database.assign_port(smtp.clone(), |_port| true)?;
+    let assigned_dashboard = database.assign_port(dashboard.clone(), |_port| true)?;
+    let reused_smtp = database.assign_port(smtp, |_port| true)?;
+    let released_dashboard = database.release_port(PortOwner::Resource {
+        name: "mailpit".to_string(),
+        track: "1.0".to_string(),
+        port: "dashboard".to_string(),
+    })?;
+
+    with_normalized_timestamps(|| {
+        assert_debug_snapshot!((
+            assigned_smtp,
+            assigned_dashboard,
+            reused_smtp,
+            released_dashboard,
+            database.assigned_ports()?,
+        ));
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn legacy_port_insert_contract_survives_named_resource_port_migration() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+
+    state::testing::transaction(&mut database, |transaction| {
+        transaction.execute(
+            "INSERT INTO ports (owner_kind, owner_id, owner_track, port, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(owner_kind, owner_id, owner_track) DO UPDATE SET
+                port = excluded.port,
+                updated_at = excluded.updated_at",
+            params!["resource", "mysql", "8.0", 3306, "2026-06-08T00:00:00Z"],
+        )?;
+        transaction.execute(
+            "INSERT INTO ports (owner_kind, owner_id, owner_track, port, updated_at)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(owner_kind, owner_id, owner_track) DO UPDATE SET
+                port = excluded.port,
+                updated_at = excluded.updated_at",
+            params!["resource", "mysql", "8.0", 3307, "2026-06-08T00:00:01Z"],
+        )?;
+
+        Ok(())
+    })?;
+
+    let smtp = PortRequest::resource_port("mailpit", "1.0", "smtp", 1025, 45000, 45009);
+    let dashboard = PortRequest::resource_port("mailpit", "1.0", "dashboard", 8025, 45000, 45009);
+    let assigned_smtp = database.assign_port(smtp, |_port| true)?;
+    let assigned_dashboard = database.assign_port(dashboard, |_port| true)?;
+    let legacy_mysql_rows = state::testing::query_i64(
+        &database,
+        "SELECT COUNT(*)
+        FROM ports
+        WHERE owner_kind = 'resource'
+        AND owner_id = 'mysql'
+        AND owner_track = '8.0'
+        AND port = 3307",
+    )?;
+
+    with_normalized_timestamps(|| {
+        assert_debug_snapshot!((
+            legacy_mysql_rows,
+            assigned_smtp,
+            assigned_dashboard,
             database.assigned_ports()?,
         ));
         Ok::<(), anyhow::Error>(())
@@ -2446,37 +2560,38 @@ fn port_allocator_keeps_owner_components_structured() -> Result<()> {
     let tempdir = tempdir()?;
     let paths = PvPaths::for_home(tempdir.path().join("home"));
     let mut database = Database::open(&paths)?;
-    let mysql_debug = PortRequest::resource("mysql", "8.4:debug", 45000, 45000, 45009);
-    let mysql_track_resource = PortRequest::resource("mysql:8.4", "debug", 45000, 45000, 45009);
+    let mysql_debug = PortRequest::resource_port("mysql", "8.4", "debug", 45000, 45000, 45009);
+    let mysql_default =
+        PortRequest::resource_port("mysql", "8.4-debug", "default", 45000, 45000, 45009);
 
     let assigned_mysql_debug = database.assign_port(mysql_debug, |_port| true)?;
-    let assigned_mysql_track_resource = database.assign_port(mysql_track_resource, |_port| true)?;
+    let assigned_mysql_default = database.assign_port(mysql_default, |_port| true)?;
     let released_mysql_debug = database.release_port(PortOwner::Resource {
         name: "mysql".to_string(),
-        track: "8.4:debug".to_string(),
+        track: "8.4".to_string(),
+        port: "debug".to_string(),
     })?;
 
     assert_eq!(
         assigned_mysql_debug.owner,
         PortOwner::Resource {
             name: "mysql".to_string(),
-            track: "8.4:debug".to_string(),
+            track: "8.4".to_string(),
+            port: "debug".to_string(),
         }
     );
     assert_eq!(assigned_mysql_debug.port, 45000);
     assert_eq!(
-        assigned_mysql_track_resource.owner,
+        assigned_mysql_default.owner,
         PortOwner::Resource {
-            name: "mysql:8.4".to_string(),
-            track: "debug".to_string(),
+            name: "mysql".to_string(),
+            track: "8.4-debug".to_string(),
+            port: "default".to_string(),
         }
     );
-    assert_eq!(assigned_mysql_track_resource.port, 45001);
+    assert_eq!(assigned_mysql_default.port, 45001);
     assert!(released_mysql_debug);
-    assert_eq!(
-        database.assigned_ports()?,
-        vec![assigned_mysql_track_resource]
-    );
+    assert_eq!(database.assigned_ports()?, vec![assigned_mysql_default]);
 
     Ok(())
 }

--- a/docs/superpowers/plans/2026-06-08-pr-16-20-managed-resource-adapters.md
+++ b/docs/superpowers/plans/2026-06-08-pr-16-20-managed-resource-adapters.md
@@ -139,14 +139,12 @@ RustFS adapter:
 ```toml
 [workspace.dependencies]
 object_store = { version = "0.13.2", default-features = false, features = ["aws"] }
-aws-sdk-s3 = { version = "1.135.0", default-features = false, features = ["rustls", "rt-tokio", "http-1x"] }
 ```
 
 Then:
 
 ```bash
 cargo update -p object_store --precise 0.13.2
-cargo update -p aws-sdk-s3 --precise 1.135.0
 ```
 
 Use `sqlx::query(...)`, `sqlx::query_as(...)`, and dynamic SQL strings. Do not use `sqlx::query!` macros or offline metadata.
@@ -159,28 +157,7 @@ let mut connection = client.get_multiplexed_async_connection().await?;
 let pong: String = redis::cmd("PING").query_async(&mut connection).await?;
 ```
 
-Use `object_store` only for S3 object checks. Use `aws-sdk-s3` for RustFS bucket creation:
-
-```rust
-use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
-use aws_sdk_s3::{Client, Config};
-
-let config = Config::builder()
-    .behavior_version(BehaviorVersion::latest())
-    .credentials_provider(Credentials::new(
-        access_key,
-        secret_key,
-        None,
-        None,
-        "pv-rustfs",
-    ))
-    .region(Region::new("us-east-1"))
-    .endpoint_url(endpoint)
-    .force_path_style(true)
-    .build();
-let client = Client::from_conf(config);
-client.create_bucket().bucket(bucket).send().await?;
-```
+Use `object_store` first for RustFS bucket create/check work. Add the AWS SDK only if `object_store` cannot create or verify buckets cleanly against RustFS.
 
 ## Task 1: Runtime Foundation
 
@@ -561,7 +538,7 @@ pub(crate) async fn reconcile_project_resources(
 Behavior:
 
 1. For every resource in `plan.resources`, look up a runtime adapter in the catalog.
-2. If no adapter is registered, return `DaemonError::UnsupportedManagedResourceRuntime`.
+2. If no adapter is registered and no seeded test env context exists for that track, record the resource runtime as failed and return `DaemonError::UnsupportedManagedResourceRuntime`.
 3. Ensure the track is installed. If a track row exists without `current_artifact_path`, return `ManagedResourceArtifactMissing` in this task. Demand-driven install from manifests is added in Step 12.
 4. Assign every named port with `PortRequest::resource_port`.
 5. Build `ManagedResourceRuntimeContext`.
@@ -1270,7 +1247,7 @@ url=http://127.0.0.1:<api port>
 
 Allocation behavior:
 
-1. Create bucket with `aws-sdk-s3` `create_bucket`.
+1. Create or confirm the bucket through `object_store`.
 2. Treat already-existing bucket as success.
 3. Verify object operations by creating a short object with `object_store::aws::AmazonS3Builder` and `ObjectStoreExt::put` followed by `head`.
 4. Mark allocation ready with `bucket`, `access_key`, `secret_key`, `endpoint`, `host`, `port`, and `url`.

--- a/docs/superpowers/plans/2026-06-08-pr-16-20-managed-resource-adapters.md
+++ b/docs/superpowers/plans/2026-06-08-pr-16-20-managed-resource-adapters.md
@@ -1,0 +1,1681 @@
+# PR 16-20 Managed Resource Adapters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build shared runtime and SQL foundations, then land full vertical slices for Mailpit, Redis, MySQL, Postgres, and RustFS Managed Resource adapters.
+
+**Architecture:** Backing Managed Resource runtime orchestration stays daemon-local. The `resources` crate keeps artifact identity, manifest, install, and layout validation responsibilities. State adds only the narrow resource port-role support required for named multi-port runtimes; adapter env context and allocation readiness use the existing Managed Resource track and Resource allocation tables.
+
+**Tech Stack:** Rust 2024, Tokio, rusqlite-backed state, clap, insta, nextest, `sqlx 0.9.0`, `redis 1.2.2`, `object_store 0.13.2`, `aws-sdk-s3 1.135.0`, Solo orchestration, git worktrees.
+
+---
+
+## Source Documents
+
+Before editing code in any worktree, read these files in that worktree:
+
+```bash
+sed -n '1,220p' CONTRIBUTING.md
+sed -n '1,260p' DESIGN.md
+sed -n '1,360p' IMPLEMENTATION.md
+sed -n '1,260p' docs/superpowers/specs/2026-06-08-pr-16-20-managed-resource-adapters-design.md
+```
+
+Expected: the commands print the current project rules and the approved adapter design. Stop and ask if the checked-out files conflict with this plan.
+
+## Workstream Graph
+
+Use this blocker graph:
+
+| Workstream | Branch | Base | Blockers |
+| --- | --- | --- | --- |
+| Runtime foundation | `pr-16-20-runtime-foundation` | current `main` after this plan commit | none |
+| SQL foundation | `pr-16-20-sql-foundation` | `pr-16-20-runtime-foundation` | runtime foundation |
+| Mailpit adapter | `pr-16-mailpit-adapter` | `pr-16-20-runtime-foundation` | runtime foundation |
+| Redis adapter | `pr-17-redis-adapter` | `pr-16-20-runtime-foundation` | runtime foundation |
+| RustFS adapter | `pr-20-rustfs-adapter` | `pr-16-20-runtime-foundation` | runtime foundation |
+| MySQL adapter | `pr-18-mysql-adapter` | `pr-16-20-sql-foundation` | runtime foundation, SQL foundation |
+| Postgres adapter | `pr-19-postgres-adapter` | `pr-16-20-sql-foundation` | runtime foundation, SQL foundation |
+
+Use the `superpowers:using-git-worktrees` skill when execution starts. Suggested worktree commands after approval:
+
+```bash
+git fetch origin main
+git worktree add ../pv-pr16-20-runtime-foundation -b pr-16-20-runtime-foundation HEAD
+```
+
+After the runtime foundation branch is committed:
+
+```bash
+git worktree add ../pv-pr16-20-sql-foundation -b pr-16-20-sql-foundation pr-16-20-runtime-foundation
+git worktree add ../pv-pr16-mailpit-adapter -b pr-16-mailpit-adapter pr-16-20-runtime-foundation
+git worktree add ../pv-pr17-redis-adapter -b pr-17-redis-adapter pr-16-20-runtime-foundation
+git worktree add ../pv-pr20-rustfs-adapter -b pr-20-rustfs-adapter pr-16-20-runtime-foundation
+```
+
+After the SQL foundation branch is committed:
+
+```bash
+git worktree add ../pv-pr18-mysql-adapter -b pr-18-mysql-adapter pr-16-20-sql-foundation
+git worktree add ../pv-pr19-postgres-adapter -b pr-19-postgres-adapter pr-16-20-sql-foundation
+```
+
+## File Structure
+
+Runtime foundation creates or modifies:
+
+- Create `crates/state/src/sql/007_resource_port_roles.sql`: migration that adds `owner_port` to the port assignment key.
+- Modify `crates/state/src/migrations.rs`: register migration 7.
+- Modify `crates/state/src/database.rs`: extend `PortOwner::Resource`, `PortRequest`, port serialization, runtime observed subjects, and validation.
+- Modify `crates/state/src/lib.rs`: export the new public state types or constructors used by daemon tests.
+- Modify `crates/state/tests/state_foundation.rs`: state migration, port-role, and resource runtime subject coverage.
+- Modify `crates/state/tests/snapshots/*.snap`: accepted snapshot changes from state tests.
+- Modify `crates/state/src/paths.rs`: add resource runtime path helpers.
+- Create `crates/daemon/src/managed_resources/mod.rs`: daemon-local runtime catalog, resource demand reconciliation, process start/adopt/stop, env context recording, allocation hook dispatch, and test injection.
+- Create `crates/daemon/src/managed_resources/fake.rs`: test-only fake multi-port runtime adapter.
+- Modify `crates/daemon/src/lib.rs`: register `managed_resources`.
+- Modify `crates/daemon/src/jobs.rs`: route non-Gateway resource reconciliation to Managed Resource runtime reconciliation and make Project/System reconciliation await resource runtime prep before Project env rendering.
+- Modify `crates/daemon/src/project_env.rs`: make reconciliation async and call Managed Resource reconciliation after demand planning and before env rendering.
+- Modify `crates/daemon/src/error.rs`: add concise runtime adapter errors.
+- Create `crates/daemon/tests/managed_resource_runtime.rs`: test-only multi-port runtime integration tests.
+- Modify `crates/cli/src/commands/mod.rs`: add a private reusable artifact-resource command helper module.
+- Create `crates/cli/src/commands/artifact_resource.rs`: private helper for install/update/uninstall/list commands that adapter command modules reuse.
+- Modify `crates/cli/tests` or `it/cli.rs` only if helper behavior has direct observable output; otherwise leave public command snapshots to adapter PRs.
+
+SQL foundation creates or modifies:
+
+- Modify `Cargo.toml`: add workspace `sqlx`.
+- Modify `crates/daemon/Cargo.toml`: add `sqlx` dependency.
+- Create `crates/daemon/src/managed_resources/sql.rs`: shared MySQL/Postgres admin connection, readiness, database create/check, env helpers.
+- Modify `crates/daemon/src/managed_resources/mod.rs`: expose SQL helpers to child modules.
+- Create `crates/daemon/tests/sql_foundation.rs`: shared SQL helper tests with a recording test admin.
+
+Each adapter PR creates or modifies:
+
+- Modify `crates/resources/src/runtime.rs`: add the adapter layout validator function for that resource.
+- Modify `crates/daemon/src/managed_resources/mod.rs`: register the adapter module in the production runtime catalog.
+- Create `crates/daemon/src/managed_resources/<adapter>.rs`: runtime definition, readiness, env context, allocation admin, and adapter tests.
+- Modify `crates/cli/src/args.rs`: add public command variants for the adapter namespace.
+- Modify `crates/cli/src/commands/mod.rs`: route command variants.
+- Create `crates/cli/src/commands/<adapter>.rs`: command namespace functions using `artifact_resource`.
+- Modify `it/cli.rs`: add CLI help/namespace snapshots.
+- Modify completion snapshots under `it/snapshots/` through `cargo insta`.
+- Add or modify focused tests under `crates/daemon/tests/` and `crates/resources/tests/`.
+
+## Dependency Matrix
+
+Add dependencies only in the PR that first uses them.
+
+Runtime foundation: no new external crates.
+
+SQL foundation:
+
+```toml
+[workspace.dependencies]
+sqlx = { version = "0.9.0", default-features = false, features = ["mysql", "postgres", "runtime-tokio", "tls-rustls"] }
+```
+
+Then:
+
+```bash
+cargo update -p sqlx --precise 0.9.0
+```
+
+Redis adapter:
+
+```toml
+[workspace.dependencies]
+redis = { version = "1.2.2", default-features = false, features = ["tokio-comp"] }
+```
+
+Then:
+
+```bash
+cargo update -p redis --precise 1.2.2
+```
+
+RustFS adapter:
+
+```toml
+[workspace.dependencies]
+object_store = { version = "0.13.2", default-features = false, features = ["aws"] }
+aws-sdk-s3 = { version = "1.135.0", default-features = false, features = ["rustls", "rt-tokio", "http-1x"] }
+```
+
+Then:
+
+```bash
+cargo update -p object_store --precise 0.13.2
+cargo update -p aws-sdk-s3 --precise 1.135.0
+```
+
+Use `sqlx::query(...)`, `sqlx::query_as(...)`, and dynamic SQL strings. Do not use `sqlx::query!` macros or offline metadata.
+
+Use Redis async APIs with the current method names:
+
+```rust
+let client = redis::Client::open("redis://127.0.0.1:6379/")?;
+let mut connection = client.get_multiplexed_async_connection().await?;
+let pong: String = redis::cmd("PING").query_async(&mut connection).await?;
+```
+
+Use `object_store` only for S3 object checks. Use `aws-sdk-s3` for RustFS bucket creation:
+
+```rust
+use aws_sdk_s3::config::{BehaviorVersion, Credentials, Region};
+use aws_sdk_s3::{Client, Config};
+
+let config = Config::builder()
+    .behavior_version(BehaviorVersion::latest())
+    .credentials_provider(Credentials::new(
+        access_key,
+        secret_key,
+        None,
+        None,
+        "pv-rustfs",
+    ))
+    .region(Region::new("us-east-1"))
+    .endpoint_url(endpoint)
+    .force_path_style(true)
+    .build();
+let client = Client::from_conf(config);
+client.create_bucket().bucket(bucket).send().await?;
+```
+
+## Task 1: Runtime Foundation
+
+**Files:**
+
+- Create: `crates/state/src/sql/007_resource_port_roles.sql`
+- Modify: `crates/state/src/migrations.rs`
+- Modify: `crates/state/src/database.rs`
+- Modify: `crates/state/src/lib.rs`
+- Modify: `crates/state/src/paths.rs`
+- Modify: `crates/state/tests/state_foundation.rs`
+- Create: `crates/daemon/src/managed_resources/mod.rs`
+- Create: `crates/daemon/src/managed_resources/fake.rs`
+- Modify: `crates/daemon/src/lib.rs`
+- Modify: `crates/daemon/src/jobs.rs`
+- Modify: `crates/daemon/src/project_env.rs`
+- Modify: `crates/daemon/src/error.rs`
+- Create: `crates/daemon/tests/managed_resource_runtime.rs`
+- Create: `crates/cli/src/commands/artifact_resource.rs`
+- Modify: `crates/cli/src/commands/mod.rs`
+
+- [ ] **Step 1: Write state tests for multi-port resource owners**
+
+Add this test shape to `crates/state/tests/state_foundation.rs` near the existing port allocator tests:
+
+```rust
+#[test]
+fn resource_port_allocator_distinguishes_named_ports_for_one_track() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let mut database = Database::open(&paths)?;
+    let smtp = PortRequest::resource_port("mailpit", "1.0", "smtp", 1025, 45000, 45009);
+    let dashboard = PortRequest::resource_port("mailpit", "1.0", "dashboard", 8025, 45000, 45009);
+
+    let assigned_smtp = database.assign_port(smtp.clone(), |_port| true)?;
+    let assigned_dashboard = database.assign_port(dashboard.clone(), |_port| true)?;
+    let reused_smtp = database.assign_port(smtp, |_port| true)?;
+    let released_dashboard = database.release_port(PortOwner::Resource {
+        name: "mailpit".to_string(),
+        track: "1.0".to_string(),
+        port: "dashboard".to_string(),
+    })?;
+
+    with_normalized_timestamps(|| {
+        assert_debug_snapshot!((
+            assigned_smtp,
+            assigned_dashboard,
+            reused_smtp,
+            released_dashboard,
+            database.assigned_ports()?,
+        ));
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}
+```
+
+Extend `runtime_observed_state_round_trips_through_observed_states` with a resource subject:
+
+```rust
+database.record_runtime_observed_snapshot(
+    RuntimeSubject::Resource {
+        name: "mailpit".to_string(),
+        track: "1.0".to_string(),
+    },
+    RuntimeObservedStatus::Running,
+    Some("mailpit is ready"),
+)?;
+```
+
+- [ ] **Step 2: Run the new state tests and confirm failure**
+
+Run:
+
+```bash
+cargo nextest run -p state resource_port_allocator_distinguishes_named_ports_for_one_track --locked
+cargo nextest run -p state runtime_observed_state_round_trips_through_observed_states --locked
+```
+
+Expected: compile failure for `PortRequest::resource_port`, `PortOwner::Resource { port }`, or `RuntimeSubject::Resource`.
+
+- [ ] **Step 3: Add migration 7**
+
+Create `crates/state/src/sql/007_resource_port_roles.sql`:
+
+```sql
+ALTER TABLE ports RENAME TO ports_without_owner_port;
+
+CREATE TABLE ports (
+    owner_kind TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    owner_track TEXT NOT NULL,
+    owner_port TEXT NOT NULL,
+    port INTEGER NOT NULL UNIQUE,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (owner_kind, owner_id, owner_track, owner_port)
+);
+
+INSERT INTO ports (owner_kind, owner_id, owner_track, owner_port, port, updated_at)
+SELECT
+    owner_kind,
+    owner_id,
+    owner_track,
+    CASE owner_kind WHEN 'resource' THEN 'default' ELSE '' END,
+    port,
+    updated_at
+FROM ports_without_owner_port;
+
+DROP TABLE ports_without_owner_port;
+```
+
+Modify `crates/state/src/migrations.rs`:
+
+```rust
+const RESOURCE_PORT_ROLES_SQL: &str = include_str!("sql/007_resource_port_roles.sql");
+```
+
+Add to `DEFAULT_MIGRATIONS` after migration 6:
+
+```rust
+Migration::new(7, "resource_port_roles", RESOURCE_PORT_ROLES_SQL),
+```
+
+- [ ] **Step 4: Extend port ownership state**
+
+In `crates/state/src/database.rs`, change the enum to:
+
+```rust
+pub enum PortOwner {
+    Dns,
+    Gateway(GatewayPort),
+    PhpWorker { php_track: String },
+    Resource { name: String, track: String, port: String },
+}
+```
+
+Add a named constructor while keeping the existing constructor as the default port:
+
+```rust
+pub fn resource(
+    name: impl Into<String>,
+    track: impl Into<String>,
+    preferred_port: u16,
+    fallback_start: u16,
+    fallback_end: u16,
+) -> Self {
+    Self::resource_port(name, track, "default", preferred_port, fallback_start, fallback_end)
+}
+
+pub fn resource_port(
+    name: impl Into<String>,
+    track: impl Into<String>,
+    port: impl Into<String>,
+    preferred_port: u16,
+    fallback_start: u16,
+    fallback_end: u16,
+) -> Self {
+    Self::new(
+        PortOwner::Resource {
+            name: name.into(),
+            track: track.into(),
+            port: port.into(),
+        },
+        preferred_port,
+        fallback_start,
+        fallback_end,
+    )
+}
+```
+
+Extend `PortIdentity` with `owner_port: String`, update every query that reads or writes `ports`, and require empty `owner_port` for DNS, gateway, and PHP worker rows. For resource rows, validate `name`, `track`, and `port` with the existing managed resource identity validation rules.
+
+Use this display text:
+
+```rust
+Self::Resource { name, track, port } => {
+    format!("resource {name:?} track {track:?} port {port:?}")
+}
+```
+
+- [ ] **Step 5: Extend runtime observed subjects**
+
+In `RuntimeSubject`, add:
+
+```rust
+Resource { name: String, track: String },
+```
+
+Serialize as:
+
+```rust
+Self::Resource { name, track } => {
+    validate_managed_resource_identity("name", name)?;
+    validate_concrete_track(track)?;
+
+    Ok(format!("resource:{name}:{track}"))
+}
+```
+
+Parse with `strip_prefix("resource:")` and `split_once(':')`. Since resource names and tracks reject `:`, this format is unambiguous.
+
+- [ ] **Step 6: Run state tests and accept snapshots**
+
+Run:
+
+```bash
+cargo insta test --accept --test-runner nextest -p state -- resource_port_allocator_distinguishes_named_ports_for_one_track
+cargo insta test --accept --test-runner nextest -p state -- runtime_observed_state_round_trips_through_observed_states
+```
+
+Expected: both tests pass and only relevant `crates/state/tests/snapshots/*.snap` files change.
+
+- [ ] **Step 7: Add resource runtime path helpers**
+
+In `crates/state/src/paths.rs`, add:
+
+```rust
+pub fn resource_runtime_config(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+    self.config()
+        .join(format!("resources/{resource_name}-{track}.json"))
+}
+
+pub fn resource_log(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+    self.logs()
+        .join(format!("resources/{resource_name}-{track}.log"))
+}
+
+pub fn resource_pid(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+    self.run()
+        .join(format!("resources/{resource_name}-{track}.pid"))
+}
+
+pub fn resource_runtime_metadata(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+    self.run()
+        .join(format!("resources/{resource_name}-{track}.json"))
+}
+
+pub fn resource_data_dir(&self, resource_name: &str, track: &str) -> Utf8PathBuf {
+    self.resources()
+        .join(resource_name)
+        .join(track)
+        .join("data")
+}
+```
+
+Add a small path snapshot test if existing path summary tests cover new helpers; otherwise keep coverage in daemon runtime tests.
+
+- [ ] **Step 8: Create daemon runtime foundation types**
+
+Create `crates/daemon/src/managed_resources/mod.rs` with these public-to-crate types:
+
+```rust
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use state::{Database, EnvContextValues, PvPaths, ResourceAllocationRecord};
+
+use crate::{DaemonError, ProcessSpec, ReadinessCheck};
+
+const RESOURCE_HOST: &str = "127.0.0.1";
+const RESOURCE_READINESS_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ManagedResourcePortSpec {
+    pub name: &'static str,
+    pub preferred_port: u16,
+    pub env_key: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ManagedResourcePortAssignment {
+    pub name: String,
+    pub port: u16,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ManagedResourceRuntimeContext {
+    pub resource_name: String,
+    pub track: String,
+    pub artifact_path: Utf8PathBuf,
+    pub data_dir: Utf8PathBuf,
+    pub ports: BTreeMap<String, u16>,
+}
+
+pub(crate) trait ManagedResourceRuntimeAdapter: Send + Sync {
+    fn resource_name(&self) -> &'static str;
+    fn artifact_adapter(&self) -> Result<resources::RuntimeArtifactAdapter, DaemonError>;
+    fn port_specs(&self) -> &'static [ManagedResourcePortSpec];
+    fn build_process_spec(&self, paths: &PvPaths, context: &ManagedResourceRuntimeContext)
+        -> Result<ProcessSpec, DaemonError>;
+    fn readiness(&self, context: &ManagedResourceRuntimeContext) -> Result<ReadinessCheck, DaemonError>;
+    fn resource_env(&self, context: &ManagedResourceRuntimeContext) -> Result<EnvContextValues, DaemonError>;
+    async fn reconcile_allocations(
+        &self,
+        _paths: &PvPaths,
+        _database: &mut Database,
+        _context: &ManagedResourceRuntimeContext,
+        _allocations: &[ResourceAllocationRecord],
+    ) -> Result<(), DaemonError> {
+        Ok(())
+    }
+}
+```
+
+Implement a `ManagedResourceRuntimeCatalog` that stores adapters by canonical resource name and carries install options:
+
+```rust
+#[derive(Clone, Debug)]
+pub(crate) struct ManagedResourceInstallOptions {
+    pub manifest_url: String,
+    pub target_platform: resources::TargetPlatform,
+}
+```
+
+Production uses `https://artifacts.prvious.test/manifest.json` and the current platform. Tests construct a catalog with a local fixture manifest URL and fake adapters. Production starts with no real backing-resource adapters in this task; test code can build a catalog with fake adapters.
+
+- [ ] **Step 9: Add daemon errors**
+
+In `crates/daemon/src/error.rs`, add:
+
+```rust
+#[error("Managed Resource runtime `{resource}` is not supported yet")]
+UnsupportedManagedResourceRuntime { resource: String },
+
+#[error("Managed Resource runtime `{resource}` track `{track}` is missing installed artifact path")]
+ManagedResourceArtifactMissing { resource: String, track: String },
+
+#[error("Managed Resource runtime `{resource}` track `{track}` is missing port `{port}`")]
+ManagedResourcePortMissing {
+    resource: String,
+    track: String,
+    port: String,
+},
+```
+
+- [ ] **Step 10: Wire resource reconciliation into Project env rendering**
+
+Change `reconcile_project_env` in `crates/daemon/src/project_env.rs` to async:
+
+```rust
+pub(crate) async fn reconcile_project_env(
+    paths: &PvPaths,
+    project_id: &str,
+) -> Result<ProjectEnvReconciliationSummary, DaemonError>
+```
+
+After `apply_project_resource_plan(database, &project.id, &plan)?;`, call:
+
+```rust
+crate::managed_resources::reconcile_project_resources(paths, database, &project, &plan).await?;
+```
+
+Make `ProjectResourcePlan` and `ProjectResourceAllocationPlan` fields `pub(crate)` so the daemon-local runtime module can inspect demanded resources and allocations. Do not expose these types outside `daemon`.
+
+In `crates/daemon/src/jobs.rs`, update:
+
+```rust
+let project_env_summary = reconcile_project_env(paths, id.as_str()).await?;
+```
+
+Make `reconcile_system_projects` async and await each Project reconciliation in sequence. This preserves the current ordered error reporting.
+
+- [ ] **Step 11: Implement resource runtime reconciliation**
+
+In `crates/daemon/src/managed_resources/mod.rs`, implement:
+
+```rust
+pub(crate) async fn reconcile_project_resources(
+    paths: &PvPaths,
+    database: &mut Database,
+    project: &state::ProjectRecord,
+    plan: &crate::project_env::ProjectResourcePlan,
+) -> Result<(), DaemonError>
+```
+
+Behavior:
+
+1. For every resource in `plan.resources`, look up a runtime adapter in the catalog.
+2. If no adapter is registered, return `DaemonError::UnsupportedManagedResourceRuntime`.
+3. Ensure the track is installed. If a track row exists without `current_artifact_path`, return `ManagedResourceArtifactMissing` in this task. Demand-driven install from manifests is added in Step 12.
+4. Assign every named port with `PortRequest::resource_port`.
+5. Build `ManagedResourceRuntimeContext`.
+6. Start or adopt the process with `ProcessSupervisor`.
+7. Wait for readiness.
+8. Record `RuntimeSubject::Resource { name, track }` as `Running`.
+9. Record resource env context with `database.record_managed_resource_track_env_context`.
+10. Load desired allocations for the Project/resource/track and call `adapter.reconcile_allocations`.
+
+Use the existing gateway runtime start/adopt pattern. PV must verify ownership before adopting or stopping.
+
+- [ ] **Step 12: Add demand-driven install for missing tracks**
+
+Add this helper in `managed_resources/mod.rs`:
+
+```rust
+fn install_missing_track_blocking(
+    paths: PvPaths,
+    resource_name: String,
+    track: String,
+) -> Result<(), DaemonError>
+```
+
+The helper uses:
+
+```rust
+let commands = resources::ManagedResourceCommands::new(
+    paths,
+    install_options.manifest_url,
+    install_options.target_platform,
+);
+let adapter = catalog
+    .adapter(&resource_name)?
+    .artifact_adapter()?;
+let client = resources::UreqResourceHttpClient::default();
+commands.install(&adapter, resources::TrackSelector::Track(resources::TrackName::new(track)?), &client)?;
+```
+
+Run this helper from async reconciliation with `tokio::task::spawn_blocking`. The production adapter map controls which `resources::RuntimeArtifactAdapter` is available. In this task, only test adapters use this path. The fake-runtime tests must exercise both preinstalled artifacts and missing-track install from a local fixture manifest.
+
+Add `current_target_platform()` by reusing the CLI mapping:
+
+```rust
+fn current_target_platform() -> resources::TargetPlatform {
+    resources::TargetPlatform {
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+    }
+}
+```
+
+- [ ] **Step 13: Add test-only fake runtime**
+
+Create `crates/daemon/src/managed_resources/fake.rs` gated with `#[cfg(test)]`. The fake adapter uses canonical resource `mailpit` and ports `smtp` and `dashboard`, but it is registered only through test catalog construction.
+
+The fake `build_process_spec` runs `/bin/sh` with a script that writes a log line and serves two TCP listeners. Use a fixture script under a temp artifact root in the test, not a checked-in binary.
+
+Add a test in `crates/daemon/tests/managed_resource_runtime.rs`:
+
+```rust
+#[tokio::test]
+async fn demanded_resource_starts_fake_multi_port_runtime_before_env_rendering() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mailpit:
+  version: "1.0"
+  env:
+    MAIL_HOST: "${smtp_host}"
+    MAIL_PORT: "${smtp_port}"
+    MAILPIT_DASHBOARD: "${dashboard_url}"
+"#,
+    )?;
+    seed_fake_mailpit_artifact(&paths, "1.0")?;
+
+    let catalog = fake_runtime_catalog()?;
+    reconcile_project_env_with_catalog(&paths, &project.id, &catalog).await?;
+    let database = Database::open(&paths)?;
+
+    assert_with_normalized_timestamps(
+        "demanded_resource_starts_fake_multi_port_runtime_before_env_rendering",
+        (
+            read_dotenv(&project)?,
+            database.managed_resource_track("mailpit", "1.0")?,
+            database.assigned_ports()?,
+            database.runtime_observed_states()?,
+        ),
+    )?;
+
+    Ok(())
+}
+```
+
+Also add tests for readiness failure and demand removal stopping the fake runtime. The demand-removal test should rewrite Project config without `mailpit`, run reconciliation again, and assert observed state is `Stopped` for the resource subject.
+
+- [ ] **Step 14: Add private artifact command helper**
+
+Create `crates/cli/src/commands/artifact_resource.rs`:
+
+```rust
+use std::io::Write;
+use std::process::ExitCode;
+
+use resources::{
+    ManagedResourceCommands, ManagedResourceUninstallOptions, ResourceAdapter,
+    ResourceHttpClient, ResourceName, TargetPlatform, TrackName, TrackSelector,
+    UreqResourceHttpClient,
+};
+use state::{Database, PvPaths};
+
+use crate::environment::Environment;
+use crate::error::ExecuteError;
+use crate::output::{Output, OutputMode};
+
+pub(crate) struct ArtifactResourceCommandSpec {
+    pub resource_name: &'static str,
+    pub display_name: &'static str,
+    pub adapter: fn() -> resources::Result<resources::RuntimeArtifactAdapter>,
+}
+```
+
+Implement `install`, `update`, `uninstall`, and `list` functions that mirror PHP/Composer output style and call `request_system_reconciliation` after state-changing commands. Keep open/dashboard commands in each adapter module because only Mailpit and RustFS expose read-only open behavior in this wave.
+
+Add `mod artifact_resource;` to `crates/cli/src/commands/mod.rs`.
+
+- [ ] **Step 15: Run foundation verification**
+
+Run:
+
+```bash
+cargo nextest run -p state -p daemon -p cli --locked resource_port_allocator_distinguishes_named_ports_for_one_track
+cargo nextest run -p state -p daemon -p cli --locked demanded_resource_starts_fake_multi_port_runtime_before_env_rendering
+cargo insta test --accept --test-runner nextest -p state -p daemon -- resource_port_allocator_distinguishes_named_ports_for_one_track demanded_resource_starts_fake_multi_port_runtime_before_env_rendering
+cargo fmt --all -- --check
+cargo clippy -p state -p daemon -p cli --all-targets --locked -- -D warnings
+git diff --check
+```
+
+Expected: commands pass; snapshots change only for the new or updated tests.
+
+- [ ] **Step 16: Commit runtime foundation**
+
+Run:
+
+```bash
+git status --short
+git add crates/state crates/daemon crates/cli
+git commit -m "feat: add managed resource runtime foundation"
+```
+
+Expected: one conventional commit on `pr-16-20-runtime-foundation`.
+
+## Task 2: SQL Foundation
+
+**Files:**
+
+- Modify: `Cargo.toml`
+- Modify: `crates/daemon/Cargo.toml`
+- Create: `crates/daemon/src/managed_resources/sql.rs`
+- Modify: `crates/daemon/src/managed_resources/mod.rs`
+- Create: `crates/daemon/tests/sql_foundation.rs`
+- Modify: `Cargo.lock`
+
+- [ ] **Step 1: Add SQL dependency**
+
+Add workspace dependency:
+
+```toml
+sqlx = { version = "0.9.0", default-features = false, features = ["mysql", "postgres", "runtime-tokio", "tls-rustls"] }
+```
+
+Add daemon dependency:
+
+```toml
+sqlx = { workspace = true }
+```
+
+Run:
+
+```bash
+cargo update -p sqlx --precise 0.9.0
+```
+
+Expected: `Cargo.lock` updates for `sqlx` and its transitive dependencies only.
+
+- [ ] **Step 2: Write SQL foundation tests**
+
+Create `crates/daemon/tests/sql_foundation.rs` with recording-admin tests:
+
+```rust
+#[tokio::test]
+async fn sql_foundation_creates_database_and_marks_allocation_ready() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = seed_project_with_desired_mysql_allocation(&paths)?;
+    let mut database = Database::open(&paths)?;
+    let mut admin = RecordingSqlAdmin::default();
+
+    daemon::managed_resources::sql::ensure_database_allocation_for_test(
+        &mut database,
+        &mut admin,
+        &project.id,
+        "mysql",
+        "8.0",
+        "app-db",
+        SqlEngine::Mysql,
+        &sql_admin_context(),
+    )
+    .await?;
+
+    assert_debug_snapshot!((
+        admin.operations(),
+        database.resource_allocations(&project.id, "mysql")?,
+    ));
+
+    Ok(())
+}
+```
+
+Add a Postgres variant and a test that leaves an already-ready allocation untouched except for verifying the database exists.
+
+- [ ] **Step 3: Implement shared SQL helpers**
+
+Create `crates/daemon/src/managed_resources/sql.rs`:
+
+```rust
+use state::{Database, EnvContextValues};
+
+use crate::DaemonError;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SqlEngine {
+    Mysql,
+    Postgres,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SqlAdminContext {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SqlAllocationContext {
+    pub database: String,
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+}
+```
+
+Implement:
+
+```rust
+pub(crate) fn sql_resource_env(context: &SqlAdminContext, engine: SqlEngine) -> EnvContextValues
+pub(crate) fn sql_allocation_env(context: &SqlAllocationContext, engine: SqlEngine) -> EnvContextValues
+pub(crate) async fn ping_admin(context: &SqlAdminContext, engine: SqlEngine) -> Result<(), DaemonError>
+pub(crate) async fn create_database_if_missing(context: &SqlAdminContext, engine: SqlEngine, database: &str) -> Result<(), DaemonError>
+```
+
+Use dynamic queries:
+
+```rust
+sqlx::query("SELECT 1").execute(&pool).await?;
+```
+
+For MySQL database creation, use a backtick-quoted identifier built by a helper that accepts only ASCII alphanumeric and underscore. For Postgres, use a double-quoted identifier helper with the same accepted character set. Generated allocation names already use that character set for SQL allocations.
+
+- [ ] **Step 4: Expose SQL helpers to adapter modules**
+
+In `crates/daemon/src/managed_resources/mod.rs`, add:
+
+```rust
+pub(crate) mod sql;
+```
+
+- [ ] **Step 5: Run SQL foundation verification**
+
+Run:
+
+```bash
+cargo nextest run -p daemon --locked sql_foundation_creates_database_and_marks_allocation_ready
+cargo insta test --accept --test-runner nextest -p daemon -- sql_foundation
+cargo fmt --all -- --check
+cargo clippy -p daemon --all-targets --locked -- -D warnings
+git diff --check
+```
+
+Expected: daemon tests pass and snapshots cover generated SQL env values.
+
+- [ ] **Step 6: Commit SQL foundation**
+
+Run:
+
+```bash
+git status --short
+git add Cargo.toml Cargo.lock crates/daemon
+git commit -m "feat: add managed resource SQL foundation"
+```
+
+## Task 3: Mailpit Adapter PR 16
+
+**Files:**
+
+- Modify: `crates/resources/src/runtime.rs`
+- Create: `crates/daemon/src/managed_resources/mailpit.rs`
+- Modify: `crates/daemon/src/managed_resources/mod.rs`
+- Modify: `crates/cli/src/args.rs`
+- Create: `crates/cli/src/commands/mailpit.rs`
+- Modify: `crates/cli/src/commands/mod.rs`
+- Modify: `it/cli.rs`
+- Modify: `it/snapshots/*.snap`
+
+- [ ] **Step 1: Add Mailpit layout validator**
+
+In `crates/resources/src/runtime.rs`, add:
+
+```rust
+pub fn mailpit_adapter() -> Result<RuntimeArtifactAdapter> {
+    Ok(RuntimeArtifactAdapter::new(
+        ResourceName::new("mailpit")?,
+        "bin/mailpit",
+    ))
+}
+```
+
+Add a resources test with a temp artifact root that passes when `bin/mailpit` exists and fails with `InvalidArtifactLayout` when missing.
+
+- [ ] **Step 2: Add Mailpit runtime module**
+
+Create `crates/daemon/src/managed_resources/mailpit.rs`:
+
+```rust
+const PORTS: &[ManagedResourcePortSpec] = &[
+    ManagedResourcePortSpec { name: "smtp", preferred_port: 1025, env_key: "smtp_port" },
+    ManagedResourcePortSpec { name: "dashboard", preferred_port: 8025, env_key: "dashboard_port" },
+];
+```
+
+Build process arguments:
+
+```rust
+vec![
+    "--smtp".to_string(),
+    format!("127.0.0.1:{}", context.port("smtp")?),
+    "--listen".to_string(),
+    format!("127.0.0.1:{}", context.port("dashboard")?),
+]
+```
+
+Readiness is HTTP on dashboard path `/`.
+
+Resource env values:
+
+```rust
+smtp_host = "127.0.0.1"
+smtp_port = smtp port as string
+dashboard_url = "http://127.0.0.1:{dashboard}"
+```
+
+No allocations are reconciled for Mailpit.
+
+- [ ] **Step 3: Add Mailpit daemon tests**
+
+Add tests in `crates/daemon/tests/managed_resource_runtime.rs` or `crates/daemon/tests/mailpit_adapter.rs`:
+
+```rust
+#[tokio::test]
+async fn mailpit_reconciliation_records_smtp_and_dashboard_env() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project_with_mailpit_env(&paths, &tempdir.path().join("project"))?;
+    seed_mailpit_fixture_artifact(&paths, "1.0")?;
+
+    run_project_reconciliation(&paths, &project).await?;
+    let database = Database::open(&paths)?;
+
+    assert_with_normalized_timestamps(
+        "mailpit_reconciliation_records_smtp_and_dashboard_env",
+        (
+            read_dotenv(&project)?,
+            database.managed_resource_track("mailpit", "1.0")?,
+            database.runtime_observed_states()?,
+        ),
+    )?;
+
+    Ok(())
+}
+```
+
+The fixture `bin/mailpit` must be test-only and must implement the two expected listen ports.
+
+Add a second daemon test named `mailpit_project_demand_installs_missing_fixture_track_before_start`. It should seed only a local fixture manifest and artifact archive, not a preinstalled track row. Project reconciliation must install the fixture track, start Mailpit, record env context, and render `.env`.
+
+- [ ] **Step 4: Add Mailpit CLI namespace**
+
+In `crates/cli/src/args.rs`, add variants for:
+
+```text
+mailpit:install [version]
+mailpit:update
+mailpit:uninstall <version> [--prune] [--force]
+mailpit:list
+mailpit:open
+mail:install [version]
+mail:update
+mail:uninstall <version> [--prune] [--force]
+mail:list
+mail:open
+```
+
+Use the existing PHP argument structs where the field names match; create `MailpitInstallArgs` and `MailpitUninstallArgs` only if clap help text needs resource-specific wording.
+
+Create `crates/cli/src/commands/mailpit.rs`. Install/update/uninstall/list call `artifact_resource`. `open` reads `managed_resource_tracks.env_json`; it opens only when `dashboard_url` exists and the observed runtime subject for `mailpit` track is `Running`. If not running, print:
+
+```text
+Mailpit is not running for any linked Project
+```
+
+Do not enqueue reconciliation from `mailpit:open` or `mail:open`.
+
+- [ ] **Step 5: Add Mailpit CLI snapshots**
+
+In `it/cli.rs`, add:
+
+```rust
+#[test]
+fn mailpit_commands_are_documented() -> Result<()> {
+    let output = [
+        run_pv(&["mailpit:install", "--help"])?,
+        run_pv(&["mailpit:update", "--help"])?,
+        run_pv(&["mailpit:uninstall", "--help"])?,
+        run_pv(&["mailpit:list", "--help"])?,
+        run_pv(&["mailpit:open", "--help"])?,
+        run_pv(&["mail:open", "--help"])?,
+    ];
+
+    assert_debug_snapshot!(output);
+
+    Ok(())
+}
+```
+
+Run:
+
+```bash
+cargo insta test --accept --test-runner nextest --test cli -- mailpit_commands_are_documented
+```
+
+- [ ] **Step 6: Verify and commit Mailpit**
+
+Run:
+
+```bash
+cargo nextest run -p resources -p daemon --locked mailpit
+cargo insta test --accept --test-runner nextest -p daemon -- mailpit
+cargo insta test --accept --test-runner nextest --test cli -- mailpit_commands_are_documented
+cargo fmt --all -- --check
+cargo clippy -p resources -p daemon -p cli --all-targets --locked -- -D warnings
+git diff --check
+git add crates/resources crates/daemon crates/cli it
+git commit -m "feat: add Mailpit managed resource adapter"
+```
+
+## Task 4: Redis Adapter PR 17
+
+**Files:**
+
+- Modify: `Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `crates/daemon/Cargo.toml`
+- Modify: `crates/resources/src/runtime.rs`
+- Create: `crates/daemon/src/managed_resources/redis.rs`
+- Modify: `crates/daemon/src/managed_resources/mod.rs`
+- Modify: `crates/cli/src/args.rs`
+- Create: `crates/cli/src/commands/redis.rs`
+- Modify: `crates/cli/src/commands/mod.rs`
+- Modify: `it/cli.rs`
+- Modify: `it/snapshots/*.snap`
+
+- [ ] **Step 1: Add Redis dependency and layout validator**
+
+Add workspace and daemon dependencies as shown in the dependency matrix, then run:
+
+```bash
+cargo update -p redis --precise 1.2.2
+```
+
+In `crates/resources/src/runtime.rs`, add:
+
+```rust
+pub fn redis_adapter() -> Result<RuntimeArtifactAdapter> {
+    Ok(RuntimeArtifactAdapter::new(
+        ResourceName::new("redis")?,
+        "bin/redis-server",
+    ))
+}
+```
+
+- [ ] **Step 2: Add Redis runtime module**
+
+Create `crates/daemon/src/managed_resources/redis.rs`.
+
+Port spec:
+
+```rust
+const PORTS: &[ManagedResourcePortSpec] = &[
+    ManagedResourcePortSpec { name: "redis", preferred_port: 6379, env_key: "port" },
+];
+```
+
+Process arguments:
+
+```rust
+vec![
+    "--bind".to_string(),
+    "127.0.0.1".to_string(),
+    "--port".to_string(),
+    context.port("redis")?.to_string(),
+    "--dir".to_string(),
+    context.data_dir.as_str().to_string(),
+    "--save".to_string(),
+    String::new(),
+    "--appendonly".to_string(),
+    "no".to_string(),
+]
+```
+
+Readiness uses Redis PING:
+
+```rust
+let url = format!("redis://127.0.0.1:{}/", context.port("redis")?);
+let client = redis::Client::open(url)?;
+let mut connection = client.get_multiplexed_async_connection().await?;
+let pong: String = redis::cmd("PING").query_async(&mut connection).await?;
+if pong != "PONG" {
+    return Err(DaemonError::DaemonRejected {
+        message: format!("Redis PING returned {pong}"),
+    });
+}
+```
+
+Resource env:
+
+```text
+host=127.0.0.1
+port=<redis port>
+url=redis://127.0.0.1:<redis port>/0
+```
+
+Allocation env for each desired allocation:
+
+```text
+host=127.0.0.1
+port=<redis port>
+prefix=<resource_allocations.generated_name>
+url=redis://127.0.0.1:<redis port>/0
+```
+
+Mark each desired allocation ready after PING succeeds. Redis v1 does not create logical databases or ACL users.
+
+- [ ] **Step 3: Add Redis tests**
+
+Add daemon test:
+
+```rust
+#[tokio::test]
+async fn redis_reconciliation_marks_prefix_allocation_ready_and_renders_env() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project_with_redis_allocation_env(&paths, &tempdir.path().join("project"))?;
+    seed_redis_fixture_artifact(&paths, "7.2")?;
+
+    run_project_reconciliation(&paths, &project).await?;
+    let database = Database::open(&paths)?;
+
+    assert_with_normalized_timestamps(
+        "redis_reconciliation_marks_prefix_allocation_ready_and_renders_env",
+        (
+            read_dotenv(&project)?,
+            database.managed_resource_track("redis", "7.2")?,
+            database.resource_allocations(&project.id, "redis")?,
+        ),
+    )?;
+
+    Ok(())
+}
+```
+
+The fixture `bin/redis-server` must accept the arguments above and implement PING.
+
+Add a second daemon test named `redis_project_demand_installs_missing_fixture_track_before_start`. It should seed only a local fixture manifest and artifact archive, not a preinstalled track row. Project reconciliation must install the fixture track, start Redis, mark the prefix allocation ready, and render `.env`.
+
+- [ ] **Step 4: Add Redis CLI namespace**
+
+Add public commands:
+
+```text
+redis:install [version]
+redis:update
+redis:uninstall <version> [--prune] [--force]
+redis:list
+```
+
+Create `crates/cli/src/commands/redis.rs` using the private `artifact_resource` helper. Add `redis_commands_are_documented` in `it/cli.rs`.
+
+- [ ] **Step 5: Verify and commit Redis**
+
+Run:
+
+```bash
+cargo nextest run -p resources -p daemon --locked redis
+cargo insta test --accept --test-runner nextest -p daemon -- redis
+cargo insta test --accept --test-runner nextest --test cli -- redis_commands_are_documented
+cargo fmt --all -- --check
+cargo clippy -p resources -p daemon -p cli --all-targets --locked -- -D warnings
+git diff --check
+git add Cargo.toml Cargo.lock crates/resources crates/daemon crates/cli it
+git commit -m "feat: add Redis managed resource adapter"
+```
+
+## Task 5: RustFS Adapter PR 20
+
+**Files:**
+
+- Modify: `Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `crates/daemon/Cargo.toml`
+- Modify: `crates/resources/src/runtime.rs`
+- Create: `crates/daemon/src/managed_resources/rustfs.rs`
+- Modify: `crates/daemon/src/managed_resources/mod.rs`
+- Modify: `crates/cli/src/args.rs`
+- Create: `crates/cli/src/commands/rustfs.rs`
+- Modify: `crates/cli/src/commands/mod.rs`
+- Modify: `it/cli.rs`
+- Modify: `it/snapshots/*.snap`
+
+- [ ] **Step 1: Add RustFS dependencies and layout validator**
+
+Add workspace and daemon dependencies as shown in the dependency matrix, then run:
+
+```bash
+cargo update -p object_store --precise 0.13.2
+cargo update -p aws-sdk-s3 --precise 1.135.0
+```
+
+In `crates/resources/src/runtime.rs`, add:
+
+```rust
+pub fn rustfs_adapter() -> Result<RuntimeArtifactAdapter> {
+    Ok(RuntimeArtifactAdapter::new(
+        ResourceName::new("rustfs")?,
+        "bin/rustfs",
+    ))
+}
+```
+
+- [ ] **Step 2: Add RustFS runtime module**
+
+Port specs:
+
+```rust
+const PORTS: &[ManagedResourcePortSpec] = &[
+    ManagedResourcePortSpec { name: "api", preferred_port: 9000, env_key: "port" },
+    ManagedResourcePortSpec { name: "console", preferred_port: 9001, env_key: "console_port" },
+];
+```
+
+Generate stable access keys when `managed_resource_tracks.env_json` is empty. Use values:
+
+```text
+access_key=pv-rustfs
+secret_key=<generated 32 character hex string>
+```
+
+Process arguments:
+
+```rust
+vec![
+    "--address".to_string(),
+    format!("127.0.0.1:{}", context.port("api")?),
+    "--console-address".to_string(),
+    format!("127.0.0.1:{}", context.port("console")?),
+    context.data_dir.as_str().to_string(),
+]
+```
+
+Readiness is HTTP on the API port path `/`.
+
+Resource env:
+
+```text
+access_key=<stable access key>
+secret_key=<stable secret key>
+endpoint=http://127.0.0.1:<api port>
+host=127.0.0.1
+port=<api port>
+url=http://127.0.0.1:<api port>
+```
+
+Allocation behavior:
+
+1. Create bucket with `aws-sdk-s3` `create_bucket`.
+2. Treat already-existing bucket as success.
+3. Verify object operations by creating a short object with `object_store::aws::AmazonS3Builder` and `ObjectStoreExt::put` followed by `head`.
+4. Mark allocation ready with `bucket`, `access_key`, `secret_key`, `endpoint`, `host`, `port`, and `url`.
+
+- [ ] **Step 3: Add RustFS tests**
+
+Add daemon test:
+
+```rust
+#[tokio::test]
+async fn rustfs_reconciliation_creates_bucket_and_renders_env() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project_with_rustfs_bucket_env(&paths, &tempdir.path().join("project"))?;
+    seed_rustfs_fixture_artifact(&paths, "1.0")?;
+
+    run_project_reconciliation(&paths, &project).await?;
+    let database = Database::open(&paths)?;
+
+    assert_with_normalized_timestamps(
+        "rustfs_reconciliation_creates_bucket_and_renders_env",
+        (
+            read_dotenv(&project)?,
+            database.managed_resource_track("rustfs", "1.0")?,
+            database.resource_allocations(&project.id, "rustfs")?,
+        ),
+    )?;
+
+    Ok(())
+}
+```
+
+The fixture `bin/rustfs` must accept the arguments above, expose the API and console ports, and implement enough S3-compatible behavior for create-bucket, put, and head.
+
+Add a second daemon test named `rustfs_project_demand_installs_missing_fixture_track_before_start`. It should seed only a local fixture manifest and artifact archive, not a preinstalled track row. Project reconciliation must install the fixture track, start RustFS, create the bucket, mark the allocation ready, and render `.env`.
+
+- [ ] **Step 4: Add RustFS CLI namespace**
+
+Add public commands:
+
+```text
+rustfs:install [version]
+rustfs:update
+rustfs:uninstall <version> [--prune] [--force]
+rustfs:list
+rustfs:open
+s3:install [version]
+s3:update
+s3:uninstall <version> [--prune] [--force]
+s3:list
+s3:open
+```
+
+`rustfs:open` and `s3:open` read the resource env and observed state only. They do not install, start, or enqueue reconciliation. When not running, print:
+
+```text
+RustFS is not running for any linked Project
+```
+
+- [ ] **Step 5: Verify and commit RustFS**
+
+Run:
+
+```bash
+cargo nextest run -p resources -p daemon --locked rustfs
+cargo insta test --accept --test-runner nextest -p daemon -- rustfs
+cargo insta test --accept --test-runner nextest --test cli -- rustfs_commands_are_documented
+cargo fmt --all -- --check
+cargo clippy -p resources -p daemon -p cli --all-targets --locked -- -D warnings
+git diff --check
+git add Cargo.toml Cargo.lock crates/resources crates/daemon crates/cli it
+git commit -m "feat: add RustFS managed resource adapter"
+```
+
+## Task 6: MySQL Adapter PR 18
+
+**Files:**
+
+- Modify: `crates/resources/src/runtime.rs`
+- Create: `crates/daemon/src/managed_resources/mysql.rs`
+- Modify: `crates/daemon/src/managed_resources/mod.rs`
+- Modify: `crates/cli/src/args.rs`
+- Create: `crates/cli/src/commands/mysql.rs`
+- Modify: `crates/cli/src/commands/mod.rs`
+- Modify: `it/cli.rs`
+- Modify: `it/snapshots/*.snap`
+
+- [ ] **Step 1: Add MySQL layout validator**
+
+In `crates/resources/src/runtime.rs`, add:
+
+```rust
+pub fn mysql_adapter() -> Result<RuntimeArtifactAdapter> {
+    Ok(RuntimeArtifactAdapter::new(
+        ResourceName::new("mysql")?,
+        "bin/mysqld",
+    ))
+}
+```
+
+The adapter module may also require `bin/mysqladmin` if readiness uses that binary. The preferred path is `sqlx` readiness, so do not require `mysqladmin` unless implementation proves `mysqld` startup cannot be tested without it.
+
+- [ ] **Step 2: Add MySQL runtime module**
+
+Port spec:
+
+```rust
+const PORTS: &[ManagedResourcePortSpec] = &[
+    ManagedResourcePortSpec { name: "mysql", preferred_port: 3306, env_key: "port" },
+];
+```
+
+Generate stable admin credentials when env is empty:
+
+```text
+username=pv_root
+password=<generated 32 character hex string>
+```
+
+Process startup:
+
+1. Create data dir.
+2. If the data dir has no initialized MySQL system database, run `bin/mysqld --initialize-insecure --datadir <data_dir> --basedir <artifact_path>`.
+3. Start `bin/mysqld` with `--no-defaults`, `--datadir`, `--bind-address=127.0.0.1`, `--port`, and a socket path under `.pv/run/resources/mysql-<track>.sock`.
+4. Use `sql::ping_admin` for readiness.
+5. Store resource env with SQL foundation `sql_resource_env`.
+
+Allocation behavior:
+
+1. Use `sql::create_database_if_missing(SqlEngine::Mysql, generated_name)`.
+2. Mark allocation ready with SQL foundation `sql_allocation_env`.
+
+- [ ] **Step 3: Add MySQL tests**
+
+Add daemon test:
+
+```rust
+#[tokio::test]
+async fn mysql_reconciliation_creates_database_allocation_and_renders_env() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project_with_mysql_database_env(&paths, &tempdir.path().join("project"))?;
+    seed_mysql_fixture_artifact(&paths, "8.0")?;
+
+    run_project_reconciliation(&paths, &project).await?;
+    let database = Database::open(&paths)?;
+
+    assert_with_normalized_timestamps(
+        "mysql_reconciliation_creates_database_allocation_and_renders_env",
+        (
+            read_dotenv(&project)?,
+            database.managed_resource_track("mysql", "8.0")?,
+            database.resource_allocations(&project.id, "mysql")?,
+        ),
+    )?;
+
+    Ok(())
+}
+```
+
+The fixture `bin/mysqld` must simulate initialization, listen on the requested port, and allow the SQL foundation test admin seam to record create-database behavior without requiring real MySQL.
+
+Add a second daemon test named `mysql_project_demand_installs_missing_fixture_track_before_start`. It should seed only a local fixture manifest and artifact archive, not a preinstalled track row. Project reconciliation must install the fixture track, start MySQL, create the database allocation through the SQL helper, and render `.env`.
+
+- [ ] **Step 4: Add MySQL CLI namespace**
+
+Add public commands:
+
+```text
+mysql:install [version]
+mysql:update
+mysql:uninstall <version> [--prune] [--force]
+mysql:list
+```
+
+Create `crates/cli/src/commands/mysql.rs` using `artifact_resource`. Add `mysql_commands_are_documented` in `it/cli.rs`.
+
+- [ ] **Step 5: Verify and commit MySQL**
+
+Run:
+
+```bash
+cargo nextest run -p resources -p daemon --locked mysql
+cargo insta test --accept --test-runner nextest -p daemon -- mysql
+cargo insta test --accept --test-runner nextest --test cli -- mysql_commands_are_documented
+cargo fmt --all -- --check
+cargo clippy -p resources -p daemon -p cli --all-targets --locked -- -D warnings
+git diff --check
+git add crates/resources crates/daemon crates/cli it
+git commit -m "feat: add MySQL managed resource adapter"
+```
+
+## Task 7: Postgres Adapter PR 19
+
+**Files:**
+
+- Modify: `crates/resources/src/runtime.rs`
+- Create: `crates/daemon/src/managed_resources/postgres.rs`
+- Modify: `crates/daemon/src/managed_resources/mod.rs`
+- Modify: `crates/cli/src/args.rs`
+- Create: `crates/cli/src/commands/postgres.rs`
+- Modify: `crates/cli/src/commands/mod.rs`
+- Modify: `it/cli.rs`
+- Modify: `it/snapshots/*.snap`
+
+- [ ] **Step 1: Add Postgres layout validator**
+
+In `crates/resources/src/runtime.rs`, add:
+
+```rust
+pub fn postgres_adapter() -> Result<RuntimeArtifactAdapter> {
+    Ok(RuntimeArtifactAdapter::new(
+        ResourceName::new("postgres")?,
+        "bin/postgres",
+    ))
+}
+```
+
+Require `bin/initdb` as an additional file in `validate_installation` for Postgres. This can be done by creating a Postgres-specific adapter struct if the generic single-executable adapter is too narrow.
+
+- [ ] **Step 2: Add Postgres runtime module**
+
+Port spec:
+
+```rust
+const PORTS: &[ManagedResourcePortSpec] = &[
+    ManagedResourcePortSpec { name: "postgres", preferred_port: 5432, env_key: "port" },
+];
+```
+
+Generate stable admin credentials when env is empty:
+
+```text
+username=pv_root
+password=<generated 32 character hex string>
+```
+
+Process startup:
+
+1. Create data dir.
+2. If the data dir lacks `PG_VERSION`, run `bin/initdb -D <data_dir> --username pv_root --pwfile <temporary password file> --auth-host=scram-sha-256 --auth-local=trust`.
+3. Start `bin/postgres -D <data_dir> -h 127.0.0.1 -p <port>`.
+4. Use `sql::ping_admin` for readiness.
+5. Store resource env with SQL foundation `sql_resource_env`.
+
+Allocation behavior:
+
+1. Use `sql::create_database_if_missing(SqlEngine::Postgres, generated_name)`.
+2. Mark allocation ready with SQL foundation `sql_allocation_env`.
+
+- [ ] **Step 3: Add Postgres tests**
+
+Add daemon test:
+
+```rust
+#[tokio::test]
+async fn postgres_reconciliation_creates_database_allocation_and_renders_env() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project_with_postgres_database_env(&paths, &tempdir.path().join("project"))?;
+    seed_postgres_fixture_artifact(&paths, "16")?;
+
+    run_project_reconciliation(&paths, &project).await?;
+    let database = Database::open(&paths)?;
+
+    assert_with_normalized_timestamps(
+        "postgres_reconciliation_creates_database_allocation_and_renders_env",
+        (
+            read_dotenv(&project)?,
+            database.managed_resource_track("postgres", "16")?,
+            database.resource_allocations(&project.id, "postgres")?,
+        ),
+    )?;
+
+    Ok(())
+}
+```
+
+The fixture `bin/postgres` and `bin/initdb` must simulate initialization and the requested port.
+
+Add a second daemon test named `postgres_project_demand_installs_missing_fixture_track_before_start`. It should seed only a local fixture manifest and artifact archive, not a preinstalled track row. Project reconciliation must install the fixture track, start Postgres, create the database allocation through the SQL helper, and render `.env`.
+
+- [ ] **Step 4: Add Postgres CLI namespace**
+
+Add public commands:
+
+```text
+postgres:install [version]
+postgres:update
+postgres:uninstall <version> [--prune] [--force]
+postgres:list
+pg:install [version]
+pg:update
+pg:uninstall <version> [--prune] [--force]
+pg:list
+```
+
+Create `crates/cli/src/commands/postgres.rs` using `artifact_resource`. Add `postgres_commands_are_documented` in `it/cli.rs`.
+
+- [ ] **Step 5: Verify and commit Postgres**
+
+Run:
+
+```bash
+cargo nextest run -p resources -p daemon --locked postgres
+cargo insta test --accept --test-runner nextest -p daemon -- postgres
+cargo insta test --accept --test-runner nextest --test cli -- postgres_commands_are_documented
+cargo fmt --all -- --check
+cargo clippy -p resources -p daemon -p cli --all-targets --locked -- -D warnings
+git diff --check
+git add crates/resources crates/daemon crates/cli it
+git commit -m "feat: add Postgres managed resource adapter"
+```
+
+## Task 8: Final Orchestration Check
+
+**Files:**
+
+- No required source edits.
+- Solo work items and scratchpad are updated outside git.
+
+- [ ] **Step 1: Convert the final plan into Solo work items**
+
+Use the existing Solo project and shared scratchpad. Update or create work items with these titles:
+
+```text
+Shared Managed Resource runtime foundation
+Shared SQL foundation
+PR 16 Mailpit adapter
+PR 17 Redis adapter
+PR 18 MySQL adapter
+PR 19 Postgres adapter
+PR 20 RustFS adapter
+```
+
+Set blockers:
+
+```text
+SQL foundation -> runtime foundation
+Mailpit -> runtime foundation
+Redis -> runtime foundation
+RustFS -> runtime foundation
+MySQL -> runtime foundation, SQL foundation
+Postgres -> runtime foundation, SQL foundation
+```
+
+Add each worktree path and branch name to the item body after the worktree is created.
+
+- [ ] **Step 2: Review branch independence**
+
+Run in each worktree:
+
+```bash
+git status --short --branch
+git log --oneline --decorate --max-count=5
+```
+
+Expected:
+
+- Runtime foundation has one feature commit on top of the plan base.
+- SQL foundation contains runtime foundation plus one SQL commit.
+- Mailpit, Redis, and RustFS contain runtime foundation plus their adapter commit.
+- MySQL and Postgres contain runtime foundation, SQL foundation, and their adapter commit.
+
+- [ ] **Step 3: Run integration surface checks before PR handoff**
+
+After all adapter branches are complete, run the broad but bounded check from the branch at the top of the stack:
+
+```bash
+cargo nextest run -p daemon -p resources -p state -p config -p cli --locked
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+git diff --check
+```
+
+Expected: all commands pass. If this check fails from branch stacking, fix the earliest affected branch and rebase dependent worktrees.
+
+## Final PR Acceptance Criteria
+
+Runtime foundation:
+
+- Resource port assignments support named ports for one resource/track.
+- Resource runtime observed subjects round-trip through state.
+- Project reconciliation can start/adopt/stop a test-only multi-port backing runtime before `.env` rendering.
+- No public fake runtime appears in CLI help, shell completions, registry examples, or manifests.
+
+SQL foundation:
+
+- Shared SQL helpers cover MySQL and Postgres URL/env generation.
+- Dynamic `sqlx` queries are used.
+- No MySQL or Postgres adapter is implemented in the SQL foundation PR.
+
+Each adapter:
+
+- Adds its own public command namespace.
+- Installs, updates, uninstalls, and lists artifacts through the shared command helper.
+- Starts only from Project config demand.
+- Installs a missing demanded track from a fixture manifest during Project reconciliation tests.
+- Uses fixture artifacts for PR tests.
+- Records resource env context before Project `.env` rendering.
+- Marks allocations ready when the adapter supports allocations.
+- Keeps `mailpit:open` and `rustfs:open` read-only.
+
+## Documentation Links Used For Dependencies
+
+- `sqlx` docs: https://docs.rs/sqlx/latest/sqlx/
+- `redis` docs: https://docs.rs/redis/
+- `object_store` docs: https://docs.rs/object_store/0.13.2/
+- `aws-sdk-s3` docs: https://docs.rs/aws-sdk-s3/1.135.0/

--- a/docs/superpowers/specs/2026-06-08-pr-16-20-managed-resource-adapters-design.md
+++ b/docs/superpowers/specs/2026-06-08-pr-16-20-managed-resource-adapters-design.md
@@ -1,0 +1,297 @@
+# PR 16-20 Managed Resource Adapters Design
+
+## Context
+
+PRs 16 through 20 implement the first backing Managed Resource adapters from `IMPLEMENTATION.md`: Mailpit, Redis, MySQL, Postgres, and RustFS.
+
+The roadmap says these adapters are parallel work after the adapter foundation and Project Resource allocation contracts. It also says adapter PRs should not depend on unpublished object-storage artifacts, and MySQL/Postgres must not begin by copying unfinished code from each other in parallel. This design turns that into a seven-workstream adapter wave with two small shared foundation PRs before the full adapter slices.
+
+The source-of-truth product constraints remain `DESIGN.md`:
+
+- Managed Resources are external artifacts installed and supervised by PV.
+- Backing Managed Resources are installed by setup/install commands but do not start until linked Project config demands them.
+- Project config demand can install a missing resource track automatically during reconciliation.
+- Resource allocation names are stable and stored in `pv.db`.
+- Generated local credentials are stored plainly in user-owned PV state for v1.
+- Public artifact recipes and object-storage publication are later release work, not adapter PR prerequisites.
+
+## Goals
+
+- Add a shared daemon-local Managed Resource runtime foundation.
+- Add a shared SQL foundation before MySQL and Postgres.
+- Implement Mailpit, Redis, MySQL, Postgres, and RustFS as full vertical adapter slices.
+- Keep each real adapter independently reviewable and testable with fixture artifacts.
+- Preserve existing crate boundaries unless a concrete adapter proves a narrow change is required.
+- Convert the final approved implementation plan into Solo todos with blocker relationships and worktree ownership metadata.
+
+## Non-Goals
+
+- Do not publish real Managed Resource artifacts.
+- Do not add public artifact recipes in these PRs.
+- Do not require upstream Mailpit, Redis, MySQL, Postgres, or RustFS binaries for normal PR verification.
+- Do not change public Project config syntax.
+- Do not casually expand the existing `resources::ResourceAdapter` install trait into a broad runtime trait.
+- Do not add rich status, logs, doctor, jobs, or JSON status UX beyond minimal runtime observed state. That remains PR 21 scope.
+- Do not run Project application behavior such as migrations, `APP_KEY`, Composer install, or Laravel commands.
+
+## Workstreams
+
+The adapter wave is seven workstreams:
+
+| Workstream | Purpose | Blocked By |
+| ---------- | ------- | ---------- |
+| Runtime foundation | Generic daemon-local runtime orchestration for backing Managed Resources | None |
+| SQL foundation | Shared MySQL/Postgres admin and allocation helpers | Runtime foundation |
+| Mailpit adapter | Full Mailpit adapter slice | Runtime foundation |
+| Redis adapter | Full Redis adapter slice | Runtime foundation |
+| RustFS adapter | Full RustFS adapter slice | Runtime foundation |
+| MySQL adapter | Full MySQL adapter slice | Runtime foundation, SQL foundation |
+| Postgres adapter | Full Postgres adapter slice | Runtime foundation, SQL foundation |
+
+This gives one root foundation branch, one SQL branch after it, and five adapter branches with explicit blockers.
+
+## Architecture
+
+Runtime orchestration stays in `daemon`.
+
+The `resources` crate continues to own resource identity, registry descriptors, Artifact manifest parsing, download/cache behavior, atomic installs, fixture artifacts, and install validation adapters. It should not gain a broad runtime adapter trait during the foundation PR.
+
+The `daemon` crate owns backing Managed Resource runtime behavior:
+
+- Project-demand detection.
+- Demand-driven artifact install before runtime start.
+- Named multi-port assignment.
+- `ProcessSpec` construction.
+- Start, adopt, stop, and ownership verification.
+- Readiness checks.
+- Log paths and runtime metadata.
+- Minimal observed runtime state.
+- Resource env context recording hooks.
+- Allocation reconciliation hooks for adapter-specific admin behavior.
+
+Adapter PRs add daemon-local resource runtime definitions/builders that consume installed artifact paths and existing registry descriptors.
+
+## Runtime Foundation
+
+The shared runtime foundation replaces non-Gateway resource reconciliation stubs with daemon-local Managed Resource runtime plumbing.
+
+The foundation must support named multi-port resources. Redis, MySQL, and Postgres each need a data port. Mailpit needs SMTP and HTTP UI ports. RustFS needs an S3/API port and, if the packaged runtime exposes it, a console UI port.
+
+Runtime start is driven by Project demand only. `pv setup` and resource `*:install` commands install artifacts or record desired installed state, but they do not start backing Managed Resource processes. When no linked Projects need a Managed Resource track, reconciliation stops that runtime while preserving installed artifacts and allocation data.
+
+When Project reconciliation sees a demanded resource track that is not installed, the daemon installs it before starting the runtime. The sequence is:
+
+1. Resolve Project resource track.
+2. Install the selected artifact if missing.
+3. Assign named ports.
+4. Start or adopt the runtime.
+5. Verify readiness.
+6. Record resource env context.
+7. Reconcile adapter-specific allocations.
+8. Render Project `.env` only after all required context is ready.
+
+The foundation records minimal observed runtime state: running, ready, failed, or stopped, with a concise message and useful log/runtime metadata references. Rich status formatting, doctor checks, log browsing UX, and JSON status output remain PR 21 scope.
+
+The foundation also adds a test-only fake multi-port Managed Resource runtime. The fake runtime must not appear in normal registry, Project config, CLI help, shell completions, public manifests, or user-facing examples.
+
+## SQL Foundation
+
+The SQL foundation is a small shared PR before MySQL and Postgres.
+
+It may add focused `sqlx` usage for MySQL/Postgres readiness and admin operations. SQL admin queries should be runtime/dynamic queries. PV v1 must not require `sqlx` offline query metadata.
+
+The SQL foundation should cover common behavior only:
+
+- SQL connection/admin scaffolding.
+- Shared database allocation helper behavior.
+- Stable database name handling using existing generated allocation names.
+- Common resource env context expectations.
+- Common database create/check behavior.
+
+It must not implement a full MySQL or Postgres adapter.
+
+## Adapter Slices
+
+Each real adapter PR is a full vertical slice after its blockers land.
+
+Mailpit:
+
+- Artifact layout validation.
+- Demand-driven install/start from Project config.
+- SMTP and UI/dashboard runtime ports.
+- HTTP readiness for the dashboard where feasible.
+- Resource env context for SMTP host/port and dashboard URL.
+- Public `mailpit:*` and `mail:*` command namespace.
+- Read-only `mailpit:open` / `mail:open`.
+- Install, update, uninstall, list, help, completion, and snapshot coverage.
+- No Resource allocations.
+
+Redis:
+
+- Artifact layout validation.
+- Demand-driven install/start from Project config.
+- Redis runtime port.
+- Redis client PING/readiness behavior instead of shelling out to `redis-cli`.
+- Prefix allocation creation/reuse using existing allocation state.
+- Resource and allocation env contexts.
+- Public `redis:*` command namespace.
+- Project env and CLI snapshot coverage.
+
+MySQL:
+
+- Artifact layout validation.
+- Demand-driven install/start from Project config.
+- MySQL runtime port.
+- `sqlx` readiness/admin behavior instead of shelling out to `mysql`.
+- Database allocation creation/reuse using existing allocation state.
+- Resource and allocation env contexts.
+- Public `mysql:*` command namespace.
+- Project env and CLI snapshot coverage.
+
+Postgres:
+
+- Artifact layout validation.
+- Demand-driven install/start from Project config.
+- Postgres runtime port.
+- `sqlx` readiness/admin behavior instead of shelling out to `psql`.
+- Database allocation creation/reuse using existing allocation state.
+- Resource and allocation env contexts.
+- Public `postgres:*` and `pg:*` command namespace.
+- Project env and CLI snapshot coverage.
+
+RustFS:
+
+- Artifact layout validation.
+- Demand-driven install/start from Project config.
+- S3/API runtime port and console port when available.
+- S3-compatible bucket creation/check behavior.
+- Prefer `object_store` for bucket operations first.
+- Fall back to AWS SDK for Rust only if `object_store` cannot create/check buckets cleanly against RustFS.
+- Do not manage buckets through `mc`.
+- Bucket allocation creation/reuse using existing allocation state.
+- Resource and allocation env contexts.
+- Public `rustfs:*` and `s3:*` command namespace.
+- Read-only `rustfs:open` / `s3:open`.
+- Project env and CLI snapshot coverage.
+
+## State
+
+Stable resource-level credentials and endpoint values use existing `managed_resource_tracks.env_json` in v1.
+
+Examples include SQL root/superuser credentials, RustFS access and secret keys, Mailpit SMTP/UI values, and Redis host/port/url values. New resource-specific state tables should not be added unless a concrete adapter proves it needs structured state beyond resource env context and existing allocation records.
+
+Allocation-specific state uses existing `resource_allocations.generated_name` plus `resource_allocations.env_json`.
+
+SQL database names, Redis prefixes, and RustFS bucket names use the existing stable generated allocation name state. Adapter PRs mark allocations ready with allocation env values through the existing state API.
+
+## Command Surface
+
+Each adapter PR adds its own public command namespace. There is no separate shared command-surface PR.
+
+```shell
+pv {mailpit|mail}:install [version]
+pv {mailpit|mail}:update
+pv {mailpit|mail}:uninstall <version> [--prune] [--force]
+pv {mailpit|mail}:list
+pv {mailpit|mail}:open
+
+pv redis:install [version]
+pv redis:update
+pv redis:uninstall <version> [--prune] [--force]
+pv redis:list
+
+pv mysql:install [version]
+pv mysql:update
+pv mysql:uninstall <version> [--prune] [--force]
+pv mysql:list
+
+pv {postgres|pg}:install [version]
+pv {postgres|pg}:update
+pv {postgres|pg}:uninstall <version> [--prune] [--force]
+pv {postgres|pg}:list
+
+pv {rustfs|s3}:install [version]
+pv {rustfs|s3}:update
+pv {rustfs|s3}:uninstall <version> [--prune] [--force]
+pv {rustfs|s3}:list
+pv {rustfs|s3}:open
+```
+
+`mailpit:open` / `mail:open` and `rustfs:open` / `s3:open` are read-only. They must not install artifacts, start runtimes, or record desired state. They open the dashboard or console only when the runtime is already running and has a known URL. If not running, they report that plainly and point to Project config demand and install/setup as appropriate.
+
+## Error Handling
+
+Failures are scoped to the affected Managed Resource track and Project.
+
+If install, start, readiness, admin allocation, or env context generation fails, reconciliation records minimal observed failure state and preserves the previous valid Project `.env` block. Other Projects and unrelated resources should continue reconciling where possible.
+
+Project `.env` rendering is all-or-nothing for a Project. PV must not write partial generated resource values.
+
+Runtime adoption must verify PV ownership before reusing or stopping a process. PV never kills a process based on PID alone.
+
+Destructive cleanup remains behind uninstall/prune intent.
+
+## Testing
+
+Prefer integration-style tests and `insta` snapshots following nearby test style.
+
+The runtime foundation should prove application behavior with the test-only fake multi-port runtime:
+
+- Project config demand installs and starts a fake Managed Resource runtime.
+- Named ports are assigned and rendered into resource env context.
+- Readiness success and failure paths are observable.
+- Logs, runtime metadata, and minimal observed state are recorded.
+- Runtime adoption is covered where feasible.
+- Removing Project demand stops the fake runtime while preserving installed artifacts/state.
+
+Adapter PRs use lightweight fixture artifacts with controllable test binaries/scripts. Normal PR verification must not require real upstream binaries or published object-storage artifacts.
+
+Each adapter PR should include:
+
+- Artifact layout validation tests.
+- Demand-driven Project reconciliation tests.
+- Readiness tests.
+- Resource env context tests.
+- Allocation tests when the adapter supports Resource allocations.
+- Project env rendering tests.
+- CLI help and command snapshot coverage.
+- Non-happy-path tests for install/start/readiness/admin failures where feasible.
+
+Real upstream Managed Resource artifacts and public publication belong to later artifact recipe/publication work and release-candidate validation.
+
+## Orchestration
+
+After this design spec and the implementation plan are approved, the final plan will be converted into Solo todos with blocker relationships and worktree metadata.
+
+Current Solo blocker shape:
+
+- `#68` Shared Managed Resource runtime foundation.
+- `#67` Shared SQL foundation, blocked by `#68`.
+- Mailpit, Redis, and RustFS adapter todos are blocked by `#68`.
+- MySQL and Postgres adapter todos are blocked by both `#68` and `#67`.
+
+Implementation agents should be spawned only after the implementation plan is approved. Each agent should receive one worktree, the relevant Solo todo, the shared scratchpad, exact blocker context, and verification commands. Solo scratchpads should hold cross-lane decisions, and Solo timers should be used for orchestrator check-ins instead of polling loops.
+
+## Verification
+
+Foundation and adapter implementation plans should prefer focused checks:
+
+```shell
+cargo nextest run -E 'test(<specific_test_name>)'
+cargo insta test --accept --test-runner nextest -- <specific_test_name>
+cargo fmt --all -- --check
+git diff --check
+```
+
+Before each PR is considered complete, run the narrowest crate set that covers the touched behavior, then run clippy for the relevant workspace surface:
+
+```shell
+cargo nextest run -p daemon -p resources -p state -p config -p cli --locked
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+```
+
+If dependency changes are needed, avoid broad lockfile churn and use precise updates.
+
+## Open Decisions
+
+None. The approved direction is seven workstreams, daemon-local runtime orchestration, a small SQL foundation, full vertical adapter slices, fixture-based PR tests, existing state tables for resource/allocation env context, and Solo-backed orchestration after the implementation plan is approved.


### PR DESCRIPTION
## Summary
- Add the daemon-local Managed Resource runtime foundation for demanded resource reconciliation.
- Add resource port-role state support, runtime observed subjects, path helpers, and test-only fake multi-port runtime coverage.
- Add the private CLI artifact-resource helper used by later adapter namespaces.

## Stack
Base: main

## Test Plan
- cargo nextest run -p state -E 'test(resource_port_allocator_distinguishes_named_ports_for_one_track)' --locked
- cargo nextest run -p daemon -E 'test(managed_resources::tests)' --locked
- cargo fmt --all -- --check
- cargo clippy -p state -p daemon -p cli --all-targets --locked -- -D warnings
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: install/update/uninstall/list for artifact resources; uninstall supports interactive prune confirmation.
  * Listing shows per-track status and port info for service-backed resources.
  * Daemon: full managed-resource lifecycle with multi-port runtimes and system-level reconciliation.

* **Bug Fixes**
  * CLI warns instead of failing when the daemon is unreachable.

* **Tests**
  * Extensive integration tests with a fake multi-port runtime.

* **Chores**
  * Design docs added and DB migration for named resource ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
