### PR TITLE
PR SQL: shared SQL adapter foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +143,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +183,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -176,6 +194,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -194,6 +221,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -321,6 +354,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "codspeed"
 version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +446,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +521,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +551,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +573,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -515,6 +611,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "sqlx",
  "state",
  "thiserror",
  "time",
@@ -563,8 +660,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -590,10 +698,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -615,6 +732,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -683,10 +821,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -718,9 +883,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -781,6 +948,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -806,6 +975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hickory-proto"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +997,24 @@ dependencies = [
  "tinyvec",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -848,6 +1041,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "icu_collections"
@@ -1118,10 +1320,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "memchr"
@@ -1249,6 +1470,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,7 +1543,7 @@ dependencies = [
  "rustls-pemfile",
  "security-framework",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "state",
  "thiserror",
  "x509-parser",
@@ -1428,7 +1678,7 @@ dependencies = [
  "resources",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "thiserror",
  "toml",
@@ -1491,6 +1741,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,7 +1795,7 @@ dependencies = [
  "insta",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "state",
  "tar",
  "thiserror",
@@ -1681,6 +1940,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +2027,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,7 +2045,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1827,6 +2114,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1848,6 +2138,152 @@ dependencies = [
  "js-sys",
  "rsqlite-vfs",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64",
+ "bytes",
+ "cfg-if",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags 2.11.1",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sha1",
+ "sha2 0.11.0",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.11.1",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
 ]
 
 [[package]]
@@ -1881,6 +2317,17 @@ checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
 dependencies = [
  "approx",
  "num-traits",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -2061,6 +2508,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,8 +2588,21 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2150,10 +2621,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -2367,6 +2859,12 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ security-framework = "3.7.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+sqlx = { version = "0.9.0", default-features = false, features = ["mysql", "postgres", "runtime-tokio", "tls-rustls"] }
 tar = "0.4.45"
 thiserror = "2"
 time = { version = "0", features = ["formatting", "macros"] }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 resources = { path = "../resources" }
 rustix = { workspace = true }
+sqlx = { workspace = true }
 state = { path = "../state" }
 thiserror = { workspace = true }
 time = { workspace = true }

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -111,6 +111,14 @@ pub enum DaemonError {
         port: String,
     },
 
+    #[error(
+        "invalid SQL database identifier `{identifier}`: identifiers must use ASCII alphanumeric characters and underscores"
+    )]
+    InvalidSqlIdentifier { identifier: String },
+
+    #[error("SQL admin error: {0}")]
+    SqlAdmin(#[from] sqlx::Error),
+
     #[error("time formatting failed: {0}")]
     TimeFormat(#[from] time::error::Format),
 }

--- a/crates/daemon/src/managed_resources/fake.rs
+++ b/crates/daemon/src/managed_resources/fake.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use state::{EnvContextValues, PvPaths};
 
 use crate::managed_resources::{
-    ManagedResourceArtifactAdapter, ManagedResourcePortSpec, ManagedResourceRuntimeAdapter,
-    ManagedResourceRuntimeContext, RESOURCE_HOST,
+    ManagedResourceArtifactAdapter, ManagedResourcePortSpec, ManagedResourceReadiness,
+    ManagedResourceRuntimeAdapter, ManagedResourceRuntimeContext, RESOURCE_HOST,
 };
 use crate::{DaemonError, ProcessSpec, ReadinessCheck};
 
@@ -116,22 +116,25 @@ impl ManagedResourceRuntimeAdapter for FakeMailpitRuntimeAdapter {
     fn readiness(
         &self,
         context: &ManagedResourceRuntimeContext,
-    ) -> Result<ReadinessCheck, DaemonError> {
+    ) -> Result<ManagedResourceReadiness, DaemonError> {
         match self.readiness {
             FakeMailpitReadiness::Smtp => Ok(ReadinessCheck::Tcp {
                 host: RESOURCE_HOST.to_string(),
                 port: required_port(context, "smtp")?,
-            }),
+            }
+            .into()),
             FakeMailpitReadiness::ExitAfterDashboardReadiness => Ok(ReadinessCheck::Http {
                 host: RESOURCE_HOST.to_string(),
                 port: required_port(context, "dashboard")?,
                 path: "/ready".to_string(),
-            }),
+            }
+            .into()),
             FakeMailpitReadiness::UnservedDashboardPort { .. } => Ok(ReadinessCheck::Http {
                 host: RESOURCE_HOST.to_string(),
                 port: required_port(context, "dashboard")?,
                 path: "/__pv_unready_fixture__".to_string(),
-            }),
+            }
+            .into()),
         }
     }
 

--- a/crates/daemon/src/managed_resources/mod.rs
+++ b/crates/daemon/src/managed_resources/mod.rs
@@ -57,10 +57,7 @@ pub(crate) enum ManagedResourceReadiness {
     TcpHttp(ReadinessCheck),
     #[cfg_attr(
         not(test),
-        allow(
-            dead_code,
-            reason = "MySQL and Postgres adapter PRs construct async SQL readiness"
-        )
+        allow(dead_code, reason = "SQL adapter PRs construct async SQL readiness")
     )]
     Async(AsyncManagedResourceReadiness),
 }
@@ -73,10 +70,7 @@ pub(crate) struct AsyncManagedResourceReadiness {
 impl ManagedResourceReadiness {
     #[cfg_attr(
         not(test),
-        expect(
-            dead_code,
-            reason = "MySQL and Postgres adapter PRs construct async SQL readiness"
-        )
+        expect(dead_code, reason = "SQL adapter PRs construct async SQL readiness")
     )]
     pub(crate) fn async_check(
         name: impl Into<String>,

--- a/crates/daemon/src/managed_resources/mod.rs
+++ b/crates/daemon/src/managed_resources/mod.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 mod fake;
+pub(crate) mod sql;
 #[cfg(test)]
 mod tests;
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
 use std::io;
 use std::net::TcpListener;
-use std::time::Duration;
+use std::pin::Pin;
+use std::time::{Duration, Instant};
 
 use camino::{Utf8Path, Utf8PathBuf};
 use resources::{
@@ -18,15 +21,22 @@ use state::{
     PortRequest, ProjectRecord, PvPaths, RUNTIME_PORT_FALLBACK_END, RUNTIME_PORT_FALLBACK_START,
     ResourceAllocationRecord, RuntimeObservedStatus, RuntimeSubject, StateError,
 };
+use tokio::time::{sleep, timeout};
 
 use crate::{DaemonError, ProcessSpec, ProcessSupervisor, ReadinessCheck, wait_for_readiness};
 
 const DEFAULT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json";
 const RESOURCE_HOST: &str = "127.0.0.1";
 const RESOURCE_READINESS_TIMEOUT: Duration = Duration::from_secs(15);
+const ASYNC_READINESS_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const RESOURCE_STOP_GRACE_PERIOD: Duration = Duration::from_secs(10);
 const RESOURCE_START_ATTEMPTS: usize = 10;
 const RESERVED_RESOURCE_PORT_NAME: &str = "default";
+
+pub(crate) type ManagedResourceReadinessFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<(), DaemonError>> + Send + 'a>>;
+pub(crate) type ManagedResourceAllocationFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<(), DaemonError>> + Send + 'a>>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ManagedResourcePortSpec {
@@ -41,6 +51,48 @@ pub(crate) struct ManagedResourceRuntimeContext {
     pub artifact_path: camino::Utf8PathBuf,
     pub data_dir: camino::Utf8PathBuf,
     pub ports: BTreeMap<String, u16>,
+}
+
+pub(crate) enum ManagedResourceReadiness {
+    TcpHttp(ReadinessCheck),
+    #[cfg_attr(
+        not(test),
+        allow(
+            dead_code,
+            reason = "MySQL and Postgres adapter PRs construct async SQL readiness"
+        )
+    )]
+    Async(AsyncManagedResourceReadiness),
+}
+
+pub(crate) struct AsyncManagedResourceReadiness {
+    name: String,
+    check: Box<dyn Fn() -> ManagedResourceReadinessFuture<'static> + Send + Sync>,
+}
+
+impl ManagedResourceReadiness {
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "MySQL and Postgres adapter PRs construct async SQL readiness"
+        )
+    )]
+    pub(crate) fn async_check(
+        name: impl Into<String>,
+        check: impl Fn() -> ManagedResourceReadinessFuture<'static> + Send + Sync + 'static,
+    ) -> Self {
+        Self::Async(AsyncManagedResourceReadiness {
+            name: name.into(),
+            check: Box::new(check),
+        })
+    }
+}
+
+impl From<ReadinessCheck> for ManagedResourceReadiness {
+    fn from(check: ReadinessCheck) -> Self {
+        Self::TcpHttp(check)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -113,7 +165,7 @@ pub(crate) trait ManagedResourceRuntimeAdapter: Send + Sync {
     fn readiness(
         &self,
         context: &ManagedResourceRuntimeContext,
-    ) -> Result<ReadinessCheck, DaemonError>;
+    ) -> Result<ManagedResourceReadiness, DaemonError>;
 
     #[cfg(test)]
     fn readiness_timeout(&self) -> Duration {
@@ -125,14 +177,14 @@ pub(crate) trait ManagedResourceRuntimeAdapter: Send + Sync {
         context: &ManagedResourceRuntimeContext,
     ) -> Result<EnvContextValues, DaemonError>;
 
-    fn reconcile_allocations(
-        &self,
-        _paths: &PvPaths,
-        _database: &mut Database,
-        _context: &ManagedResourceRuntimeContext,
-        _allocations: &[ResourceAllocationRecord],
-    ) -> Result<(), DaemonError> {
-        Ok(())
+    fn reconcile_allocations<'a>(
+        &'a self,
+        _paths: &'a PvPaths,
+        _database: &'a mut Database,
+        _context: &'a ManagedResourceRuntimeContext,
+        _allocations: &'a [ResourceAllocationRecord],
+    ) -> ManagedResourceAllocationFuture<'a> {
+        Box::pin(async { Ok(()) })
     }
 }
 
@@ -355,7 +407,7 @@ impl ResourceRuntimeAttempt<'_> {
         let readiness = self.adapter.readiness(context)?;
         let readiness_timeout = adapter_readiness_timeout(self.adapter);
 
-        start_or_adopt_runtime(self.supervisor, spec, readiness, readiness_timeout).await?;
+        start_or_adopt_runtime(self.supervisor, spec, &readiness, readiness_timeout).await?;
 
         let env = self.adapter.resource_env(context)?;
         self.database.record_managed_resource_track_env_context(
@@ -366,7 +418,8 @@ impl ResourceRuntimeAttempt<'_> {
         let allocations =
             desired_allocations(self.database, self.project, self.plan, self.resource)?;
         self.adapter
-            .reconcile_allocations(self.paths, self.database, context, &allocations)?;
+            .reconcile_allocations(self.paths, self.database, context, &allocations)
+            .await?;
         self.database.record_runtime_observed_snapshot(
             self.subject.clone(),
             RuntimeObservedStatus::Running,
@@ -556,23 +609,22 @@ fn ports_occupied_without_recorded_runtime(
 async fn start_or_adopt_runtime(
     supervisor: &ProcessSupervisor,
     spec: ProcessSpec,
-    readiness: ReadinessCheck,
+    readiness: &ManagedResourceReadiness,
     readiness_timeout: Duration,
 ) -> Result<(), DaemonError> {
     if supervisor.adopt(&spec)?.is_some() {
-        wait_for_readiness(readiness, readiness_timeout).await?;
+        wait_for_managed_resource_readiness(readiness, readiness_timeout).await?;
 
         return Ok(());
     }
-    if crate::supervisor::probe_readiness_once(&readiness)
-        .await
-        .is_ok()
+    if let ManagedResourceReadiness::TcpHttp(check) = readiness
+        && crate::supervisor::probe_readiness_once(check).await.is_ok()
     {
         return Err(DaemonError::NonPvManagedResourceRuntimeListener { name: spec.name });
     }
 
     let mut process = supervisor.start(spec.clone()).await?;
-    if let Err(error) = wait_for_readiness(readiness, readiness_timeout).await {
+    if let Err(error) = wait_for_managed_resource_readiness(readiness, readiness_timeout).await {
         process.stop(RESOURCE_STOP_GRACE_PERIOD).await?;
         cleanup_started_runtime_files(&spec)?;
 
@@ -591,6 +643,54 @@ async fn start_or_adopt_runtime(
     }
 
     Ok(())
+}
+
+async fn wait_for_managed_resource_readiness(
+    readiness: &ManagedResourceReadiness,
+    readiness_timeout: Duration,
+) -> Result<(), DaemonError> {
+    match readiness {
+        ManagedResourceReadiness::TcpHttp(check) => {
+            wait_for_readiness(check.clone(), readiness_timeout).await
+        }
+        ManagedResourceReadiness::Async(check) => {
+            wait_for_async_readiness(check, readiness_timeout).await
+        }
+    }
+}
+
+async fn wait_for_async_readiness(
+    readiness: &AsyncManagedResourceReadiness,
+    readiness_timeout: Duration,
+) -> Result<(), DaemonError> {
+    let started_at = Instant::now();
+    let mut last_error = None;
+
+    while let Some(remaining) = remaining_timeout(started_at, readiness_timeout) {
+        match timeout(remaining, (readiness.check)()).await {
+            Ok(Ok(())) => return Ok(()),
+            Ok(Err(error)) => {
+                last_error = Some(error.to_string());
+                sleep(remaining.min(ASYNC_READINESS_POLL_INTERVAL)).await;
+            }
+            Err(elapsed) => {
+                last_error = Some(elapsed.to_string());
+                break;
+            }
+        }
+    }
+
+    Err(DaemonError::ReadinessTimedOut {
+        check: format!("async:{}", readiness.name),
+        timeout_ms: readiness_timeout.as_millis(),
+        last_error,
+    })
+}
+
+fn remaining_timeout(started_at: Instant, readiness_timeout: Duration) -> Option<Duration> {
+    readiness_timeout
+        .checked_sub(started_at.elapsed())
+        .filter(|remaining| !remaining.is_zero())
 }
 
 fn cleanup_started_runtime_files(spec: &ProcessSpec) -> Result<(), DaemonError> {

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__async_readiness_reassigns_unowned_persisted_port_before_resource_readiness.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__async_readiness_reassigns_unowned_persisted_port_before_resource_readiness.snap
@@ -1,0 +1,64 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    (
+        "persisted_port_reassigned",
+        true,
+    ),
+    (
+        "env_uses_occupied_port",
+        false,
+    ),
+    "# >>> PV MANAGED\nDATABASE_URL=mysql://root:secret@127.0.0.1:<mysql_port>/acme_test_app_db\n# <<< PV MANAGED\n",
+    [
+        PortAssignment {
+            owner: Resource {
+                name: "mysql",
+                track: "8.0",
+                port: "mysql",
+            },
+            port: <port>,
+            updated_at: "<timestamp>",
+        },
+    ],
+    [
+        ResourceAllocationRecord {
+            id: "allocation_000001",
+            project_id: "<project_id>",
+            resource_name: "mysql",
+            track: "8.0",
+            allocation_name: "app-db",
+            generated_name: "acme_test_app_db",
+            env: {
+                "database": "acme_test_app_db",
+                "host": "127.0.0.1",
+                "password": "secret",
+                "port": "<port>",
+                "url": "mysql://root:secret@127.0.0.1:<mysql_port>/acme_test_app_db",
+                "username": "root",
+            },
+            status: Ready,
+            created_at: "<timestamp>",
+            updated_at: "<timestamp>",
+        },
+    ],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mysql",
+                track: "8.0",
+            },
+            status: Running,
+            message: Some(
+                "Managed Resource runtime is ready",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+    [
+        "readiness",
+        "allocation",
+    ],
+)

--- a/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_uses_async_readiness_and_allocation_hooks.snap
+++ b/crates/daemon/src/managed_resources/snapshots/daemon__managed_resources__tests__demanded_resource_uses_async_readiness_and_allocation_hooks.snap
@@ -1,0 +1,45 @@
+---
+source: crates/daemon/src/managed_resources/tests.rs
+expression: snapshot
+---
+(
+    "# >>> PV MANAGED\nDATABASE_URL=mysql://root:secret@127.0.0.1:<mysql_port>/acme_test_app_db\n# <<< PV MANAGED\n",
+    [
+        ResourceAllocationRecord {
+            id: "allocation_000001",
+            project_id: "<project_id>",
+            resource_name: "mysql",
+            track: "8.0",
+            allocation_name: "app-db",
+            generated_name: "acme_test_app_db",
+            env: {
+                "database": "acme_test_app_db",
+                "host": "127.0.0.1",
+                "password": "secret",
+                "port": "<port>",
+                "url": "mysql://root:secret@127.0.0.1:<mysql_port>/acme_test_app_db",
+                "username": "root",
+            },
+            status: Ready,
+            created_at: "<timestamp>",
+            updated_at: "<timestamp>",
+        },
+    ],
+    [
+        RuntimeObservedStateRecord {
+            subject: Resource {
+                name: "mysql",
+                track: "8.0",
+            },
+            status: Running,
+            message: Some(
+                "Managed Resource runtime is ready",
+            ),
+            observed_at: "<timestamp>",
+        },
+    ],
+    [
+        "readiness",
+        "allocation",
+    ],
+)

--- a/crates/daemon/src/managed_resources/sql.rs
+++ b/crates/daemon/src/managed_resources/sql.rs
@@ -4,7 +4,7 @@
 )]
 
 use sqlx::mysql::{MySqlConnectOptions, MySqlPool};
-use sqlx::postgres::{PgConnectOptions, PgPool};
+use sqlx::postgres::{PgConnectOptions, PgPool, PgSslMode};
 use state::{
     Database, EnvContextValues, ResourceAllocationRecord, ResourceAllocationStatus, StateError,
 };
@@ -204,10 +204,6 @@ fn mark_database_allocation_ready(
     request: SqlAllocationRequest<'_>,
     allocation: ResourceAllocationRecord,
 ) -> Result<(), DaemonError> {
-    if allocation.status != ResourceAllocationStatus::Desired {
-        return Ok(());
-    }
-
     let allocation_context = SqlAllocationContext {
         database: allocation.generated_name,
         host: request.context.host.clone(),
@@ -215,13 +211,29 @@ fn mark_database_allocation_ready(
         username: request.context.username.clone(),
         password: request.context.password.clone(),
     };
-    database.mark_resource_allocation_ready(
-        request.project_id,
-        request.resource_name,
-        request.track,
-        request.allocation_name,
-        &sql_allocation_env(&allocation_context, request.engine),
-    )?;
+    let env = sql_allocation_env(&allocation_context, request.engine);
+
+    match allocation.status {
+        ResourceAllocationStatus::Desired => {
+            database.mark_resource_allocation_ready(
+                request.project_id,
+                request.resource_name,
+                request.track,
+                request.allocation_name,
+                &env,
+            )?;
+        }
+        ResourceAllocationStatus::Ready if allocation.env != env => {
+            database.record_resource_allocation_env_context(
+                request.project_id,
+                request.resource_name,
+                request.track,
+                request.allocation_name,
+                &env,
+            )?;
+        }
+        _ => {}
+    }
 
     Ok(())
 }
@@ -234,13 +246,15 @@ fn mysql_options(context: &SqlAdminContext) -> MySqlConnectOptions {
         .password(&context.password)
 }
 
-fn postgres_options(context: &SqlAdminContext) -> PgConnectOptions {
+pub(crate) fn postgres_options(context: &SqlAdminContext) -> PgConnectOptions {
     PgConnectOptions::new()
         .host(&context.host)
         .port(context.port)
         .username(&context.username)
         .password(&context.password)
         .database("postgres")
+        .ssl_mode(PgSslMode::Disable)
+        .application_name("pv")
 }
 
 fn sql_resource_url(context: &SqlAdminContext, engine: SqlEngine) -> String {

--- a/crates/daemon/src/managed_resources/sql.rs
+++ b/crates/daemon/src/managed_resources/sql.rs
@@ -1,0 +1,349 @@
+#![expect(
+    dead_code,
+    reason = "MySQL and Postgres adapter PRs consume the shared SQL foundation"
+)]
+
+use sqlx::mysql::{MySqlConnectOptions, MySqlPool};
+use sqlx::postgres::{PgConnectOptions, PgPool};
+use state::{
+    Database, EnvContextValues, ResourceAllocationRecord, ResourceAllocationStatus, StateError,
+};
+
+use crate::DaemonError;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SqlEngine {
+    Mysql,
+    Postgres,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SqlAdminContext {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SqlAllocationContext {
+    pub database: String,
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SqlAllocationRequest<'a> {
+    pub project_id: &'a str,
+    pub resource_name: &'a str,
+    pub track: &'a str,
+    pub allocation_name: &'a str,
+    pub engine: SqlEngine,
+    pub context: &'a SqlAdminContext,
+}
+
+pub(crate) fn sql_resource_env(context: &SqlAdminContext, engine: SqlEngine) -> EnvContextValues {
+    env_context(&[
+        ("host", context.host.as_str()),
+        ("password", context.password.as_str()),
+        ("port", &context.port.to_string()),
+        ("url", &sql_resource_url(context, engine)),
+        ("username", context.username.as_str()),
+    ])
+}
+
+pub(crate) fn sql_allocation_env(
+    context: &SqlAllocationContext,
+    engine: SqlEngine,
+) -> EnvContextValues {
+    env_context(&[
+        ("database", context.database.as_str()),
+        ("host", context.host.as_str()),
+        ("password", context.password.as_str()),
+        ("port", &context.port.to_string()),
+        ("url", &sql_allocation_url(context, engine)),
+        ("username", context.username.as_str()),
+    ])
+}
+
+pub(crate) async fn ping_admin(
+    context: &SqlAdminContext,
+    engine: SqlEngine,
+) -> Result<(), DaemonError> {
+    match engine {
+        SqlEngine::Mysql => {
+            let pool = MySqlPool::connect_with(mysql_options(context)).await?;
+            sqlx::query("SELECT 1").execute(&pool).await?;
+        }
+        SqlEngine::Postgres => {
+            let pool = PgPool::connect_with(postgres_options(context)).await?;
+            sqlx::query("SELECT 1").execute(&pool).await?;
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn create_database_if_missing(
+    context: &SqlAdminContext,
+    engine: SqlEngine,
+    database: &str,
+) -> Result<(), DaemonError> {
+    let statement = create_database_statement(engine, database)?;
+
+    match engine {
+        SqlEngine::Mysql => {
+            let pool = MySqlPool::connect_with(mysql_options(context)).await?;
+
+            sqlx::query(sqlx::AssertSqlSafe(statement))
+                .execute(&pool)
+                .await?;
+        }
+        SqlEngine::Postgres => {
+            let pool = PgPool::connect_with(postgres_options(context)).await?;
+            let exists = sqlx::query("SELECT 1 FROM pg_database WHERE datname = $1")
+                .bind(database)
+                .fetch_optional(&pool)
+                .await?;
+
+            if exists.is_none() {
+                sqlx::query(sqlx::AssertSqlSafe(statement))
+                    .execute(&pool)
+                    .await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn ensure_database_allocation(
+    database: &mut Database,
+    request: SqlAllocationRequest<'_>,
+) -> Result<(), DaemonError> {
+    let allocation = desired_database_allocation(database, request)?;
+
+    create_database_if_missing(request.context, request.engine, &allocation.generated_name).await?;
+    mark_database_allocation_ready(database, request, allocation)
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RecordingSqlAdmin {
+    operations: Vec<RecordedSqlAdminOperation>,
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct RecordedSqlAdminOperation {
+    pub engine: SqlEngine,
+    pub database: String,
+    pub statement: String,
+}
+
+#[cfg(test)]
+impl RecordingSqlAdmin {
+    pub(crate) fn operations(&self) -> &[RecordedSqlAdminOperation] {
+        &self.operations
+    }
+
+    async fn create_database_if_missing(
+        &mut self,
+        engine: SqlEngine,
+        database: &str,
+    ) -> Result<(), DaemonError> {
+        self.operations.push(RecordedSqlAdminOperation {
+            engine,
+            database: database.to_string(),
+            statement: create_database_statement(engine, database)?,
+        });
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) async fn ensure_database_allocation_for_test(
+    database: &mut Database,
+    admin: &mut RecordingSqlAdmin,
+    request: SqlAllocationRequest<'_>,
+) -> Result<(), DaemonError> {
+    let allocation = desired_database_allocation(database, request)?;
+
+    admin
+        .create_database_if_missing(request.engine, &allocation.generated_name)
+        .await?;
+
+    mark_database_allocation_ready(database, request, allocation)
+}
+
+fn desired_database_allocation(
+    database: &Database,
+    request: SqlAllocationRequest<'_>,
+) -> Result<ResourceAllocationRecord, DaemonError> {
+    let allocation = database
+        .resource_allocations(request.project_id, request.resource_name)?
+        .into_iter()
+        .find(|allocation| {
+            allocation.track == request.track
+                && allocation.allocation_name == request.allocation_name
+        })
+        .ok_or_else(|| StateError::ResourceAllocationNotFound {
+            project_id: request.project_id.to_string(),
+            resource: request.resource_name.to_string(),
+            allocation: request.allocation_name.to_string(),
+        })?;
+
+    Ok(allocation)
+}
+
+fn mark_database_allocation_ready(
+    database: &mut Database,
+    request: SqlAllocationRequest<'_>,
+    allocation: ResourceAllocationRecord,
+) -> Result<(), DaemonError> {
+    if allocation.status != ResourceAllocationStatus::Desired {
+        return Ok(());
+    }
+
+    let allocation_context = SqlAllocationContext {
+        database: allocation.generated_name,
+        host: request.context.host.clone(),
+        port: request.context.port,
+        username: request.context.username.clone(),
+        password: request.context.password.clone(),
+    };
+    database.mark_resource_allocation_ready(
+        request.project_id,
+        request.resource_name,
+        request.track,
+        request.allocation_name,
+        &sql_allocation_env(&allocation_context, request.engine),
+    )?;
+
+    Ok(())
+}
+
+fn mysql_options(context: &SqlAdminContext) -> MySqlConnectOptions {
+    MySqlConnectOptions::new()
+        .host(&context.host)
+        .port(context.port)
+        .username(&context.username)
+        .password(&context.password)
+}
+
+fn postgres_options(context: &SqlAdminContext) -> PgConnectOptions {
+    PgConnectOptions::new()
+        .host(&context.host)
+        .port(context.port)
+        .username(&context.username)
+        .password(&context.password)
+        .database("postgres")
+}
+
+fn sql_resource_url(context: &SqlAdminContext, engine: SqlEngine) -> String {
+    let username = percent_encode_userinfo(&context.username);
+    let password = percent_encode_userinfo(&context.password);
+
+    format!(
+        "{}://{}:{}@{}:{}",
+        engine.url_scheme(),
+        username,
+        password,
+        context.host,
+        context.port
+    )
+}
+
+fn sql_allocation_url(context: &SqlAllocationContext, engine: SqlEngine) -> String {
+    let username = percent_encode_userinfo(&context.username);
+    let password = percent_encode_userinfo(&context.password);
+
+    format!(
+        "{}://{}:{}@{}:{}/{}",
+        engine.url_scheme(),
+        username,
+        password,
+        context.host,
+        context.port,
+        context.database
+    )
+}
+
+fn create_database_statement(engine: SqlEngine, database: &str) -> Result<String, DaemonError> {
+    let identifier = quote_database_identifier(engine, database)?;
+    let statement = match engine {
+        SqlEngine::Mysql => format!("CREATE DATABASE IF NOT EXISTS {identifier}"),
+        SqlEngine::Postgres => format!("CREATE DATABASE {identifier}"),
+    };
+
+    Ok(statement)
+}
+
+fn quote_database_identifier(engine: SqlEngine, identifier: &str) -> Result<String, DaemonError> {
+    let quote = match engine {
+        SqlEngine::Mysql => '`',
+        SqlEngine::Postgres => '"',
+    };
+
+    quote_ascii_identifier(identifier, quote)
+}
+
+fn quote_ascii_identifier(identifier: &str, quote: char) -> Result<String, DaemonError> {
+    if identifier.is_empty()
+        || !identifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        return Err(DaemonError::InvalidSqlIdentifier {
+            identifier: identifier.to_string(),
+        });
+    }
+
+    let mut quoted = String::with_capacity(identifier.len() + 2);
+    quoted.push(quote);
+    quoted.push_str(identifier);
+    quoted.push(quote);
+
+    Ok(quoted)
+}
+
+fn env_context(entries: &[(&str, &str)]) -> EnvContextValues {
+    entries
+        .iter()
+        .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+        .collect()
+}
+
+fn percent_encode_userinfo(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            push_percent_encoded_byte(&mut encoded, byte);
+        }
+    }
+
+    encoded
+}
+
+fn push_percent_encoded_byte(encoded: &mut String, byte: u8) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    encoded.push('%');
+    encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+    encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+}
+
+impl SqlEngine {
+    const fn url_scheme(self) -> &'static str {
+        match self {
+            Self::Mysql => "mysql",
+            Self::Postgres => "postgres",
+        }
+    }
+}

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -1469,7 +1469,7 @@ fn assert_with_normalized_runtime(
     settings.add_filter(r"timeout_ms: \d+", "timeout_ms: <timeout_ms>");
     settings.add_filter(r"os error \d+", "os error <code>");
     settings.add_filter(
-        r"I/O error: Connection refused \(os error <code>\)|I/O error: HTTP readiness returned non-success status",
+        r"I/O error: Connection refused \(os error <code>\)|I/O error: HTTP readiness returned non-success status|deadline has elapsed",
         "I/O error: readiness unavailable",
     );
     settings.add_filter(r"port: \d+", "port: <port>");

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -8,7 +8,7 @@ use camino::Utf8Path;
 use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
 use state::{
-    Database, EnvContextValues, LinkProjectInput, PortRequest, ProjectRecord, PvPaths,
+    Database, EnvContextValues, LinkProjectInput, PortOwner, PortRequest, ProjectRecord, PvPaths,
     ResourceAllocationRecord, RuntimeObservedStatus, RuntimeSubject, StateError,
 };
 
@@ -790,6 +790,88 @@ async fn demanded_resource_uses_async_readiness_and_allocation_hooks() -> Result
     Ok(())
 }
 
+#[tokio::test]
+async fn async_readiness_reassigns_unowned_persisted_port_before_resource_readiness() -> Result<()>
+{
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mysql:
+  version: "8.0"
+  allocations:
+    app-db:
+      env:
+        DATABASE_URL: "${url}"
+"#,
+    )?;
+    seed_fake_sql_artifact(&paths, "mysql", FAKE_SQL_TRACK)?;
+    let external_listener = TcpListener::bind(("127.0.0.1", 0))?;
+    let occupied_port = external_listener.local_addr()?.port();
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let catalog = super::ManagedResourceRuntimeCatalog::with_adapter(
+        super::ManagedResourceInstallOptions {
+            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            target_platform: super::current_target_platform(),
+        },
+        AsyncSqlHookRuntimeAdapter::new(Arc::clone(&hook_events))?,
+    );
+    let mut database = Database::open(&paths)?;
+    database.assign_port(
+        PortRequest::resource_port(
+            "mysql",
+            FAKE_SQL_TRACK,
+            "mysql",
+            occupied_port,
+            occupied_port,
+            occupied_port,
+        ),
+        |_port| true,
+    )?;
+
+    crate::project_env::reconcile_project_env_with_catalog(
+        &paths,
+        &mut database,
+        &project.id,
+        &catalog,
+    )
+    .await?;
+    let assigned_ports = database.assigned_ports()?;
+    let resource_allocations = database.resource_allocations(&project.id, "mysql")?;
+    let assigned_mysql_port = assigned_mysql_port(&assigned_ports)?;
+    let dotenv = read_dotenv(&project)?;
+    let uses_occupied_port = dotenv.contains(&format!(":{occupied_port}/"));
+
+    assert_ne!(
+        assigned_mysql_port, occupied_port,
+        "expected async readiness resource to reassign the externally occupied persisted port"
+    );
+    assert!(
+        !uses_occupied_port,
+        "expected rendered env to use the reassigned resource port"
+    );
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "async_readiness_reassigns_unowned_persisted_port_before_resource_readiness",
+        (
+            (
+                "persisted_port_reassigned",
+                assigned_mysql_port != occupied_port,
+            ),
+            ("env_uses_occupied_port", uses_occupied_port),
+            dotenv,
+            assigned_ports,
+            resource_allocations,
+            database.runtime_observed_states()?,
+            cloned_hook_events(&hook_events)?,
+        ),
+    )?;
+
+    Ok(())
+}
+
 async fn reconcile_project_env_with_fake_runtime_catalog(
     paths: &PvPaths,
     project_id: &str,
@@ -1436,6 +1518,22 @@ fn required_sql_port(
             port: "mysql".to_string(),
         }
     })
+}
+
+fn assigned_mysql_port(assignments: &[state::PortAssignment]) -> Result<u16> {
+    assignments
+        .iter()
+        .find_map(|assignment| match &assignment.owner {
+            PortOwner::Resource {
+                name,
+                track: owner_track,
+                port,
+            } if name == "mysql" && owner_track == FAKE_SQL_TRACK && port == "mysql" => {
+                Some(assignment.port)
+            }
+            _ => None,
+        })
+        .ok_or_else(|| anyhow::anyhow!("missing assigned mysql {FAKE_SQL_TRACK} mysql port"))
 }
 
 fn assert_runtime_status(

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::net::TcpListener;
 use std::os::unix::fs::PermissionsExt;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, bail};
 use camino::Utf8Path;
@@ -8,7 +9,7 @@ use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
 use state::{
     Database, EnvContextValues, LinkProjectInput, PortRequest, ProjectRecord, PvPaths,
-    RuntimeObservedStatus, RuntimeSubject, StateError,
+    ResourceAllocationRecord, RuntimeObservedStatus, RuntimeSubject, StateError,
 };
 
 use crate::{
@@ -19,6 +20,8 @@ const FAKE_MAILPIT_TRACK: &str = "1.0";
 const FAKE_MAILPIT_NEXT_TRACK: &str = "1.1";
 const FAKE_MAILPIT_ARTIFACT_VERSION: &str = "1.0.0-pv1";
 const FAKE_MAILPIT_ARCHIVE_FILE_NAME: &str = "mailpit-1.0.0-pv1-any.tar.gz";
+const FAKE_SQL_TRACK: &str = "8.0";
+const FAKE_SQL_ARTIFACT_VERSION: &str = "8.0.0-pv1";
 const OFFLINE_TEST_MANIFEST_URL: &str = "https://127.0.0.1:9/manifest.json";
 const INVALID_DEFAULT_PORT_SPECS: &[super::ManagedResourcePortSpec] = &[
     super::ManagedResourcePortSpec {
@@ -117,8 +120,13 @@ fn unready_fake_runtime_uses_http_readiness_to_avoid_parallel_tcp_collisions() -
         ]),
     };
 
+    let readiness = adapter.readiness(&context)?;
+    let super::ManagedResourceReadiness::TcpHttp(readiness) = readiness else {
+        bail!("expected tcp/http readiness");
+    };
+
     assert_eq!(
-        adapter.readiness(&context)?,
+        readiness,
         ReadinessCheck::Http {
             host: super::RESOURCE_HOST.to_string(),
             port: 18026,
@@ -718,6 +726,70 @@ async fn demand_change_stops_previous_runtime_when_new_runtime_readiness_fails()
     Ok(())
 }
 
+#[tokio::test]
+async fn demanded_resource_uses_async_readiness_and_allocation_hooks() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mysql:
+  version: "8.0"
+  allocations:
+    app-db:
+      env:
+        DATABASE_URL: "${url}"
+"#,
+    )?;
+    seed_fake_sql_artifact(&paths, "mysql", FAKE_SQL_TRACK)?;
+    let hook_events = Arc::new(Mutex::new(Vec::new()));
+    let catalog = super::ManagedResourceRuntimeCatalog::with_adapter(
+        super::ManagedResourceInstallOptions {
+            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            target_platform: super::current_target_platform(),
+        },
+        AsyncSqlHookRuntimeAdapter::new(Arc::clone(&hook_events))?,
+    );
+    let mut database = Database::open(&paths)?;
+
+    crate::project_env::reconcile_project_env_with_catalog(
+        &paths,
+        &mut database,
+        &project.id,
+        &catalog,
+    )
+    .await?;
+    let started_snapshot = (
+        read_dotenv(&project)?,
+        database.resource_allocations(&project.id, "mysql")?,
+        database.runtime_observed_states()?,
+        cloned_hook_events(&hook_events)?,
+    );
+
+    write_project_config(
+        &project,
+        r#"env:
+  APP_URL: "${project_url}"
+"#,
+    )?;
+    crate::project_env::reconcile_project_env_with_catalog(
+        &paths,
+        &mut database,
+        &project.id,
+        &catalog,
+    )
+    .await?;
+
+    assert_with_normalized_runtime(
+        tempdir.path(),
+        "demanded_resource_uses_async_readiness_and_allocation_hooks",
+        started_snapshot,
+    )?;
+
+    Ok(())
+}
+
 async fn reconcile_project_env_with_fake_runtime_catalog(
     paths: &PvPaths,
     project_id: &str,
@@ -910,6 +982,27 @@ fn seed_fake_mailpit_runtime_port(
     )?;
 
     Ok(listener)
+}
+
+fn seed_fake_sql_artifact(paths: &PvPaths, resource: &str, track: &str) -> Result<()> {
+    let release_path = paths
+        .resources()
+        .join(resource)
+        .join(track)
+        .join(format!("releases/{FAKE_SQL_ARTIFACT_VERSION}"));
+    let executable = release_path.join("bin/pv-fake-sql");
+
+    state::fs::write_sensitive_file(&executable, fake_sql_script())?;
+    set_executable(&executable)?;
+    let mut database = Database::open(paths)?;
+    database.record_managed_resource_track_installed(
+        resource,
+        track,
+        FAKE_SQL_ARTIFACT_VERSION,
+        &release_path,
+    )?;
+
+    Ok(())
 }
 
 fn seed_fake_mailpit_cached_fixture(paths: &PvPaths, tempdir: &Utf8Path) -> Result<()> {
@@ -1109,6 +1202,152 @@ PY
 "#
 }
 
+fn fake_sql_script() -> &'static str {
+    r#"#!/bin/sh
+set -eu
+
+stop() {
+  exit 0
+}
+
+trap stop TERM INT
+
+while true; do
+  sleep 1
+done
+"#
+}
+
+#[derive(Clone, Debug)]
+struct AsyncSqlHookRuntimeAdapter {
+    artifact_adapter: super::ManagedResourceArtifactAdapter,
+    hook_events: Arc<Mutex<Vec<String>>>,
+}
+
+impl AsyncSqlHookRuntimeAdapter {
+    fn new(hook_events: Arc<Mutex<Vec<String>>>) -> Result<Self> {
+        Ok(Self {
+            artifact_adapter: super::ManagedResourceArtifactAdapter::new(
+                "mysql",
+                "bin/pv-fake-sql",
+            )?,
+            hook_events,
+        })
+    }
+}
+
+impl super::ManagedResourceRuntimeAdapter for AsyncSqlHookRuntimeAdapter {
+    fn resource_name(&self) -> &'static str {
+        "mysql"
+    }
+
+    fn artifact_adapter(
+        &self,
+    ) -> Result<super::ManagedResourceArtifactAdapter, crate::DaemonError> {
+        Ok(self.artifact_adapter.clone())
+    }
+
+    fn port_specs(&self) -> &'static [super::ManagedResourcePortSpec] {
+        &[super::ManagedResourcePortSpec {
+            name: "mysql",
+            preferred_port: 3306,
+        }]
+    }
+
+    fn build_process_spec(
+        &self,
+        paths: &PvPaths,
+        context: &super::ManagedResourceRuntimeContext,
+    ) -> Result<crate::ProcessSpec, crate::DaemonError> {
+        let config_path = paths.resource_runtime_config(&context.resource_name, &context.track);
+        state::fs::write_sensitive_file(&config_path, "{}")?;
+
+        Ok(crate::ProcessSpec {
+            name: format!("{}-{}", context.resource_name, context.track),
+            command: self
+                .artifact_adapter
+                .executable_path(&context.artifact_path),
+            arguments: Vec::new(),
+            config_path,
+            log_path: paths.resource_log(&context.resource_name, &context.track),
+            pid_path: paths.resource_pid(&context.resource_name, &context.track),
+            metadata_path: paths.resource_runtime_metadata(&context.resource_name, &context.track),
+            resource_name: context.resource_name.clone(),
+            track: context.track.clone(),
+        })
+    }
+
+    fn readiness(
+        &self,
+        _context: &super::ManagedResourceRuntimeContext,
+    ) -> Result<super::ManagedResourceReadiness, crate::DaemonError> {
+        let hook_events = Arc::clone(&self.hook_events);
+
+        Ok(super::ManagedResourceReadiness::async_check(
+            "sql:mysql:admin",
+            move || {
+                let hook_events = Arc::clone(&hook_events);
+
+                Box::pin(async move {
+                    push_hook_event(&hook_events, "readiness")?;
+
+                    Ok(())
+                })
+            },
+        ))
+    }
+
+    fn resource_env(
+        &self,
+        context: &super::ManagedResourceRuntimeContext,
+    ) -> Result<EnvContextValues, crate::DaemonError> {
+        Ok(BTreeMap::from([
+            ("host".to_string(), "127.0.0.1".to_string()),
+            ("port".to_string(), required_sql_port(context)?.to_string()),
+        ]))
+    }
+
+    fn reconcile_allocations<'a>(
+        &'a self,
+        _paths: &'a PvPaths,
+        database: &'a mut Database,
+        context: &'a super::ManagedResourceRuntimeContext,
+        allocations: &'a [ResourceAllocationRecord],
+    ) -> super::ManagedResourceAllocationFuture<'a> {
+        let hook_events = Arc::clone(&self.hook_events);
+
+        Box::pin(async move {
+            push_hook_event(&hook_events, "allocation")?;
+            let port = required_sql_port(context)?;
+
+            for allocation in allocations {
+                database.mark_resource_allocation_ready(
+                    &allocation.project_id,
+                    &allocation.resource_name,
+                    &allocation.track,
+                    &allocation.allocation_name,
+                    &BTreeMap::from([
+                        ("database".to_string(), allocation.generated_name.clone()),
+                        ("host".to_string(), "127.0.0.1".to_string()),
+                        ("password".to_string(), "secret".to_string()),
+                        ("port".to_string(), port.to_string()),
+                        (
+                            "url".to_string(),
+                            format!(
+                                "mysql://root:secret@127.0.0.1:{port}/{}",
+                                allocation.generated_name
+                            ),
+                        ),
+                        ("username".to_string(), "root".to_string()),
+                    ]),
+                )?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
 fn assert_with_normalized_runtime(
     tempdir: &Utf8Path,
     name: &'static str,
@@ -1131,10 +1370,19 @@ fn assert_with_normalized_runtime(
         r#""dashboard_url": "http://127.0.0.1:<dashboard_port>""#,
     );
     settings.add_filter(r#""smtp_port": "\d+""#, r#""smtp_port": "<smtp_port>""#);
+    settings.add_filter(r#""port": "\d+""#, r#""port": "<port>""#);
     settings.add_filter(r"tcp:127\.0\.0\.1:\d+", "tcp:127.0.0.1:<readiness_port>");
     settings.add_filter(
         r"http:127\.0\.0\.1:\d+/__pv_unready_fixture__",
         "http:127.0.0.1:<readiness_port>/__pv_unready_fixture__",
+    );
+    settings.add_filter(
+        r"DATABASE_URL=mysql://root:secret@127\.0\.0\.1:\d+/acme_test_app_db",
+        "DATABASE_URL=mysql://root:secret@127.0.0.1:<mysql_port>/acme_test_app_db",
+    );
+    settings.add_filter(
+        r#"mysql://root:secret@127\.0\.0\.1:\d+/acme_test_app_db"#,
+        "mysql://root:secret@127.0.0.1:<mysql_port>/acme_test_app_db",
     );
     settings.add_filter(r"timeout_ms: \d+", "timeout_ms: <timeout_ms>");
     settings.add_filter(r"os error \d+", "os error <code>");
@@ -1153,6 +1401,41 @@ fn assert_with_normalized_runtime(
 
 fn assert_failed_mailpit_runtime(states: &[state::RuntimeObservedStateRecord]) {
     assert_runtime_status(states, FAKE_MAILPIT_TRACK, RuntimeObservedStatus::Failed);
+}
+
+fn push_hook_event(
+    hook_events: &Arc<Mutex<Vec<String>>>,
+    event: &str,
+) -> Result<(), crate::DaemonError> {
+    let mut events =
+        hook_events
+            .lock()
+            .map_err(|_error| crate::DaemonError::UnexpectedProtocolResponse {
+                reason: "async hook event log was poisoned".to_string(),
+            })?;
+    events.push(event.to_string());
+
+    Ok(())
+}
+
+fn cloned_hook_events(hook_events: &Arc<Mutex<Vec<String>>>) -> Result<Vec<String>> {
+    let events = hook_events
+        .lock()
+        .map_err(|_error| anyhow::anyhow!("async hook event log was poisoned"))?;
+
+    Ok(events.clone())
+}
+
+fn required_sql_port(
+    context: &super::ManagedResourceRuntimeContext,
+) -> Result<u16, crate::DaemonError> {
+    context.ports.get("mysql").copied().ok_or_else(|| {
+        crate::DaemonError::ManagedResourcePortMissing {
+            resource: context.resource_name.clone(),
+            track: context.track.clone(),
+            port: "mysql".to_string(),
+        }
+    })
 }
 
 fn assert_runtime_status(
@@ -1312,7 +1595,7 @@ impl ManagedResourceRuntimeAdapter for InvalidDefaultPortRuntimeAdapter {
     fn readiness(
         &self,
         _context: &super::ManagedResourceRuntimeContext,
-    ) -> Result<ReadinessCheck, DaemonError> {
+    ) -> Result<super::ManagedResourceReadiness, DaemonError> {
         Err(DaemonError::UnexpectedProtocolResponse {
             reason: "invalid default-port test adapter should fail during port assignment"
                 .to_string(),

--- a/crates/daemon/tests/project_env_reconciliation.rs
+++ b/crates/daemon/tests/project_env_reconciliation.rs
@@ -152,19 +152,19 @@ async fn seeded_resource_and_allocation_contexts_render_dotenv() -> Result<()> {
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        r#"mysql:
+        r#"postgres:
   version: "8.0"
   allocations:
     app-db:
       env:
-        DATABASE_URL: "mysql://${username}:${password}@${host}:${port}/${database}"
+        DATABASE_URL: "postgres://${username}:${password}@${host}:${port}/${database}"
         DB_DATABASE: "${database}"
         DB_HOST: "${host}"
         DB_PORT: "${port}"
         DB_USERNAME: "${username}"
 "#,
     )?;
-    seed_mysql_context(&paths, &project)?;
+    seed_postgres_context(&paths, &project)?;
 
     let lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
@@ -175,7 +175,7 @@ async fn seeded_resource_and_allocation_contexts_render_dotenv() -> Result<()> {
             lines,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
-            database.resource_allocations(&project.id, "mysql")?,
+            database.resource_allocations(&project.id, "postgres")?,
             database.project_env_observed_state(&project.id)?,
             latest_job(&database, &format!("project:{}", project.id))?,
         ),
@@ -192,7 +192,7 @@ async fn existing_allocation_name_survives_primary_hostname_change() -> Result<(
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        r#"mysql:
+        r#"postgres:
   version: "8.0"
   allocations:
     app-db:
@@ -200,7 +200,7 @@ async fn existing_allocation_name_survives_primary_hostname_change() -> Result<(
         DB_DATABASE: "${database}"
 "#,
     )?;
-    seed_mysql_context(&paths, &project)?;
+    seed_postgres_context(&paths, &project)?;
     let project = update_project_primary_hostname(
         &paths,
         &project,
@@ -215,7 +215,7 @@ async fn existing_allocation_name_survives_primary_hostname_change() -> Result<(
         (
             lines,
             read_optional_dotenv(&project)?,
-            database.resource_allocations(&project.id, "mysql")?,
+            database.resource_allocations(&project.id, "postgres")?,
             database.project_env_observed_state(&project.id)?,
             latest_job(&database, &format!("project:{}", project.id))?,
         ),
@@ -232,7 +232,7 @@ async fn missing_context_leaves_dotenv_unchanged_and_records_failure() -> Result
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        "mysql:\n  version: \"8.0\"\n  env:\n    DB_HOST: \"${host}\"\n",
+        "postgres:\n  version: \"8.0\"\n  env:\n    DB_HOST: \"${host}\"\n",
     )?;
     state::fs::write_sensitive_file(&project.path.join(".env"), "USER_VALUE=kept\n")?;
 
@@ -260,7 +260,7 @@ async fn root_env_with_resource_waits_for_resource_context_before_dotenv() -> Re
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        "env:\n  APP_URL: \"${project_url}\"\nmysql:\n  version: \"8.0\"\n",
+        "env:\n  APP_URL: \"${project_url}\"\npostgres:\n  version: \"8.0\"\n",
     )?;
     state::fs::write_sensitive_file(&project.path.join(".env"), "USER_VALUE=kept\n")?;
 
@@ -290,7 +290,7 @@ async fn first_allocation_reconciliation_records_desired_state_before_context_fa
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        r#"mysql:
+        r#"postgres:
   version: "8.0"
   allocations:
     app-db:
@@ -308,7 +308,7 @@ async fn first_allocation_reconciliation_records_desired_state_before_context_fa
             lines,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
-            database.resource_allocations(&project.id, "mysql")?,
+            database.resource_allocations(&project.id, "postgres")?,
             database.project_env_observed_state(&project.id)?,
             latest_job(&database, &format!("project:{}", project.id))?,
         ),
@@ -358,7 +358,7 @@ async fn malformed_pv_block_preflight_preserves_resource_and_hostname_state() ->
         "acme.test",
         r#"hostnames:
   - api.acme.test
-mysql:
+postgres:
   version: "8.0"
   env:
     DB_HOST: "${host}"
@@ -382,7 +382,7 @@ mysql:
             read_dotenv(&project)?,
             hostnames,
             database.project_managed_resources(&project.id)?,
-            database.resource_allocations(&project.id, "mysql")?,
+            database.resource_allocations(&project.id, "postgres")?,
             database.project_env_observed_state(&project.id)?,
             latest_job(&database, &format!("project:{}", project.id))?,
         ),
@@ -427,15 +427,15 @@ async fn duplicate_rendered_env_key_leaves_resource_state_unchanged() -> Result<
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        r#"mysql:
+        r#"postgres:
   version: "8.0"
   allocations:
     analytics:
       env:
-        DATABASE_URL: "mysql://${database}"
+        DATABASE_URL: "postgres://${database}"
     app:
       env:
-        DATABASE_URL: "mysql://${database}"
+        DATABASE_URL: "postgres://${database}"
 "#,
     )?;
 
@@ -448,7 +448,7 @@ async fn duplicate_rendered_env_key_leaves_resource_state_unchanged() -> Result<
             lines,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
-            database.resource_allocations(&project.id, "mysql")?,
+            database.resource_allocations(&project.id, "postgres")?,
             database.project_env_observed_state(&project.id)?,
             latest_job(&database, &format!("project:{}", project.id))?,
         ),
@@ -467,7 +467,7 @@ async fn generated_allocation_name_too_long_leaves_resource_state_unchanged() ->
         &tempdir.path().join("project"),
         "a.test",
         &format!(
-            r#"mysql:
+            r#"postgres:
   version: "8.0"
   allocations:
     {allocation_name}:
@@ -486,7 +486,7 @@ async fn generated_allocation_name_too_long_leaves_resource_state_unchanged() ->
             lines,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
-            database.resource_allocations(&project.id, "mysql")?,
+            database.resource_allocations(&project.id, "postgres")?,
             database.project_env_observed_state(&project.id)?,
             latest_job(&database, &format!("project:{}", project.id))?,
         ),
@@ -505,7 +505,7 @@ async fn invalid_config_failure_rolls_back_resource_state_mutations() -> Result<
         "acme.test",
         r#"hostnames:
   - api.acme.test
-mysql:
+postgres:
   version: "8.0"
   allocations:
     app-db:
@@ -513,11 +513,11 @@ mysql:
         DB_DATABASE: "${database}"
 "#,
     )?;
-    seed_mysql_context(&paths, &project)?;
+    seed_postgres_context(&paths, &project)?;
     let initial_lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
     let managed_resources_before = database.project_managed_resources(&project.id)?;
-    let allocations_before = database.resource_allocations(&project.id, "mysql")?;
+    let allocations_before = database.resource_allocations(&project.id, "postgres")?;
     let hostnames_before = database
         .project_by_id(&project.id)?
         .map(|project| project.additional_hostnames);
@@ -537,7 +537,7 @@ redis:
     let invalid_lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
     let managed_resources_after = database.project_managed_resources(&project.id)?;
-    let allocations_after = database.resource_allocations(&project.id, "mysql")?;
+    let allocations_after = database.resource_allocations(&project.id, "postgres")?;
     let hostnames_after = database
         .project_by_id(&project.id)?
         .map(|project| project.additional_hostnames);
@@ -590,7 +590,7 @@ async fn legacy_url_placeholder_failure_preserves_last_valid_desired_state() -> 
   - api.acme.test
 env:
   APP_URL: "${project_url}"
-mysql:
+postgres:
   version: "8.0"
   allocations:
     app-db:
@@ -598,11 +598,11 @@ mysql:
         DB_DATABASE: "${database}"
 "#,
     )?;
-    seed_mysql_context(&paths, &project)?;
+    seed_postgres_context(&paths, &project)?;
     let initial_lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
     let managed_resources_before = database.project_managed_resources(&project.id)?;
-    let allocations_before = database.resource_allocations(&project.id, "mysql")?;
+    let allocations_before = database.resource_allocations(&project.id, "postgres")?;
     let hostnames_before = database
         .project_by_id(&project.id)?
         .map(|project| project.additional_hostnames);
@@ -624,7 +624,7 @@ redis:
     let invalid_lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
     let managed_resources_after = database.project_managed_resources(&project.id)?;
-    let allocations_after = database.resource_allocations(&project.id, "mysql")?;
+    let allocations_after = database.resource_allocations(&project.id, "postgres")?;
     let hostnames_after = database
         .project_by_id(&project.id)?
         .map(|project| project.additional_hostnames);
@@ -702,7 +702,7 @@ async fn resources_and_empty_allocations_without_env_mappings_update_state_witho
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        r#"mysql:
+        r#"postgres:
   version: "8.0"
   allocations:
     app-db: {}
@@ -718,7 +718,7 @@ async fn resources_and_empty_allocations_without_env_mappings_update_state_witho
             lines,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
-            database.resource_allocations(&project.id, "mysql")?,
+            database.resource_allocations(&project.id, "postgres")?,
             database.project_env_observed_state(&project.id)?,
             latest_job(&database, &format!("project:{}", project.id))?,
         ),
@@ -841,10 +841,10 @@ async fn latest_resource_track_resolves_default_track_before_state_and_dotenv_wr
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        "mysql:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n",
+        "postgres:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n",
     )?;
     seed_manifest(&paths, "8.0")?;
-    seed_mysql_resource_context(&paths)?;
+    seed_postgres_resource_context(&paths)?;
 
     let lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
@@ -856,7 +856,7 @@ async fn latest_resource_track_resolves_default_track_before_state_and_dotenv_wr
             read_project_config(&project)?,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
-            database.resource_allocations(&project.id, "mysql")?,
+            database.resource_allocations(&project.id, "postgres")?,
             database.project_env_observed_state(&project.id)?,
             latest_job(&database, &format!("project:{}", project.id))?,
         ),
@@ -873,14 +873,14 @@ async fn latest_resource_track_reuses_stored_track_when_manifest_default_changes
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        "mysql:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
+        "postgres:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
     )?;
     seed_manifest(&paths, "8.0")?;
-    seed_mysql_resource_context(&paths)?;
+    seed_postgres_resource_context(&paths)?;
     let initial_lines = run_project_reconciliation(&paths, &project).await?;
 
     seed_manifest(&paths, "8.4")?;
-    seed_mysql_resource_context_for_track(&paths, "8.4", "3406")?;
+    seed_postgres_resource_context_for_track(&paths, "8.4", "3406")?;
     let rerun_lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
 
@@ -908,10 +908,10 @@ async fn omitted_resource_track_resolves_manifest_default_track() -> Result<()> 
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        "mysql:\n  env:\n    DB_HOST: \"${host}\"\n",
+        "postgres:\n  env:\n    DB_HOST: \"${host}\"\n",
     )?;
     seed_manifest(&paths, "8.0")?;
-    seed_mysql_resource_context(&paths)?;
+    seed_postgres_resource_context(&paths)?;
 
     let lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
@@ -939,14 +939,14 @@ async fn omitted_resource_track_reuses_stored_track_when_manifest_default_change
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        "mysql:\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
+        "postgres:\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
     )?;
     seed_manifest(&paths, "8.0")?;
-    seed_mysql_resource_context(&paths)?;
+    seed_postgres_resource_context(&paths)?;
     let initial_lines = run_project_reconciliation(&paths, &project).await?;
 
     seed_manifest(&paths, "8.4")?;
-    seed_mysql_resource_context_for_track(&paths, "8.4", "3406")?;
+    seed_postgres_resource_context_for_track(&paths, "8.4", "3406")?;
     let rerun_lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
 
@@ -974,7 +974,7 @@ async fn omitted_resource_track_without_mappings_updates_state_without_dotenv() 
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        "mysql:\n",
+        "postgres:\n",
     )?;
     seed_manifest(&paths, "8.0")?;
 
@@ -987,7 +987,7 @@ async fn omitted_resource_track_without_mappings_updates_state_without_dotenv() 
             lines,
             read_optional_dotenv(&project)?,
             database.project_managed_resources(&project.id)?,
-            database.resource_allocations(&project.id, "mysql")?,
+            database.resource_allocations(&project.id, "postgres")?,
             database.project_env_observed_state(&project.id)?,
             latest_job(&database, &format!("project:{}", project.id))?,
         ),
@@ -1122,20 +1122,20 @@ fn update_project_primary_hostname(
     Ok(result.project)
 }
 
-fn seed_mysql_context(paths: &PvPaths, project: &ProjectRecord) -> Result<()> {
+fn seed_postgres_context(paths: &PvPaths, project: &ProjectRecord) -> Result<()> {
     let mut database = Database::open(paths)?;
 
-    seed_mysql_resource_context_in_database(&mut database)?;
+    seed_postgres_resource_context_in_database(&mut database)?;
     database.replace_project_managed_resources(
         &project.id,
         &[ProjectManagedResourceInput {
-            resource_name: "mysql".to_string(),
+            resource_name: "postgres".to_string(),
             track: "8.0".to_string(),
         }],
     )?;
     database.replace_project_resource_allocations(
         &project.id,
-        "mysql",
+        "postgres",
         "8.0",
         &[ResourceAllocationInput {
             allocation_name: "app-db".to_string(),
@@ -1144,7 +1144,7 @@ fn seed_mysql_context(paths: &PvPaths, project: &ProjectRecord) -> Result<()> {
     )?;
     database.mark_resource_allocation_ready(
         &project.id,
-        "mysql",
+        "postgres",
         "8.0",
         "app-db",
         &env_context(&[("database", "acme_test_app_db")]),
@@ -1153,26 +1153,30 @@ fn seed_mysql_context(paths: &PvPaths, project: &ProjectRecord) -> Result<()> {
     Ok(())
 }
 
-fn seed_mysql_resource_context(paths: &PvPaths) -> Result<()> {
-    seed_mysql_resource_context_for_track(paths, "8.0", "3306")
+fn seed_postgres_resource_context(paths: &PvPaths) -> Result<()> {
+    seed_postgres_resource_context_for_track(paths, "8.0", "3306")
 }
 
-fn seed_mysql_resource_context_for_track(paths: &PvPaths, track: &str, port: &str) -> Result<()> {
+fn seed_postgres_resource_context_for_track(
+    paths: &PvPaths,
+    track: &str,
+    port: &str,
+) -> Result<()> {
     let mut database = Database::open(paths)?;
-    seed_mysql_resource_context_for_track_in_database(&mut database, track, port)
+    seed_postgres_resource_context_for_track_in_database(&mut database, track, port)
 }
 
-fn seed_mysql_resource_context_in_database(database: &mut Database) -> Result<()> {
-    seed_mysql_resource_context_for_track_in_database(database, "8.0", "3306")
+fn seed_postgres_resource_context_in_database(database: &mut Database) -> Result<()> {
+    seed_postgres_resource_context_for_track_in_database(database, "8.0", "3306")
 }
 
-fn seed_mysql_resource_context_for_track_in_database(
+fn seed_postgres_resource_context_for_track_in_database(
     database: &mut Database,
     track: &str,
     port: &str,
 ) -> Result<()> {
     database.record_managed_resource_track_env_context(
-        "mysql",
+        "postgres",
         track,
         &env_context(&[
             ("host", "127.0.0.1"),
@@ -1200,7 +1204,7 @@ fn test_manifest(default_track: &str) -> String {
         "minimum_pv_version": "0.1.0",
         "resources": [
             {
-                "name": "mysql",
+                "name": "postgres",
                 "default_track": default_track,
                 "tracks": [
                     {
@@ -1211,7 +1215,7 @@ fn test_manifest(default_track: &str) -> String {
                                 "upstream_version": "8.0.42",
                                 "pv_build_revision": "pv1",
                                 "platform": "darwin-arm64",
-                                "url": "https://artifacts.example.test/mysql-8.0.42-pv1-darwin-arm64.tar.gz",
+                                "url": "https://artifacts.example.test/postgres-8.0.42-pv1-darwin-arm64.tar.gz",
                                 "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                                 "size": 12345,
                                 "published_at": "2026-05-26T14:30:00Z"
@@ -1226,7 +1230,7 @@ fn test_manifest(default_track: &str) -> String {
                                 "upstream_version": "8.4.5",
                                 "pv_build_revision": "pv1",
                                 "platform": "darwin-arm64",
-                                "url": "https://artifacts.example.test/mysql-8.4.5-pv1-darwin-arm64.tar.gz",
+                                "url": "https://artifacts.example.test/postgres-8.4.5-pv1-darwin-arm64.tar.gz",
                                 "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                                 "size": 12345,
                                 "published_at": "2026-05-27T14:30:00Z"

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__duplicate_rendered_env_key_leaves_resource_state_unchanged.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__duplicate_rendered_env_key_leaves_resource_state_unchanged.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Project config error: duplicate rendered Project env key `DATABASE_URL` from same-depth mappings `mysql.allocations.analytics.env.DATABASE_URL` and `mysql.allocations.app.env.DATABASE_URL`"),
+            "error": String("Project config error: duplicate rendered Project env key `DATABASE_URL` from same-depth mappings `postgres.allocations.analytics.env.DATABASE_URL` and `postgres.allocations.app.env.DATABASE_URL`"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -36,7 +36,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Project config error: duplicate rendered Project env key `DATABASE_URL` from same-depth mappings `mysql.allocations.analytics.env.DATABASE_URL` and `mysql.allocations.app.env.DATABASE_URL`",
+                "Project config error: duplicate rendered Project env key `DATABASE_URL` from same-depth mappings `postgres.allocations.analytics.env.DATABASE_URL` and `postgres.allocations.app.env.DATABASE_URL`",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -53,7 +53,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Project config error: duplicate rendered Project env key `DATABASE_URL` from same-depth mappings `mysql.allocations.analytics.env.DATABASE_URL` and `mysql.allocations.app.env.DATABASE_URL`",
+            "Project config error: duplicate rendered Project env key `DATABASE_URL` from same-depth mappings `postgres.allocations.analytics.env.DATABASE_URL` and `postgres.allocations.app.env.DATABASE_URL`",
         ),
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__existing_allocation_name_survives_primary_hostname_change.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__existing_allocation_name_survives_primary_hostname_change.snap
@@ -40,7 +40,7 @@ expression: snapshot
         ResourceAllocationRecord {
             id: "allocation_000001",
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             allocation_name: "app-db",
             generated_name: "acme_test_app_db",

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__first_allocation_reconciliation_records_desired_state_before_context_failure.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__first_allocation_reconciliation_records_desired_state_before_context_failure.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Managed Resource runtime `mysql` is not supported yet"),
+            "error": String("Managed Resource runtime `postgres` is not supported yet"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -32,7 +32,7 @@ expression: snapshot
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",
@@ -42,7 +42,7 @@ expression: snapshot
         ResourceAllocationRecord {
             id: "allocation_000001",
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             allocation_name: "app-db",
             generated_name: "acme_test_app_db",
@@ -57,7 +57,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Managed Resource runtime `mysql` is not supported yet",
+                "Managed Resource runtime `postgres` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -74,7 +74,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Managed Resource runtime `mysql` is not supported yet",
+            "Managed Resource runtime `postgres` is not supported yet",
         ),
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__generated_allocation_name_too_long_leaves_resource_state_unchanged.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__generated_allocation_name_too_long_leaves_resource_state_unchanged.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Managed Resource error: generated Resource allocation name `a_test_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` for `mysql` allocation `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` exceeds 63 characters"),
+            "error": String("Managed Resource error: generated Resource allocation name `a_test_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` for `postgres` allocation `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` exceeds 63 characters"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -36,7 +36,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Managed Resource error: generated Resource allocation name `a_test_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` for `mysql` allocation `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` exceeds 63 characters",
+                "Managed Resource error: generated Resource allocation name `a_test_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` for `postgres` allocation `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` exceeds 63 characters",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -53,7 +53,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Managed Resource error: generated Resource allocation name `a_test_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` for `mysql` allocation `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` exceeds 63 characters",
+            "Managed Resource error: generated Resource allocation name `a_test_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` for `postgres` allocation `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` exceeds 63 characters",
         ),
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__invalid_config_failure_rolls_back_resource_state_mutations.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__invalid_config_failure_rolls_back_resource_state_mutations.snap
@@ -66,7 +66,7 @@ expression: snapshot
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",
@@ -76,7 +76,7 @@ expression: snapshot
         ResourceAllocationRecord {
             id: "allocation_000001",
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             allocation_name: "app-db",
             generated_name: "acme_test_app_db",

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__latest_resource_track_resolves_default_track_before_state_and_dotenv_writes.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__latest_resource_track_resolves_default_track_before_state_and_dotenv_writes.snap
@@ -33,14 +33,14 @@ expression: snapshot
             "type": String("job_completed"),
         },
     ],
-    "mysql:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n",
+    "postgres:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n",
     Some(
         "# >>> PV MANAGED\nDB_HOST=127.0.0.1\n# <<< PV MANAGED\n",
     ),
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__latest_resource_track_reuses_stored_track_when_manifest_default_changes.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__latest_resource_track_reuses_stored_track_when_manifest_default_changes.snap
@@ -63,14 +63,14 @@ expression: snapshot
             "type": String("job_completed"),
         },
     ],
-    "mysql:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
+    "postgres:\n  version: latest\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
     Some(
         "# >>> PV MANAGED\nDB_HOST=127.0.0.1\nDB_PORT=3306\n# <<< PV MANAGED\n",
     ),
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__legacy_url_placeholder_failure_preserves_last_valid_desired_state.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__legacy_url_placeholder_failure_preserves_last_valid_desired_state.snap
@@ -66,7 +66,7 @@ expression: snapshot
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",
@@ -76,7 +76,7 @@ expression: snapshot
         ResourceAllocationRecord {
             id: "allocation_000001",
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             allocation_name: "app-db",
             generated_name: "acme_test_app_db",

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__missing_context_leaves_dotenv_unchanged_and_records_failure.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__missing_context_leaves_dotenv_unchanged_and_records_failure.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Managed Resource runtime `mysql` is not supported yet"),
+            "error": String("Managed Resource runtime `postgres` is not supported yet"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -34,7 +34,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Managed Resource runtime `mysql` is not supported yet",
+                "Managed Resource runtime `postgres` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -51,7 +51,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Managed Resource runtime `mysql` is not supported yet",
+            "Managed Resource runtime `postgres` is not supported yet",
         ),
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_resolves_manifest_default_track.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_resolves_manifest_default_track.snap
@@ -33,14 +33,14 @@ expression: snapshot
             "type": String("job_completed"),
         },
     ],
-    "mysql:\n  env:\n    DB_HOST: \"${host}\"\n",
+    "postgres:\n  env:\n    DB_HOST: \"${host}\"\n",
     Some(
         "# >>> PV MANAGED\nDB_HOST=127.0.0.1\n# <<< PV MANAGED\n",
     ),
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_reuses_stored_track_when_manifest_default_changes.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_reuses_stored_track_when_manifest_default_changes.snap
@@ -63,14 +63,14 @@ expression: snapshot
             "type": String("job_completed"),
         },
     ],
-    "mysql:\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
+    "postgres:\n  env:\n    DB_HOST: \"${host}\"\n    DB_PORT: \"${port}\"\n",
     Some(
         "# >>> PV MANAGED\nDB_HOST=127.0.0.1\nDB_PORT=3306\n# <<< PV MANAGED\n",
     ),
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_without_mappings_updates_state_without_dotenv.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__omitted_resource_track_without_mappings_updates_state_without_dotenv.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Managed Resource runtime `mysql` is not supported yet"),
+            "error": String("Managed Resource runtime `postgres` is not supported yet"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -32,7 +32,7 @@ expression: snapshot
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",
@@ -44,7 +44,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Managed Resource runtime `mysql` is not supported yet",
+                "Managed Resource runtime `postgres` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -61,7 +61,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Managed Resource runtime `mysql` is not supported yet",
+            "Managed Resource runtime `postgres` is not supported yet",
         ),
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__resources_and_empty_allocations_without_env_mappings_update_state_without_dotenv.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__resources_and_empty_allocations_without_env_mappings_update_state_without_dotenv.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Managed Resource runtime `mysql` is not supported yet"),
+            "error": String("Managed Resource runtime `postgres` is not supported yet"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -32,7 +32,7 @@ expression: snapshot
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",
@@ -42,7 +42,7 @@ expression: snapshot
         ResourceAllocationRecord {
             id: "allocation_000001",
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             allocation_name: "app-db",
             generated_name: "acme_test_app_db",
@@ -57,7 +57,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Managed Resource runtime `mysql` is not supported yet",
+                "Managed Resource runtime `postgres` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -74,7 +74,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Managed Resource runtime `mysql` is not supported yet",
+            "Managed Resource runtime `postgres` is not supported yet",
         ),
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__root_env_with_resource_waits_for_resource_context_before_dotenv.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__root_env_with_resource_waits_for_resource_context_before_dotenv.snap
@@ -23,7 +23,7 @@ expression: snapshot
             "type": String("log"),
         },
         Object {
-            "error": String("Managed Resource runtime `mysql` is not supported yet"),
+            "error": String("Managed Resource runtime `postgres` is not supported yet"),
             "job_id": String("job_000001"),
             "type": String("job_failed"),
         },
@@ -32,7 +32,7 @@ expression: snapshot
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",
@@ -43,7 +43,7 @@ expression: snapshot
             project_id: "<project_id>",
             status: Failed,
             message: Some(
-                "Managed Resource runtime `mysql` is not supported yet",
+                "Managed Resource runtime `postgres` is not supported yet",
             ),
             observed_at: "<timestamp>",
             warnings: [],
@@ -60,7 +60,7 @@ expression: snapshot
         ),
         summary: None,
         error: Some(
-            "Managed Resource runtime `mysql` is not supported yet",
+            "Managed Resource runtime `postgres` is not supported yet",
         ),
     },
 )

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__seeded_resource_and_allocation_contexts_render_dotenv.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__seeded_resource_and_allocation_contexts_render_dotenv.snap
@@ -34,12 +34,12 @@ expression: snapshot
         },
     ],
     Some(
-        "# >>> PV MANAGED\nDATABASE_URL=mysql://root:secret@127.0.0.1:3306/acme_test_app_db\nDB_DATABASE=acme_test_app_db\nDB_HOST=127.0.0.1\nDB_PORT=3306\nDB_USERNAME=root\n# <<< PV MANAGED\n",
+        "# >>> PV MANAGED\nDATABASE_URL=postgres://root:secret@127.0.0.1:3306/acme_test_app_db\nDB_DATABASE=acme_test_app_db\nDB_HOST=127.0.0.1\nDB_PORT=3306\nDB_USERNAME=root\n# <<< PV MANAGED\n",
     ),
     [
         ProjectManagedResourceRecord {
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             created_at: "<timestamp>",
             updated_at: "<timestamp>",
@@ -49,7 +49,7 @@ expression: snapshot
         ResourceAllocationRecord {
             id: "allocation_000001",
             project_id: "<project_id>",
-            resource_name: "mysql",
+            resource_name: "postgres",
             track: "8.0",
             allocation_name: "app-db",
             generated_name: "acme_test_app_db",

--- a/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_creates_database_and_marks_allocation_ready.snap
+++ b/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_creates_database_and_marks_allocation_ready.snap
@@ -1,0 +1,41 @@
+---
+source: crates/daemon/tests/sql_foundation.rs
+expression: snapshot
+---
+(
+    {
+        "host": "127.0.0.1",
+        "password": "secret",
+        "port": "3306",
+        "url": "mysql://root:secret@127.0.0.1:3306",
+        "username": "root",
+    },
+    [
+        RecordedSqlAdminOperation {
+            engine: Mysql,
+            database: "acme_test_app_db",
+            statement: "CREATE DATABASE IF NOT EXISTS `acme_test_app_db`",
+        },
+    ],
+    [
+        ResourceAllocationRecord {
+            id: "allocation_000001",
+            project_id: "<project_id>",
+            resource_name: "mysql",
+            track: "8.0",
+            allocation_name: "app-db",
+            generated_name: "acme_test_app_db",
+            env: {
+                "database": "acme_test_app_db",
+                "host": "127.0.0.1",
+                "password": "secret",
+                "port": "3306",
+                "url": "mysql://root:secret@127.0.0.1:3306/acme_test_app_db",
+                "username": "root",
+            },
+            status: Ready,
+            created_at: "<timestamp>",
+            updated_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_creates_postgres_database_and_marks_allocation_ready.snap
+++ b/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_creates_postgres_database_and_marks_allocation_ready.snap
@@ -1,0 +1,41 @@
+---
+source: crates/daemon/tests/sql_foundation.rs
+expression: snapshot
+---
+(
+    {
+        "host": "127.0.0.1",
+        "password": "pg-secret",
+        "port": "5432",
+        "url": "postgres://postgres:pg-secret@127.0.0.1:5432",
+        "username": "postgres",
+    },
+    [
+        RecordedSqlAdminOperation {
+            engine: Postgres,
+            database: "api_acme_test_analytics",
+            statement: "CREATE DATABASE \"api_acme_test_analytics\"",
+        },
+    ],
+    [
+        ResourceAllocationRecord {
+            id: "allocation_000001",
+            project_id: "<project_id>",
+            resource_name: "postgres",
+            track: "16",
+            allocation_name: "analytics",
+            generated_name: "api_acme_test_analytics",
+            env: {
+                "database": "api_acme_test_analytics",
+                "host": "127.0.0.1",
+                "password": "pg-secret",
+                "port": "5432",
+                "url": "postgres://postgres:pg-secret@127.0.0.1:5432/api_acme_test_analytics",
+                "username": "postgres",
+            },
+            status: Ready,
+            created_at: "<timestamp>",
+            updated_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_percent_encodes_url_userinfo.snap
+++ b/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_percent_encodes_url_userinfo.snap
@@ -1,0 +1,36 @@
+---
+source: crates/daemon/tests/sql_foundation.rs
+expression: snapshot
+---
+(
+    {
+        "host": "127.0.0.1",
+        "password": "pa:ss/wo@rd%#",
+        "port": "15432",
+        "url": "mysql://admin%40local%3Adev%2F%25%23:pa%3Ass%2Fwo%40rd%25%23@127.0.0.1:15432",
+        "username": "admin@local:dev/%#",
+    },
+    {
+        "database": "acme_test_app_db",
+        "host": "127.0.0.1",
+        "password": "pa:ss/wo@rd%#",
+        "port": "15432",
+        "url": "mysql://admin%40local%3Adev%2F%25%23:pa%3Ass%2Fwo%40rd%25%23@127.0.0.1:15432/acme_test_app_db",
+        "username": "admin@local:dev/%#",
+    },
+    {
+        "host": "127.0.0.1",
+        "password": "pa:ss/wo@rd%#",
+        "port": "15432",
+        "url": "postgres://admin%40local%3Adev%2F%25%23:pa%3Ass%2Fwo%40rd%25%23@127.0.0.1:15432",
+        "username": "admin@local:dev/%#",
+    },
+    {
+        "database": "acme_test_app_db",
+        "host": "127.0.0.1",
+        "password": "pa:ss/wo@rd%#",
+        "port": "15432",
+        "url": "postgres://admin%40local%3Adev%2F%25%23:pa%3Ass%2Fwo%40rd%25%23@127.0.0.1:15432/acme_test_app_db",
+        "username": "admin@local:dev/%#",
+    },
+)

--- a/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_refreshes_ready_allocation_env_when_context_changes.snap
+++ b/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_refreshes_ready_allocation_env_when_context_changes.snap
@@ -1,0 +1,34 @@
+---
+source: crates/daemon/tests/sql_foundation.rs
+expression: snapshot
+---
+(
+    [
+        RecordedSqlAdminOperation {
+            engine: Mysql,
+            database: "acme_test_app_db",
+            statement: "CREATE DATABASE IF NOT EXISTS `acme_test_app_db`",
+        },
+    ],
+    [
+        ResourceAllocationRecord {
+            id: "allocation_000001",
+            project_id: "<project_id>",
+            resource_name: "mysql",
+            track: "8.0",
+            allocation_name: "app-db",
+            generated_name: "acme_test_app_db",
+            env: {
+                "database": "acme_test_app_db",
+                "host": "127.0.0.1",
+                "password": "secret",
+                "port": "19002",
+                "url": "mysql://root:secret@127.0.0.1:19002/acme_test_app_db",
+                "username": "root",
+            },
+            status: Ready,
+            created_at: "<timestamp>",
+            updated_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_rejects_unsafe_database_identifier_before_connecting.snap
+++ b/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_rejects_unsafe_database_identifier_before_connecting.snap
@@ -1,0 +1,5 @@
+---
+source: crates/daemon/tests/sql_foundation.rs
+expression: snapshot
+---
+"Err(\n    InvalidSqlIdentifier {\n        identifier: \"bad-name\",\n    },\n)"

--- a/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_verifies_already_ready_allocation_without_rewriting_state.snap
+++ b/crates/daemon/tests/snapshots/sql_foundation__sql_foundation_verifies_already_ready_allocation_without_rewriting_state.snap
@@ -1,0 +1,34 @@
+---
+source: crates/daemon/tests/sql_foundation.rs
+expression: snapshot
+---
+(
+    [
+        RecordedSqlAdminOperation {
+            engine: Mysql,
+            database: "acme_test_app_db",
+            statement: "CREATE DATABASE IF NOT EXISTS `acme_test_app_db`",
+        },
+    ],
+    [
+        ResourceAllocationRecord {
+            id: "allocation_000001",
+            project_id: "<project_id>",
+            resource_name: "mysql",
+            track: "8.0",
+            allocation_name: "app-db",
+            generated_name: "acme_test_app_db",
+            env: {
+                "database": "acme_test_app_db",
+                "host": "127.0.0.1",
+                "password": "secret",
+                "port": "3306",
+                "url": "mysql://root:secret@127.0.0.1:3306/acme_test_app_db",
+                "username": "root",
+            },
+            status: Ready,
+            created_at: "<timestamp>",
+            updated_at: "<timestamp>",
+        },
+    ],
+)

--- a/crates/daemon/tests/sql_foundation.rs
+++ b/crates/daemon/tests/sql_foundation.rs
@@ -1,3 +1,6 @@
+use std::ffi::OsString;
+use std::sync::{Mutex, MutexGuard};
+
 use anyhow::{Result, anyhow};
 use camino::Utf8Path;
 use camino_tempfile::tempdir;
@@ -15,8 +18,10 @@ mod sql;
 
 use sql::{
     RecordingSqlAdmin, SqlAdminContext, SqlAllocationContext, SqlAllocationRequest, SqlEngine,
-    ensure_database_allocation_for_test, sql_allocation_env, sql_resource_env,
+    ensure_database_allocation_for_test, postgres_options, sql_allocation_env, sql_resource_env,
 };
+
+static PG_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 #[tokio::test]
 async fn sql_foundation_creates_database_and_marks_allocation_ready() -> Result<()> {
@@ -188,6 +193,107 @@ async fn sql_foundation_verifies_already_ready_allocation_without_rewriting_stat
 }
 
 #[tokio::test]
+async fn sql_foundation_refreshes_ready_allocation_env_when_context_changes() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mysql:
+  version: "8.0"
+  allocations:
+    app-db: {}
+"#,
+    )?;
+    seed_desired_sql_allocation(
+        &paths,
+        &project,
+        "mysql",
+        "8.0",
+        "app-db",
+        "acme_test_app_db",
+    )?;
+    let mut database = Database::open(&paths)?;
+    let old_context = SqlAdminContext {
+        port: 19_001,
+        ..sql_admin_context()
+    };
+    let new_context = SqlAdminContext {
+        port: 19_002,
+        ..sql_admin_context()
+    };
+    database.mark_resource_allocation_ready(
+        &project.id,
+        "mysql",
+        "8.0",
+        "app-db",
+        &sql_allocation_env(
+            &allocation_context(&old_context, "acme_test_app_db"),
+            SqlEngine::Mysql,
+        ),
+    )?;
+    let mut admin = RecordingSqlAdmin::default();
+
+    ensure_database_allocation_for_test(
+        &mut database,
+        &mut admin,
+        SqlAllocationRequest {
+            project_id: &project.id,
+            resource_name: "mysql",
+            track: "8.0",
+            allocation_name: "app-db",
+            engine: SqlEngine::Mysql,
+            context: &new_context,
+        },
+    )
+    .await?;
+
+    let allocations = database.resource_allocations(&project.id, "mysql")?;
+    let expected_env = sql_allocation_env(
+        &allocation_context(&new_context, "acme_test_app_db"),
+        SqlEngine::Mysql,
+    );
+    assert_eq!(
+        allocations[0].env, expected_env,
+        "expected Ready allocation env to refresh after SQL runtime context changed"
+    );
+    assert_sql_snapshot(
+        "sql_foundation_refreshes_ready_allocation_env_when_context_changes",
+        (admin.operations(), allocations),
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn sql_foundation_postgres_admin_options_ignore_ambient_ssl_env() -> Result<()> {
+    let _env = ScopedPgEnv::with([
+        ("PGSSLMODE", "require"),
+        ("PGSSLROOTCERT", "/tmp/hostile-root.pem"),
+        ("PGSSLCERT", "/tmp/hostile-client.pem"),
+        ("PGSSLKEY", "/tmp/hostile-client.key"),
+        ("PGAPPNAME", "hostile-app"),
+    ]);
+    let context = postgres_admin_context();
+
+    let options = postgres_options(&context);
+
+    assert_eq!(
+        format!("{:?}", options.get_ssl_mode()),
+        "Disable",
+        "expected PV Postgres admin options to force local non-TLS connections"
+    );
+    assert_eq!(
+        options.get_application_name(),
+        Some("pv"),
+        "expected PV Postgres admin options to use a PV-owned application name"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn sql_foundation_rejects_unsafe_database_identifier_before_connecting() -> Result<()> {
     let result =
         sql::create_database_if_missing(&sql_admin_context(), SqlEngine::Mysql, "bad-name").await;
@@ -301,6 +407,88 @@ fn allocation_context(context: &SqlAdminContext, database: &str) -> SqlAllocatio
         port: context.port,
         username: context.username.clone(),
         password: context.password.clone(),
+    }
+}
+
+struct ScopedPgEnv {
+    _guard: MutexGuard<'static, ()>,
+    saved: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl ScopedPgEnv {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "SQL foundation regression tests explicitly control PG* env inputs"
+    )]
+    fn with<const N: usize>(vars: [(&'static str, &'static str); N]) -> Self {
+        let guard = pg_env_guard();
+        let keys = [
+            "PGSSLMODE",
+            "PGSSLROOTCERT",
+            "PGSSLCERT",
+            "PGSSLKEY",
+            "PGAPPNAME",
+        ];
+        let saved = keys
+            .into_iter()
+            .map(|key| (key, std::env::var_os(key)))
+            .collect::<Vec<_>>();
+
+        for key in keys {
+            // SAFETY: This test helper serializes all PG* environment mutations in this
+            // test binary with PG_ENV_LOCK and restores the previous values before the
+            // guard is released.
+            unsafe {
+                std::env::remove_var(key);
+            }
+        }
+        for (key, value) in vars {
+            // SAFETY: This test helper serializes all PG* environment mutations in this
+            // test binary with PG_ENV_LOCK and restores the previous values before the
+            // guard is released.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+        }
+
+        Self {
+            _guard: guard,
+            saved,
+        }
+    }
+}
+
+impl Drop for ScopedPgEnv {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "SQL foundation regression tests explicitly restore PG* env inputs"
+    )]
+    fn drop(&mut self) {
+        for (key, value) in &self.saved {
+            match value {
+                Some(value) => {
+                    // SAFETY: ScopedPgEnv holds PG_ENV_LOCK while restoring the values
+                    // that were saved before this test's PG* environment mutation.
+                    unsafe {
+                        std::env::set_var(key, value);
+                    }
+                }
+                None => {
+                    // SAFETY: ScopedPgEnv holds PG_ENV_LOCK while restoring the values
+                    // that were saved before this test's PG* environment mutation.
+                    unsafe {
+                        std::env::remove_var(key);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn pg_env_guard() -> MutexGuard<'static, ()> {
+    match PG_ENV_LOCK.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
     }
 }
 

--- a/crates/daemon/tests/sql_foundation.rs
+++ b/crates/daemon/tests/sql_foundation.rs
@@ -1,0 +1,321 @@
+use anyhow::{Result, anyhow};
+use camino::Utf8Path;
+use camino_tempfile::tempdir;
+use insta::{Settings, assert_debug_snapshot};
+use state::{
+    Database, LinkProjectInput, ProjectManagedResourceInput, ProjectRecord, PvPaths,
+    ResourceAllocationInput,
+};
+
+use daemon::DaemonError;
+
+// The SQL module is daemon-local; include it here so tests do not make it public.
+#[path = "../src/managed_resources/sql.rs"]
+mod sql;
+
+use sql::{
+    RecordingSqlAdmin, SqlAdminContext, SqlAllocationContext, SqlAllocationRequest, SqlEngine,
+    ensure_database_allocation_for_test, sql_allocation_env, sql_resource_env,
+};
+
+#[tokio::test]
+async fn sql_foundation_creates_database_and_marks_allocation_ready() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mysql:
+  version: "8.0"
+  allocations:
+    app-db: {}
+"#,
+    )?;
+    seed_desired_sql_allocation(
+        &paths,
+        &project,
+        "mysql",
+        "8.0",
+        "app-db",
+        "acme_test_app_db",
+    )?;
+    let mut database = Database::open(&paths)?;
+    let mut admin = RecordingSqlAdmin::default();
+    let context = sql_admin_context();
+
+    ensure_database_allocation_for_test(
+        &mut database,
+        &mut admin,
+        SqlAllocationRequest {
+            project_id: &project.id,
+            resource_name: "mysql",
+            track: "8.0",
+            allocation_name: "app-db",
+            engine: SqlEngine::Mysql,
+            context: &context,
+        },
+    )
+    .await?;
+
+    assert_sql_snapshot(
+        "sql_foundation_creates_database_and_marks_allocation_ready",
+        (
+            sql_resource_env(&context, SqlEngine::Mysql),
+            admin.operations(),
+            database.resource_allocations(&project.id, "mysql")?,
+        ),
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sql_foundation_creates_postgres_database_and_marks_allocation_ready() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "api.acme.test",
+        r#"postgres:
+  version: "16"
+  allocations:
+    analytics: {}
+"#,
+    )?;
+    seed_desired_sql_allocation(
+        &paths,
+        &project,
+        "postgres",
+        "16",
+        "analytics",
+        "api_acme_test_analytics",
+    )?;
+    let mut database = Database::open(&paths)?;
+    let mut admin = RecordingSqlAdmin::default();
+    let context = postgres_admin_context();
+
+    ensure_database_allocation_for_test(
+        &mut database,
+        &mut admin,
+        SqlAllocationRequest {
+            project_id: &project.id,
+            resource_name: "postgres",
+            track: "16",
+            allocation_name: "analytics",
+            engine: SqlEngine::Postgres,
+            context: &context,
+        },
+    )
+    .await?;
+
+    assert_sql_snapshot(
+        "sql_foundation_creates_postgres_database_and_marks_allocation_ready",
+        (
+            sql_resource_env(&context, SqlEngine::Postgres),
+            admin.operations(),
+            database.resource_allocations(&project.id, "postgres")?,
+        ),
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sql_foundation_verifies_already_ready_allocation_without_rewriting_state() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"mysql:
+  version: "8.0"
+  allocations:
+    app-db: {}
+"#,
+    )?;
+    seed_desired_sql_allocation(
+        &paths,
+        &project,
+        "mysql",
+        "8.0",
+        "app-db",
+        "acme_test_app_db",
+    )?;
+    let mut database = Database::open(&paths)?;
+    let context = sql_admin_context();
+    database.mark_resource_allocation_ready(
+        &project.id,
+        "mysql",
+        "8.0",
+        "app-db",
+        &sql_allocation_env(
+            &allocation_context(&context, "acme_test_app_db"),
+            SqlEngine::Mysql,
+        ),
+    )?;
+    let before = database.resource_allocations(&project.id, "mysql")?;
+    let mut admin = RecordingSqlAdmin::default();
+
+    ensure_database_allocation_for_test(
+        &mut database,
+        &mut admin,
+        SqlAllocationRequest {
+            project_id: &project.id,
+            resource_name: "mysql",
+            track: "8.0",
+            allocation_name: "app-db",
+            engine: SqlEngine::Mysql,
+            context: &context,
+        },
+    )
+    .await?;
+
+    let after = database.resource_allocations(&project.id, "mysql")?;
+    if before != after {
+        return Err(anyhow!(
+            "ready allocation state changed: before={before:#?} after={after:#?}"
+        ));
+    }
+    assert_sql_snapshot(
+        "sql_foundation_verifies_already_ready_allocation_without_rewriting_state",
+        (admin.operations(), after),
+    )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sql_foundation_rejects_unsafe_database_identifier_before_connecting() -> Result<()> {
+    let result =
+        sql::create_database_if_missing(&sql_admin_context(), SqlEngine::Mysql, "bad-name").await;
+
+    assert_sql_snapshot(
+        "sql_foundation_rejects_unsafe_database_identifier_before_connecting",
+        format!("{result:#?}"),
+    )?;
+
+    Ok(())
+}
+
+#[test]
+fn sql_foundation_percent_encodes_url_userinfo() -> Result<()> {
+    let context = SqlAdminContext {
+        host: "127.0.0.1".to_string(),
+        port: 15432,
+        username: "admin@local:dev/%#".to_string(),
+        password: "pa:ss/wo@rd%#".to_string(),
+    };
+    let allocation = allocation_context(&context, "acme_test_app_db");
+
+    assert_sql_snapshot(
+        "sql_foundation_percent_encodes_url_userinfo",
+        (
+            sql_resource_env(&context, SqlEngine::Mysql),
+            sql_allocation_env(&allocation, SqlEngine::Mysql),
+            sql_resource_env(&context, SqlEngine::Postgres),
+            sql_allocation_env(&allocation, SqlEngine::Postgres),
+        ),
+    )?;
+
+    Ok(())
+}
+
+fn link_project(
+    paths: &PvPaths,
+    project_path: &Utf8Path,
+    primary_hostname: &str,
+    config_source: &str,
+) -> Result<ProjectRecord> {
+    let config_path = project_path.join("pv.yml");
+
+    state::fs::write_sensitive_file(&config_path, config_source)?;
+
+    let mut database = Database::open(paths)?;
+    let result = database.link_project(LinkProjectInput {
+        path: project_path.to_path_buf(),
+        original_path: project_path.to_path_buf(),
+        primary_hostname: primary_hostname.to_string(),
+        config_path,
+        desired_php_track: None,
+        additional_hostnames: Vec::new(),
+    })?;
+
+    Ok(result.project)
+}
+
+fn seed_desired_sql_allocation(
+    paths: &PvPaths,
+    project: &ProjectRecord,
+    resource_name: &str,
+    track: &str,
+    allocation_name: &str,
+    generated_name: &str,
+) -> Result<()> {
+    let mut database = Database::open(paths)?;
+
+    database.replace_project_managed_resources(
+        &project.id,
+        &[ProjectManagedResourceInput {
+            resource_name: resource_name.to_string(),
+            track: track.to_string(),
+        }],
+    )?;
+    database.replace_project_resource_allocations(
+        &project.id,
+        resource_name,
+        track,
+        &[ResourceAllocationInput {
+            allocation_name: allocation_name.to_string(),
+            generated_name: generated_name.to_string(),
+        }],
+    )?;
+
+    Ok(())
+}
+
+fn sql_admin_context() -> SqlAdminContext {
+    SqlAdminContext {
+        host: "127.0.0.1".to_string(),
+        port: 3306,
+        username: "root".to_string(),
+        password: "secret".to_string(),
+    }
+}
+
+fn postgres_admin_context() -> SqlAdminContext {
+    SqlAdminContext {
+        host: "127.0.0.1".to_string(),
+        port: 5432,
+        username: "postgres".to_string(),
+        password: "pg-secret".to_string(),
+    }
+}
+
+fn allocation_context(context: &SqlAdminContext, database: &str) -> SqlAllocationContext {
+    SqlAllocationContext {
+        database: database.to_string(),
+        host: context.host.clone(),
+        port: context.port,
+        username: context.username.clone(),
+        password: context.password.clone(),
+    }
+}
+
+fn assert_sql_snapshot(name: &'static str, snapshot: impl std::fmt::Debug) -> Result<()> {
+    let mut settings = Settings::clone_current();
+
+    settings.add_filter(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", "<timestamp>");
+    settings.add_filter(
+        r#"project_id: "[a-z0-9]{10}""#,
+        r#"project_id: "<project_id>""#,
+    );
+    settings.bind(|| {
+        assert_debug_snapshot!(name, snapshot);
+        Ok::<(), anyhow::Error>(())
+    })?;
+
+    Ok(())
+}

--- a/crates/state/src/database.rs
+++ b/crates/state/src/database.rs
@@ -1272,6 +1272,59 @@ impl Database {
         resource_allocation_by_key(&self.connection, project_id, resource_name, allocation_name)
     }
 
+    pub fn record_resource_allocation_env_context(
+        &mut self,
+        project_id: &str,
+        resource_name: &str,
+        track: &str,
+        allocation_name: &str,
+        env: &EnvContextValues,
+    ) -> Result<ResourceAllocationRecord, StateError> {
+        validate_resource_allocation_identity("resource", resource_name)?;
+        validate_concrete_track(track)?;
+        validate_resource_allocation_name(allocation_name)?;
+        let context = format!(
+            "resource allocation {project_id:?}/{resource_name:?}/{track:?}/{allocation_name:?}"
+        );
+        let env_json = serialize_env_context(&context, env)?;
+        let updated_at = timestamp()?;
+        let updated = self.connection.execute(
+            "UPDATE resource_allocations
+            SET env_json = ?1,
+                updated_at = ?2
+            WHERE project_id = ?3
+            AND resource_name = ?4
+            AND track = ?5
+            AND allocation_name = ?6
+            AND status = ?7",
+            params![
+                env_json,
+                updated_at,
+                project_id,
+                resource_name,
+                track,
+                allocation_name,
+                ResourceAllocationStatus::Ready.as_str(),
+            ],
+        )?;
+        if updated == 0 {
+            resource_allocation_by_key(
+                &self.connection,
+                project_id,
+                resource_name,
+                allocation_name,
+            )?;
+            return Err(StateError::ResourceAllocationNotDesired {
+                project_id: project_id.to_string(),
+                resource: resource_name.to_string(),
+                track: track.to_string(),
+                allocation: allocation_name.to_string(),
+            });
+        }
+
+        resource_allocation_by_key(&self.connection, project_id, resource_name, allocation_name)
+    }
+
     pub fn resource_allocations(
         &self,
         project_id: &str,


### PR DESCRIPTION
## Summary
- Add the shared SQL helper layer used by MySQL and Postgres adapters.
- Add sqlx workspace dependency with MySQL/Postgres runtime support and dynamic-query helper behavior.
- Cover shared readiness, URL/env generation, and database allocation behavior without landing concrete SQL adapters.

## Stack
Base: pr-16-20-runtime-foundation

## Test Plan
- cargo nextest run -p daemon --locked sql_foundation
- cargo fmt --all -- --check
- cargo clippy -p daemon --all-targets --locked -- -D warnings
- git diff --check