### PR TITLE
feat(resources): centralize artifact manifest endpoint

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -598,6 +598,14 @@ PV discovers available Managed Resource artifacts through a PV-owned remote arti
 
 The Managed Resource artifact manifest points only to PV-owned packaged artifacts, not raw upstream archives or local build recipes. PV never builds Managed Resource binaries on the user's machine during setup, install, update, or reconciliation.
 
+The Managed Resource artifact manifest endpoint is a property of the built PV binary in v1. Production/default builds use PV's stable/default artifact manifest endpoint. Maintainer staging builds may override that compiled default by setting `PV_DEFAULT_ARTIFACT_MANIFEST_URL` at build time, for example:
+
+```sh
+PV_DEFAULT_ARTIFACT_MANIFEST_URL=https://artifacts-staging.pv.prvious.dev/manifest.json cargo build --release
+```
+
+PV v1 does not expose runtime/user-facing artifact manifest selection through CLI flags such as `--channel` or `--manifest-url`, config files, shell environment variables, LaunchAgent environment variables, shell profile edits, installer channel parameters, or database state. Runtime/user-facing manifest selection could redirect PV to an unintended artifact manifest and could cause the CLI and daemon to disagree about which manifest owns Managed Resource artifacts. Tests may still inject manifest URLs through test-only seams.
+
 The PV artifact release pipeline may either wrap suitable upstream binaries or build missing binaries from source, but it always produces a normalized PV artifact archive before publishing. For example, if Redis does not publish the macOS binary shape PV needs, the release pipeline builds Redis ahead of time and publishes the resulting PV-owned Redis artifact. The release pipeline is expected to run in hosted automation such as GitHub Actions, not on user machines.
 
 Artifact recipes prefer wrapping official upstream binaries when those binaries pass PV's archive validation and smoke-test requirements. Recipes build from source when upstream binaries are unavailable, do not match PV's required build matrix, cannot be packaged to run from PV's installed resource layout, or fail PV's smoke tests.

--- a/crates/cli/src/commands/artifact_resource.rs
+++ b/crates/cli/src/commands/artifact_resource.rs
@@ -13,11 +13,10 @@ use serde::Serialize;
 use state::{PortAssignment, PortOwner, PvPaths, RuntimeObservedStatus, StateError};
 
 use crate::args::ListArgs;
-use crate::environment::Environment;
+use crate::environment::{Environment, artifact_manifest_url};
 use crate::error::ExecuteError;
 use crate::output::{Output, OutputMode};
 
-const DEFAULT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json";
 const RECONCILE_KIND: &str = "reconcile";
 const SYSTEM_SCOPE: &str = "system";
 
@@ -374,9 +373,7 @@ fn pv_paths(environment: &impl Environment) -> Result<PvPaths, ExecuteError> {
 fn resource_commands(paths: &PvPaths, environment: &impl Environment) -> ManagedResourceCommands {
     ManagedResourceCommands::new(
         paths.clone(),
-        environment
-            .artifact_manifest_url()
-            .unwrap_or_else(|| DEFAULT_MANIFEST_URL.to_string()),
+        artifact_manifest_url(environment),
         target_platform(environment),
     )
 }

--- a/crates/cli/src/commands/composer.rs
+++ b/crates/cli/src/commands/composer.rs
@@ -12,11 +12,10 @@ use resources::{
 use state::{Database, ManagedResourceDesiredState, PvPaths, StateError};
 
 use crate::args::{ComposerUninstallArgs, ShimArgs};
-use crate::environment::Environment;
+use crate::environment::{Environment, artifact_manifest_url};
 use crate::error::{CliError, ExecuteError};
 use crate::output::{Output, OutputMode};
 
-const DEFAULT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json";
 const COMPOSER_TRACK: &str = "2";
 const RECONCILE_KIND: &str = "reconcile";
 const SYSTEM_SCOPE: &str = "system";
@@ -199,9 +198,7 @@ fn join_paths(entries: Vec<PathBuf>) -> Result<OsString, ExecuteError> {
 fn resource_commands(paths: &PvPaths, environment: &impl Environment) -> ManagedResourceCommands {
     ManagedResourceCommands::new(
         paths.clone(),
-        environment
-            .artifact_manifest_url()
-            .unwrap_or_else(|| DEFAULT_MANIFEST_URL.to_string()),
+        artifact_manifest_url(environment),
         target_platform(environment),
     )
 }

--- a/crates/cli/src/commands/php.rs
+++ b/crates/cli/src/commands/php.rs
@@ -14,11 +14,10 @@ use serde::Serialize;
 use state::{Database, ManagedResourceDesiredState, ProjectRecord, PvPaths, StateError};
 
 use crate::args::{ListArgs, PhpInstallArgs, PhpUninstallArgs, PhpUseArgs, ShimArgs};
-use crate::environment::Environment;
+use crate::environment::{Environment, artifact_manifest_url};
 use crate::error::{CliError, ExecuteError};
 use crate::output::{Output, OutputMode};
 
-const DEFAULT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json";
 const RECONCILE_KIND: &str = "reconcile";
 const SYSTEM_SCOPE: &str = "system";
 
@@ -407,9 +406,7 @@ fn resolve_current_project(
 fn resource_commands(paths: &PvPaths, environment: &impl Environment) -> ManagedResourceCommands {
     ManagedResourceCommands::new(
         paths.clone(),
-        environment
-            .artifact_manifest_url()
-            .unwrap_or_else(|| DEFAULT_MANIFEST_URL.to_string()),
+        artifact_manifest_url(environment),
         target_platform(environment),
     )
 }

--- a/crates/cli/src/environment.rs
+++ b/crates/cli/src/environment.rs
@@ -156,6 +156,12 @@ pub trait Environment {
     }
 }
 
+pub(crate) fn artifact_manifest_url(environment: &impl Environment) -> String {
+    environment
+        .artifact_manifest_url()
+        .unwrap_or_else(|| resources::default_artifact_manifest_url().to_string())
+}
+
 #[derive(Debug, Default)]
 pub struct ProcessEnvironment;
 
@@ -231,4 +237,97 @@ fn process_current_dir() -> io::Result<PathBuf> {
 )]
 fn process_current_exe() -> io::Result<PathBuf> {
     std::env::current_exe()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct TestEnvironment {
+        manifest_url: Option<String>,
+        vars: BTreeMap<String, OsString>,
+    }
+
+    impl TestEnvironment {
+        fn with_manifest_url(mut self, manifest_url: &str) -> Self {
+            self.manifest_url = Some(manifest_url.to_string());
+            self
+        }
+
+        fn with_var(mut self, key: &str, value: &str) -> Self {
+            self.vars.insert(key.to_string(), OsString::from(value));
+            self
+        }
+    }
+
+    impl Environment for TestEnvironment {
+        fn var_os(&self, key: &str) -> Option<OsString> {
+            self.vars.get(key).cloned()
+        }
+
+        fn home_dir(&self) -> Option<PathBuf> {
+            None
+        }
+
+        fn current_dir(&self) -> io::Result<PathBuf> {
+            Ok(PathBuf::new())
+        }
+
+        fn current_exe(&self) -> io::Result<PathBuf> {
+            Ok(PathBuf::new())
+        }
+
+        fn stdin_is_terminal(&self) -> bool {
+            false
+        }
+
+        fn read_line(&self) -> io::Result<String> {
+            Ok(String::new())
+        }
+
+        fn open_url(&self, _url: &str) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn artifact_manifest_url(&self) -> Option<String> {
+            self.manifest_url.clone()
+        }
+    }
+
+    #[test]
+    fn artifact_manifest_url_uses_compiled_default_without_test_override() {
+        let environment = TestEnvironment::default();
+
+        assert_eq!(
+            artifact_manifest_url(&environment),
+            resources::default_artifact_manifest_url()
+        );
+    }
+
+    #[test]
+    fn artifact_manifest_url_preserves_test_injection() {
+        let environment = TestEnvironment::default()
+            .with_manifest_url("https://fixtures.example.test/manifest.json");
+
+        assert_eq!(
+            artifact_manifest_url(&environment),
+            "https://fixtures.example.test/manifest.json"
+        );
+    }
+
+    #[test]
+    fn artifact_manifest_url_ignores_runtime_environment_variables() {
+        let environment = TestEnvironment::default().with_var(
+            resources::ARTIFACT_MANIFEST_URL_BUILD_ENV,
+            "https://runtime.example.test/manifest.json",
+        );
+
+        assert_eq!(
+            artifact_manifest_url(&environment),
+            resources::default_artifact_manifest_url()
+        );
+    }
 }

--- a/crates/daemon/src/managed_resources/mod.rs
+++ b/crates/daemon/src/managed_resources/mod.rs
@@ -29,7 +29,6 @@ use tokio::time::{sleep, timeout};
 
 use crate::{DaemonError, ProcessSpec, ProcessSupervisor, ReadinessCheck, wait_for_readiness};
 
-const DEFAULT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json";
 const RESOURCE_HOST: &str = "127.0.0.1";
 const RESOURCE_READINESS_TIMEOUT: Duration = Duration::from_secs(15);
 const ASYNC_READINESS_POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -168,7 +167,7 @@ impl ManagedResourceRuntimeCatalog {
         Self {
             adapters,
             install_options: ManagedResourceInstallOptions {
-                manifest_url: DEFAULT_MANIFEST_URL.to_string(),
+                manifest_url: resources::default_artifact_manifest_url().to_string(),
                 target_platform: current_target_platform(),
             },
         }
@@ -178,7 +177,7 @@ impl ManagedResourceRuntimeCatalog {
         Self {
             adapters: BTreeMap::new(),
             install_options: ManagedResourceInstallOptions {
-                manifest_url: DEFAULT_MANIFEST_URL.to_string(),
+                manifest_url: resources::default_artifact_manifest_url().to_string(),
                 target_platform: current_target_platform(),
             },
         }

--- a/crates/daemon/src/managed_resources/mysql_tests.rs
+++ b/crates/daemon/src/managed_resources/mysql_tests.rs
@@ -82,7 +82,7 @@ async fn mysql_reconciliation_creates_database_allocation_and_renders_env() -> R
     let project = link_project_with_mysql_database_env(&paths, &tempdir.path().join("project"))?;
     let admin = super::mysql::RecordingMysqlAdmin::default();
     let catalog = super::mysql::mysql_runtime_catalog_with_recording_admin(
-        super::DEFAULT_MANIFEST_URL,
+        resources::default_artifact_manifest_url(),
         admin.clone(),
     )?;
     seed_mysql_fixture_artifact(&paths, MYSQL_TRACK)?;
@@ -158,7 +158,7 @@ async fn mysql_reconciliation_reuses_admin_env_and_ready_allocation() -> Result<
     let project = link_project_with_mysql_database_env(&paths, &tempdir.path().join("project"))?;
     let admin = super::mysql::RecordingMysqlAdmin::default();
     let catalog = super::mysql::mysql_runtime_catalog_with_recording_admin(
-        super::DEFAULT_MANIFEST_URL,
+        resources::default_artifact_manifest_url(),
         admin,
     )?;
     seed_mysql_fixture_artifact(&paths, MYSQL_TRACK)?;

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -52,6 +52,26 @@ const INVALID_DEFAULT_PORT_SPECS: &[super::ManagedResourcePortSpec] = &[
     },
 ];
 
+#[test]
+fn production_catalog_uses_compiled_artifact_manifest_endpoint() {
+    let catalog = super::ManagedResourceRuntimeCatalog::production();
+
+    assert_eq!(
+        catalog.install_options.manifest_url,
+        resources::default_artifact_manifest_url()
+    );
+}
+
+#[test]
+fn without_adapters_catalog_uses_compiled_artifact_manifest_endpoint() {
+    let catalog = super::ManagedResourceRuntimeCatalog::without_adapters();
+
+    assert_eq!(
+        catalog.install_options.manifest_url,
+        resources::default_artifact_manifest_url()
+    );
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct RuntimeFilePresence {
     pid: bool,
@@ -718,7 +738,7 @@ async fn system_resource_reconciliation_stops_unlinked_project_runtime() -> Resu
     let cleanup_snapshot = {
         let mut database = Database::open(&paths)?;
         database.unlink_project(&project.id)?;
-        let catalog = super::fake_runtime_catalog(super::DEFAULT_MANIFEST_URL)?;
+        let catalog = super::fake_runtime_catalog(resources::default_artifact_manifest_url())?;
 
         super::reconcile_system_resources_with_catalog(&paths, &mut database, &catalog).await?;
 
@@ -1672,7 +1692,7 @@ async fn demanded_resource_uses_async_readiness_and_allocation_hooks() -> Result
     let hook_events = Arc::new(Mutex::new(Vec::new()));
     let catalog = super::ManagedResourceRuntimeCatalog::with_adapter(
         super::ManagedResourceInstallOptions {
-            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            manifest_url: resources::default_artifact_manifest_url().to_string(),
             target_platform: super::current_target_platform(),
         },
         AsyncSqlHookRuntimeAdapter::new(Arc::clone(&hook_events))?,
@@ -1736,7 +1756,7 @@ async fn demanded_resource_persists_env_before_runtime_side_effects() -> Result<
     let hook_events = Arc::new(Mutex::new(Vec::new()));
     let catalog = super::ManagedResourceRuntimeCatalog::with_adapter(
         super::ManagedResourceInstallOptions {
-            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            manifest_url: resources::default_artifact_manifest_url().to_string(),
             target_platform: super::current_target_platform(),
         },
         AsyncSqlHookRuntimeAdapter::new(Arc::clone(&hook_events))?,
@@ -1783,7 +1803,7 @@ async fn async_readiness_reassigns_unowned_persisted_port_before_resource_readin
     let hook_events = Arc::new(Mutex::new(Vec::new()));
     let catalog = super::ManagedResourceRuntimeCatalog::with_adapter(
         super::ManagedResourceInstallOptions {
-            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            manifest_url: resources::default_artifact_manifest_url().to_string(),
             target_platform: super::current_target_platform(),
         },
         AsyncSqlHookRuntimeAdapter::new(Arc::clone(&hook_events))?,
@@ -2082,7 +2102,7 @@ async fn reconcile_project_env_with_fake_runtime_catalog(
     reconcile_project_env_with_fake_runtime_catalog_and_manifest_url(
         paths,
         project_id,
-        super::DEFAULT_MANIFEST_URL,
+        resources::default_artifact_manifest_url(),
     )
     .await
 }
@@ -2132,7 +2152,7 @@ async fn reconcile_project_env_with_rustfs_runtime_catalog(
     reconcile_project_env_with_rustfs_runtime_catalog_and_manifest_url(
         paths,
         project_id,
-        super::DEFAULT_MANIFEST_URL,
+        resources::default_artifact_manifest_url(),
     )
     .await
 }
@@ -2160,7 +2180,7 @@ async fn reconcile_project_env_with_unready_fake_runtime_catalog(
     paths: &PvPaths,
     project_id: &str,
 ) -> Result<()> {
-    let catalog = super::fake_unready_runtime_catalog(super::DEFAULT_MANIFEST_URL)?;
+    let catalog = super::fake_unready_runtime_catalog(resources::default_artifact_manifest_url())?;
     let mut database = Database::open(paths)?;
 
     crate::project_env::reconcile_project_env_with_catalog(
@@ -2180,7 +2200,7 @@ async fn reconcile_project_env_with_fast_exit_fake_runtime_catalog(
 ) -> Result<()> {
     let catalog = super::ManagedResourceRuntimeCatalog::with_adapter(
         super::ManagedResourceInstallOptions {
-            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            manifest_url: resources::default_artifact_manifest_url().to_string(),
             target_platform: super::current_target_platform(),
         },
         super::fake::FakeMailpitRuntimeAdapter::exits_after_readiness()?,
@@ -2220,7 +2240,7 @@ async fn reconcile_project_env_with_postgres_runtime_catalog_and_manifest_url(
 fn invalid_default_port_runtime_catalog() -> Result<super::ManagedResourceRuntimeCatalog> {
     Ok(super::ManagedResourceRuntimeCatalog::with_adapter(
         super::ManagedResourceInstallOptions {
-            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            manifest_url: resources::default_artifact_manifest_url().to_string(),
             target_platform: super::current_target_platform(),
         },
         InvalidDefaultPortRuntimeAdapter {
@@ -2237,7 +2257,7 @@ async fn reconcile_project_env_with_unready_postgres_runtime_catalog(
     project_id: &str,
 ) -> Result<()> {
     let catalog = super::postgres_runtime_catalog_with_readiness_timeout(
-        super::DEFAULT_MANIFEST_URL,
+        resources::default_artifact_manifest_url(),
         Duration::from_millis(100),
     )?;
     let mut database = Database::open(paths)?;
@@ -2810,7 +2830,7 @@ fn empty_runtime_catalog() -> super::ManagedResourceRuntimeCatalog {
     super::ManagedResourceRuntimeCatalog {
         adapters: BTreeMap::new(),
         install_options: super::ManagedResourceInstallOptions {
-            manifest_url: super::DEFAULT_MANIFEST_URL.to_string(),
+            manifest_url: resources::default_artifact_manifest_url().to_string(),
             target_platform: super::current_target_platform(),
         },
     }

--- a/crates/resources/build.rs
+++ b/crates/resources/build.rs
@@ -1,0 +1,9 @@
+use std::io::Write;
+
+fn main() -> std::io::Result<()> {
+    let mut stdout = std::io::stdout().lock();
+    writeln!(
+        stdout,
+        "cargo:rerun-if-env-changed=PV_DEFAULT_ARTIFACT_MANIFEST_URL"
+    )
+}

--- a/crates/resources/src/endpoint.rs
+++ b/crates/resources/src/endpoint.rs
@@ -1,0 +1,27 @@
+pub const ARTIFACT_MANIFEST_URL_BUILD_ENV: &str = "PV_DEFAULT_ARTIFACT_MANIFEST_URL";
+pub const STABLE_ARTIFACT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json";
+
+pub fn default_artifact_manifest_url() -> &'static str {
+    option_env!("PV_DEFAULT_ARTIFACT_MANIFEST_URL").unwrap_or(STABLE_ARTIFACT_MANIFEST_URL)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_artifact_manifest_url_matches_compiled_value() {
+        let expected =
+            option_env!("PV_DEFAULT_ARTIFACT_MANIFEST_URL").unwrap_or(STABLE_ARTIFACT_MANIFEST_URL);
+
+        assert_eq!(default_artifact_manifest_url(), expected);
+    }
+
+    #[test]
+    fn stable_artifact_manifest_url_is_the_current_default_endpoint() {
+        assert_eq!(
+            STABLE_ARTIFACT_MANIFEST_URL,
+            "https://artifacts.prvious.test/manifest.json"
+        );
+    }
+}

--- a/crates/resources/src/lib.rs
+++ b/crates/resources/src/lib.rs
@@ -2,6 +2,7 @@ pub mod allocation;
 pub mod cache;
 pub mod command;
 pub mod download;
+pub mod endpoint;
 pub mod error;
 mod fs;
 pub mod http;
@@ -24,6 +25,9 @@ pub use command::{
     PhpPairRemovalIntent, PhpPairUpdate,
 };
 pub use download::{ArtifactDownload, ArtifactDownloader};
+pub use endpoint::{
+    ARTIFACT_MANIFEST_URL_BUILD_ENV, STABLE_ARTIFACT_MANIFEST_URL, default_artifact_manifest_url,
+};
 pub use error::{ResourcesError, Result};
 pub use http::{ResourceHttpClient, UreqResourceHttpClient};
 pub use identity::{

--- a/docs/superpowers/plans/2026-06-10-pr-22a-artifact-manifest-endpoint.md
+++ b/docs/superpowers/plans/2026-06-10-pr-22a-artifact-manifest-endpoint.md
@@ -1,0 +1,424 @@
+# PR 22A Artifact Manifest Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Centralize the Managed Resource artifact manifest endpoint so CLI and daemon production paths use the same compiled default, while staging builds can opt into the staging endpoint at build time.
+
+**Architecture:** Put the compiled default endpoint in the `resources` crate because both CLI and daemon already depend on it and the endpoint belongs to Managed Resource artifact discovery. Preserve CLI fake-environment URL injection and explicit daemon test-catalog injection, but remove duplicate production/default constants from CLI command modules and daemon catalog construction.
+
+**Tech Stack:** Rust 2024 workspace, Cargo build script rerun hints, `option_env!`, `cargo nextest`, `cargo insta`.
+
+---
+
+### Task 1: Design Contract
+
+**Files:**
+- Modify: `DESIGN.md`
+
+- [x] **Step 1: Add the compile-time endpoint policy**
+
+Insert this near the Managed Resource artifact manifest/distribution section:
+
+~~~markdown
+The Managed Resource artifact manifest endpoint is a property of the built PV binary in v1. Production/default builds use PV's stable/default artifact manifest endpoint. Maintainer staging builds may override that compiled default by setting `PV_DEFAULT_ARTIFACT_MANIFEST_URL` at build time, for example:
+
+```sh
+PV_DEFAULT_ARTIFACT_MANIFEST_URL=https://artifacts-staging.pv.prvious.dev/manifest.json cargo build --release
+```
+
+PV v1 does not expose runtime/user-facing artifact manifest selection through CLI flags such as `--channel` or `--manifest-url`, config files, shell environment variables, LaunchAgent environment variables, shell profile edits, installer channel parameters, or database state. Runtime/user-facing manifest selection could redirect PV to an unintended artifact manifest and could cause the CLI and daemon to disagree about which manifest owns Managed Resource artifacts. Tests may still inject manifest URLs through test-only seams.
+~~~
+
+- [x] **Step 2: Verify the design text**
+
+Run:
+
+```bash
+rg -n "PV_DEFAULT_ARTIFACT_MANIFEST_URL|--manifest-url|LaunchAgent environment variables" DESIGN.md
+```
+
+Expected: the new design text is present and no surrounding text promises runtime/user-facing channel selection.
+
+### Task 2: Shared Compiled Endpoint Helper
+
+**Files:**
+- Create: `crates/resources/build.rs`
+- Create: `crates/resources/src/endpoint.rs`
+- Modify: `crates/resources/src/lib.rs`
+
+- [x] **Step 1: Write the failing endpoint tests**
+
+Create `crates/resources/src/endpoint.rs` with tests that reference the helper before it exists:
+
+```rust
+pub const ARTIFACT_MANIFEST_URL_BUILD_ENV: &str = "PV_DEFAULT_ARTIFACT_MANIFEST_URL";
+pub const STABLE_ARTIFACT_MANIFEST_URL: &str = "https://artifacts.prvious.test/manifest.json";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_artifact_manifest_url_matches_compiled_value() {
+        let expected = option_env!("PV_DEFAULT_ARTIFACT_MANIFEST_URL")
+            .unwrap_or(STABLE_ARTIFACT_MANIFEST_URL);
+
+        assert_eq!(default_artifact_manifest_url(), expected);
+    }
+
+    #[test]
+    fn stable_artifact_manifest_url_is_the_current_default_endpoint() {
+        assert_eq!(
+            STABLE_ARTIFACT_MANIFEST_URL,
+            "https://artifacts.prvious.test/manifest.json"
+        );
+    }
+}
+```
+
+Expose the module in `crates/resources/src/lib.rs`:
+
+```rust
+pub mod endpoint;
+pub use endpoint::{
+    ARTIFACT_MANIFEST_URL_BUILD_ENV, STABLE_ARTIFACT_MANIFEST_URL,
+    default_artifact_manifest_url,
+};
+```
+
+- [x] **Step 2: Run the red test**
+
+Run:
+
+```bash
+cargo nextest run -p resources -E 'test(default_artifact_manifest_url_matches_compiled_value)' --all-features --locked
+```
+
+Expected: FAIL because `default_artifact_manifest_url` is not implemented.
+
+- [x] **Step 3: Implement the minimal helper**
+
+Add this function to `crates/resources/src/endpoint.rs`:
+
+```rust
+pub fn default_artifact_manifest_url() -> &'static str {
+    option_env!("PV_DEFAULT_ARTIFACT_MANIFEST_URL").unwrap_or(STABLE_ARTIFACT_MANIFEST_URL)
+}
+```
+
+Create `crates/resources/build.rs`:
+
+```rust
+fn main() {
+    println!("cargo:rerun-if-env-changed=PV_DEFAULT_ARTIFACT_MANIFEST_URL");
+}
+```
+
+- [x] **Step 4: Run the green tests**
+
+Run:
+
+```bash
+cargo nextest run -p resources -E 'test(default_artifact_manifest_url_matches_compiled_value) | test(stable_artifact_manifest_url_is_the_current_default_endpoint)' --all-features --locked
+```
+
+Expected: PASS.
+
+### Task 3: CLI Endpoint Construction
+
+**Files:**
+- Modify: `crates/cli/src/environment.rs`
+- Modify: `crates/cli/src/commands/artifact_resource.rs`
+- Modify: `crates/cli/src/commands/php.rs`
+- Modify: `crates/cli/src/commands/composer.rs`
+
+- [x] **Step 1: Write the failing CLI helper tests**
+
+Add a private CLI helper in `crates/cli/src/environment.rs` and tests that call it before implementation:
+
+```rust
+pub(crate) fn artifact_manifest_url(environment: &impl Environment) -> String {
+    environment
+        .artifact_manifest_url()
+        .unwrap_or_else(|| resources::default_artifact_manifest_url().to_string())
+}
+```
+
+Add tests in `crates/cli/src/environment.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct TestEnvironment {
+        manifest_url: Option<String>,
+        vars: BTreeMap<String, OsString>,
+    }
+
+    impl TestEnvironment {
+        fn with_manifest_url(mut self, manifest_url: &str) -> Self {
+            self.manifest_url = Some(manifest_url.to_string());
+            self
+        }
+
+        fn with_var(mut self, key: &str, value: &str) -> Self {
+            self.vars.insert(key.to_string(), OsString::from(value));
+            self
+        }
+    }
+
+    impl Environment for TestEnvironment {
+        fn var_os(&self, key: &str) -> Option<OsString> {
+            self.vars.get(key).cloned()
+        }
+
+        fn home_dir(&self) -> Option<PathBuf> {
+            None
+        }
+
+        fn current_dir(&self) -> io::Result<PathBuf> {
+            Ok(PathBuf::new())
+        }
+
+        fn current_exe(&self) -> io::Result<PathBuf> {
+            Ok(PathBuf::new())
+        }
+
+        fn stdin_is_terminal(&self) -> bool {
+            false
+        }
+
+        fn read_line(&self) -> io::Result<String> {
+            Ok(String::new())
+        }
+
+        fn open_url(&self, _url: &str) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn artifact_manifest_url(&self) -> Option<String> {
+            self.manifest_url.clone()
+        }
+    }
+
+    #[test]
+    fn artifact_manifest_url_uses_compiled_default_without_test_override() {
+        let environment = TestEnvironment::default();
+
+        assert_eq!(
+            artifact_manifest_url(&environment),
+            resources::default_artifact_manifest_url()
+        );
+    }
+
+    #[test]
+    fn artifact_manifest_url_preserves_test_injection() {
+        let environment =
+            TestEnvironment::default().with_manifest_url("https://fixtures.example.test/manifest.json");
+
+        assert_eq!(
+            artifact_manifest_url(&environment),
+            "https://fixtures.example.test/manifest.json"
+        );
+    }
+
+    #[test]
+    fn artifact_manifest_url_ignores_runtime_environment_variables() {
+        let environment = TestEnvironment::default().with_var(
+            resources::ARTIFACT_MANIFEST_URL_BUILD_ENV,
+            "https://runtime.example.test/manifest.json",
+        );
+
+        assert_eq!(
+            artifact_manifest_url(&environment),
+            resources::default_artifact_manifest_url()
+        );
+    }
+}
+```
+
+- [x] **Step 2: Run the red CLI tests**
+
+Run:
+
+```bash
+cargo nextest run -p cli -E 'test(artifact_manifest_url_)' --all-features --locked
+```
+
+Expected: FAIL until the helper exists and compiles.
+
+- [x] **Step 3: Wire CLI command construction**
+
+Remove local `DEFAULT_MANIFEST_URL` constants from:
+
+```text
+crates/cli/src/commands/artifact_resource.rs
+crates/cli/src/commands/php.rs
+crates/cli/src/commands/composer.rs
+```
+
+In each file, import the helper:
+
+```rust
+use crate::environment::{Environment, artifact_manifest_url};
+```
+
+Change each `resource_commands` function to:
+
+```rust
+fn resource_commands(paths: &PvPaths, environment: &impl Environment) -> ManagedResourceCommands {
+    ManagedResourceCommands::new(
+        paths.clone(),
+        artifact_manifest_url(environment),
+        target_platform(environment),
+    )
+}
+```
+
+- [x] **Step 4: Run the green CLI tests**
+
+Run:
+
+```bash
+cargo nextest run -p cli -E 'test(artifact_manifest_url_)' --all-features --locked
+```
+
+Expected: PASS.
+
+### Task 4: Daemon Catalog Defaults
+
+**Files:**
+- Modify: `crates/daemon/src/managed_resources/mod.rs`
+- Modify: `crates/daemon/src/managed_resources/tests.rs`
+- Modify: `crates/daemon/src/managed_resources/mysql_tests.rs`
+
+- [x] **Step 1: Write the failing daemon catalog tests**
+
+Add tests to `crates/daemon/src/managed_resources/tests.rs`:
+
+```rust
+#[test]
+fn production_catalog_uses_compiled_artifact_manifest_endpoint() {
+    let catalog = super::ManagedResourceRuntimeCatalog::production();
+
+    assert_eq!(
+        catalog.install_options.manifest_url,
+        resources::default_artifact_manifest_url()
+    );
+}
+
+#[test]
+fn without_adapters_catalog_uses_compiled_artifact_manifest_endpoint() {
+    let catalog = super::ManagedResourceRuntimeCatalog::without_adapters();
+
+    assert_eq!(
+        catalog.install_options.manifest_url,
+        resources::default_artifact_manifest_url()
+    );
+}
+```
+
+- [x] **Step 2: Run the red daemon tests**
+
+Run:
+
+```bash
+PV_DEFAULT_ARTIFACT_MANIFEST_URL=https://artifacts-staging.pv.prvious.dev/manifest.json cargo nextest run -p daemon -E 'test(catalog_uses_compiled_artifact_manifest_endpoint)' --all-features --locked
+```
+
+Expected: FAIL until the daemon catalog uses the shared compiled endpoint because the old daemon-local default still points at the stable endpoint.
+
+- [x] **Step 3: Wire daemon production defaults**
+
+Remove the daemon-local `DEFAULT_MANIFEST_URL` constant. In `ManagedResourceRuntimeCatalog::production()` and `ManagedResourceRuntimeCatalog::without_adapters()`, set:
+
+```rust
+manifest_url: resources::default_artifact_manifest_url().to_string(),
+```
+
+Replace test references to `super::DEFAULT_MANIFEST_URL` with:
+
+```rust
+resources::default_artifact_manifest_url()
+```
+
+Use `.to_string()` only where the field requires `String`.
+
+- [x] **Step 4: Run the green daemon tests**
+
+Run:
+
+```bash
+cargo nextest run -p daemon -E 'test(catalog_uses_compiled_artifact_manifest_endpoint)' --all-features --locked
+PV_DEFAULT_ARTIFACT_MANIFEST_URL=https://artifacts-staging.pv.prvious.dev/manifest.json cargo nextest run -p daemon -E 'test(catalog_uses_compiled_artifact_manifest_endpoint)' --all-features --locked
+```
+
+Expected: both commands PASS.
+
+### Task 5: Scope Guard And Verification
+
+**Files:**
+- Inspect: all changed files
+
+- [x] **Step 1: Confirm duplicate defaults are gone**
+
+Run:
+
+```bash
+rg -n "DEFAULT_MANIFEST_URL|PV_ARTIFACT_MANIFEST_URL|--manifest-url|--channel|EnvironmentVariables|artifact_manifest_url" crates/cli crates/daemon crates/resources crates/platform DESIGN.md docs/superpowers/plans/2026-06-10-pr-22a-artifact-manifest-endpoint.md
+```
+
+Expected: no duplicate production/default manifest constants, no runtime `PV_ARTIFACT_MANIFEST_URL`, no new CLI flags, and no LaunchAgent `EnvironmentVariables`.
+
+- [x] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+cargo nextest run -p resources -E 'test(default_artifact_manifest_url_matches_compiled_value) | test(stable_artifact_manifest_url_is_the_current_default_endpoint)' --all-features --locked
+cargo nextest run -p cli -E 'test(artifact_manifest_url_)' --all-features --locked
+cargo nextest run -p daemon -E 'test(catalog_uses_compiled_artifact_manifest_endpoint)' --all-features --locked
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run staging compile-time check**
+
+Run:
+
+```bash
+PV_DEFAULT_ARTIFACT_MANIFEST_URL=https://artifacts-staging.pv.prvious.dev/manifest.json cargo nextest run -p resources -E 'test(default_artifact_manifest_url_matches_compiled_value)' --all-features --locked
+```
+
+Expected: PASS after Cargo rebuilds the `resources` crate with the build-time value.
+
+- [x] **Step 4: Run repository quality gates**
+
+Run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo insta pending-snapshots --workspace
+git diff --check
+```
+
+Expected: PASS, with no pending snapshots.
+
+- [x] **Step 5: Commit, push, and open PR**
+
+Run:
+
+```bash
+git status --short
+git add DESIGN.md docs/superpowers/plans/2026-06-10-pr-22a-artifact-manifest-endpoint.md crates/resources/build.rs crates/resources/src/endpoint.rs crates/resources/src/lib.rs crates/cli/src/environment.rs crates/cli/src/commands/artifact_resource.rs crates/cli/src/commands/php.rs crates/cli/src/commands/composer.rs crates/daemon/src/managed_resources/mod.rs crates/daemon/src/managed_resources/tests.rs crates/daemon/src/managed_resources/mysql_tests.rs
+git commit -m "feat(resources): centralize artifact manifest endpoint"
+git push -u origin feat/pr22a-artifact-manifest-endpoint
+gh pr create --title "feat(resources): centralize artifact manifest endpoint" --body-file /tmp/pr22a-artifact-manifest-endpoint-pr.md
+```
+
+Expected: branch pushed and GitHub PR opened for review.


### PR DESCRIPTION
## Summary
- Record the v1 compile-time Managed Resource artifact manifest endpoint policy in DESIGN.md.
- Add a shared resources endpoint helper with build-time PV_DEFAULT_ARTIFACT_MANIFEST_URL support.
- Wire CLI and daemon Managed Resource paths to the shared compiled default while preserving test-only injection seams.

## Test Plan
- cargo build --locked
- cargo nextest run -p resources -E 'test(default_artifact_manifest_url_matches_compiled_value) | test(stable_artifact_manifest_url_is_the_current_default_endpoint)' --all-features --locked\n- cargo nextest run -p cli -E 'test(artifact_manifest_url_)' --all-features --locked\n- cargo nextest run -p daemon -E 'test(catalog_uses_compiled_artifact_manifest_endpoint)' --all-features --locked\n- PV_DEFAULT_ARTIFACT_MANIFEST_URL=https://artifacts-staging.pv.prvious.dev/manifest.json cargo nextest run -p resources -p daemon -E 'test(default_artifact_manifest_url_matches_compiled_value) | test(catalog_uses_compiled_artifact_manifest_endpoint)' --all-features --locked\n- cargo fmt --all -- --check\n- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings\n- cargo insta pending-snapshots --workspace\n- git diff --check\n- PV_DEFAULT_ARTIFACT_MANIFEST_URL=https://artifacts-staging.pv.prvious.dev/manifest.json cargo build --release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate artifact manifest endpoint defaults across multiple components into a unified mechanism with maintainer build-time override support.

* **Tests**
  * Added verification tests for endpoint configuration and compilation.

* **Documentation**
  * Added design documentation explaining the centralized artifact manifest endpoint system and configuration approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->