### PR TITLE
feat: add self-update foundations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,6 +3051,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-update"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "insta",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/protocol",
     "crates/pv-release",
     "crates/resources",
+    "crates/self-update",
     "crates/state",
 ]
 resolver = "3"
@@ -46,7 +47,7 @@ rcgen = { version = "0.14.8", features = ["x509-parser"] }
 redis = { version = "1.2.2", default-features = false, features = ["tokio-comp"] }
 rusqlite = { version = "0", features = ["bundled"] }
 rustls-pemfile = "2.2.0"
-rustix = { version = "1", features = ["process"] }
+rustix = { version = "1", features = ["fs", "process"] }
 security-framework = "3.7.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -426,9 +426,43 @@ Resource-specific update commands do not support `--check` in v1. Update preview
 
 PV application self-update metadata comes from a PV app update manifest that is separate from the Managed Resource artifact manifest. The app update manifest includes PV application version metadata, platform-specific download URLs, SHA-256 checksums, and compatibility fields needed by the self-updater.
 
+The v1 PV app update manifest is a single stable-channel release document. It does not contain multiple channels, preview metadata, nightly metadata, or Managed Resource artifact data. The minimal v1 JSON shape is:
+
+```json
+{
+  "schema_version": 1,
+  "channel": "stable",
+  "version": "0.2.0",
+  "minimum_pv_version": "0.1.0",
+  "published_at": "2026-06-11T12:00:00Z",
+  "assets": [
+    {
+      "platform": "darwin-arm64",
+      "url": "https://downloads.prvious.test/pv/0.2.0/pv-darwin-arm64",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 12345678
+    },
+    {
+      "platform": "darwin-amd64",
+      "url": "https://downloads.prvious.test/pv/0.2.0/pv-darwin-amd64",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "size": 12345678
+    }
+  ]
+}
+```
+
+`schema_version` must be `1`; newer schema versions fail as unsupported rather than being partially interpreted. `channel` must be exactly `stable`; runtime/user-facing channel selection is not part of v1. `version` and `minimum_pv_version` use PV's simple application version identity, `major.minor.patch` with no leading zero components. `minimum_pv_version` is the minimum currently installed PV application version that may apply this release; if the running PV binary is older than that value, self-update manifest parsing fails clearly and tells the user that a newer PV parser is required.
+
+`published_at` must be an RFC 3339 timestamp for the PV application release. Each entry in `assets` describes one native PV application binary for one exact supported target platform. V1 app update assets support `darwin-arm64` and `darwin-amd64`; `any` is not valid for the PV application binary. Each `url` must be HTTPS, include a host, and include a non-empty final path segment that is not `.` or `..` and does not contain backslashes. Each `sha256` must be a 64-character hexadecimal digest, normalized case-insensitively by the parser. Each `size` must be a positive byte count.
+
+The manifest must contain at least one asset and must not contain duplicate assets for the same platform. Selecting the current platform returns the matching asset for the current target platform. If the current target platform is missing, selection fails clearly instead of falling back to another platform.
+
 The PV app update manifest is published at a stable PV-owned URL used by the Rust self-updater. Initially, that stable URL may be backed by GitHub Releases, such as a versioned `pv-app-manifest.json` release asset plus a stable latest manifest URL. The human-facing installer URL is separate and serves a generated installer script based on the same PV app release metadata.
 
 PV v1 relies on HTTPS/GitHub trust for the PV app update manifest itself. The app update manifest format should allow signatures to be added later without breaking compatibility.
+
+The self-update foundation PR implements only the typed PV app update manifest parser, current-platform asset selection, release-layout helpers for `~/.pv/bin/releases/<version>/pv` and `~/.pv/bin/pv`, and the active OS-level update lock at `~/.pv/run/update.lock`. It may exercise release-layout helpers with fixture binaries in tests. It does not implement `pv update`, `pv update --check`, PV app binary downloads, binary swapping from a downloaded artifact, daemon restart coordination, rollback, installer generation, PV app release metadata generation, Managed Resource update orchestration, artifact recipe changes, or runtime/user-facing update channel selection.
 
 For `pv update`, the CLI fetches the PV app update manifest and performs PV binary self-update before handing Managed Resource update work to the daemon. The daemon owns Managed Resource manifest refresh, install, update, and runtime reconciliation.
 

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -9,7 +9,7 @@ use crate::project_env::{reconcile_project_env, reconcile_project_env_with_runti
 use crate::reconciliation::{EnqueueResult, ReconciliationQueue, ReconciliationScope};
 use crate::structured_log;
 use protocol::{DaemonEvent, DaemonResponse, DaemonTransport, write_line};
-use state::{Database, JobStatus, ProjectRecord, PvPaths};
+use state::{Database, JobStatus, ProjectRecord, PvPaths, UpdateLock};
 use tokio::io::AsyncWrite;
 
 pub(crate) async fn run_job(
@@ -41,6 +41,8 @@ pub(crate) async fn run_background_reconciliation_job(
     scope: ReconciliationScope,
     runtime_catalog: Option<&ManagedResourceRuntimeCatalog>,
 ) -> Result<(), DaemonError> {
+    UpdateLock::check_available(&paths)?;
+
     let result = enqueue_reconciliation_job(&paths, &queue, scope)?;
     let EnqueueResult::Queued(queued) = result else {
         return Ok(());
@@ -663,13 +665,14 @@ mod tests {
 
     use camino::Utf8Path;
     use camino_tempfile::tempdir;
-    use state::{Database, JobStatus, PvPaths, StateError};
+    use state::{Database, JobStatus, PvPaths, StateError, UpdateLock};
     use tokio::io::duplex;
 
     use super::{
         complete_or_fail_background_reconciliation, enqueue_reconciliation_job,
         foreground_reconciliation_result, record_background_reconciliation_error,
-        start_reconciliation_job, stream_started_reconciliation_job,
+        run_background_reconciliation_job, start_reconciliation_job,
+        stream_started_reconciliation_job,
     };
     use crate::reconciliation::{EnqueueResult, ReconciliationQueue, ReconciliationScope};
 
@@ -800,6 +803,32 @@ mod tests {
             job.error.as_deref(),
             Some("I/O error: background task failed")
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn background_reconciliation_rejects_update_lock_without_job() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let update_lock = UpdateLock::acquire(&paths)?;
+        let result = run_background_reconciliation_job(
+            paths.clone(),
+            ReconciliationQueue::new(),
+            ReconciliationScope::System,
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(crate::DaemonError::State(StateError::UpdateInProgress { path }))
+                if path == paths.update_lock()
+        ));
+        drop(update_lock);
+
+        let database = Database::open(&paths)?;
+        assert!(database.recent_jobs()?.is_empty());
 
         Ok(())
     }

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -9,7 +9,7 @@ use crate::project_env::{reconcile_project_env, reconcile_project_env_with_runti
 use crate::reconciliation::{EnqueueResult, ReconciliationQueue, ReconciliationScope};
 use crate::structured_log;
 use protocol::{DaemonEvent, DaemonResponse, DaemonTransport, write_line};
-use state::{Database, JobStatus, ProjectRecord, PvPaths, UpdateLock};
+use state::{Database, JobStatus, ProjectRecord, PvPaths, StateError};
 use tokio::io::AsyncWrite;
 
 pub(crate) async fn run_job(
@@ -41,8 +41,6 @@ pub(crate) async fn run_background_reconciliation_job(
     scope: ReconciliationScope,
     runtime_catalog: Option<&ManagedResourceRuntimeCatalog>,
 ) -> Result<(), DaemonError> {
-    let update_lock = UpdateLock::acquire(&paths)?;
-
     let result = enqueue_reconciliation_job(&paths, &queue, scope)?;
     let EnqueueResult::Queued(queued) = result else {
         return Ok(());
@@ -55,7 +53,6 @@ pub(crate) async fn run_background_reconciliation_job(
         .map(|_summary| ());
 
     running.finish();
-    drop(update_lock);
 
     result
 }
@@ -67,7 +64,15 @@ async fn run_reconciliation_job(
     scope: ReconciliationScope,
     runtime_catalog: Option<&ManagedResourceRuntimeCatalog>,
 ) -> Result<(), DaemonError> {
-    let result = enqueue_reconciliation_job(&paths, &queue, scope)?;
+    let result = match enqueue_reconciliation_job(&paths, &queue, scope) {
+        Ok(result) => result,
+        Err(DaemonError::State(error @ StateError::UpdateInProgress { .. })) => {
+            write_line(&mut transport, &DaemonResponse::error(error.to_string())).await?;
+
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
 
     match result {
         EnqueueResult::Queued(queued) => {
@@ -115,7 +120,8 @@ fn enqueue_reconciliation_job(
     let scope_text = scope.to_string();
     let abandon_paths = paths.clone();
 
-    queue.enqueue_with_abandon(
+    queue.enqueue_mutating_with_abandon(
+        paths,
         scope,
         || start_reconciliation_job(paths, &scope_text),
         move |job_id| {
@@ -859,6 +865,35 @@ mod tests {
             update_lock,
             Err(StateError::UpdateInProgress { path }) if path == paths.update_lock()
         ));
+
+        queued_task.abort();
+        let _join_result = queued_task.await;
+        running.finish();
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn background_reconciliation_coalesces_under_daemon_update_lock() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let queue = ReconciliationQueue::new();
+        let first = queued(enqueue_reconciliation_job(
+            &paths,
+            &queue,
+            ReconciliationScope::System,
+        )?)?;
+        let running = first.wait_for_turn().await;
+        let scope = ReconciliationScope::project("project_1")?;
+        let queued_paths = paths.clone();
+        let queued_queue = queue.clone();
+        let queued_scope = scope.clone();
+        let queued_task = tokio::spawn(async move {
+            run_background_reconciliation_job(queued_paths, queued_queue, queued_scope, None).await
+        });
+
+        wait_for_job_scope(&paths, "project:project_1").await?;
+        run_background_reconciliation_job(paths.clone(), queue.clone(), scope, None).await?;
 
         queued_task.abort();
         let _join_result = queued_task.await;

--- a/crates/daemon/src/jobs.rs
+++ b/crates/daemon/src/jobs.rs
@@ -41,7 +41,7 @@ pub(crate) async fn run_background_reconciliation_job(
     scope: ReconciliationScope,
     runtime_catalog: Option<&ManagedResourceRuntimeCatalog>,
 ) -> Result<(), DaemonError> {
-    UpdateLock::check_available(&paths)?;
+    let update_lock = UpdateLock::acquire(&paths)?;
 
     let result = enqueue_reconciliation_job(&paths, &queue, scope)?;
     let EnqueueResult::Queued(queued) = result else {
@@ -55,6 +55,7 @@ pub(crate) async fn run_background_reconciliation_job(
         .map(|_summary| ());
 
     running.finish();
+    drop(update_lock);
 
     result
 }
@@ -833,6 +834,39 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn queued_background_reconciliation_reserves_update_lock() -> anyhow::Result<()> {
+        let tempdir = tempdir()?;
+        let paths = PvPaths::for_home(tempdir.path().join("home"));
+        let queue = ReconciliationQueue::new();
+        let first = queued(enqueue_reconciliation_job(
+            &paths,
+            &queue,
+            ReconciliationScope::System,
+        )?)?;
+        let running = first.wait_for_turn().await;
+        let queued_paths = paths.clone();
+        let queued_queue = queue.clone();
+        let queued_scope = ReconciliationScope::project("project_1")?;
+        let queued_task = tokio::spawn(async move {
+            run_background_reconciliation_job(queued_paths, queued_queue, queued_scope, None).await
+        });
+
+        wait_for_job_scope(&paths, "project:project_1").await?;
+        let update_lock = UpdateLock::acquire(&paths);
+
+        assert!(matches!(
+            update_lock,
+            Err(StateError::UpdateInProgress { path }) if path == paths.update_lock()
+        ));
+
+        queued_task.abort();
+        let _join_result = queued_task.await;
+        running.finish();
+
+        Ok(())
+    }
+
     #[test]
     fn foreground_reconciliation_result_takes_precedence_over_accepted_write_error() {
         let result = foreground_reconciliation_result(
@@ -907,6 +941,22 @@ mod tests {
                 "scope unexpectedly coalesced into {}",
                 job.job_id()
             )),
+        }
+    }
+
+    async fn wait_for_job_scope(paths: &PvPaths, scope: &str) -> anyhow::Result<()> {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+
+        loop {
+            let database = Database::open(paths)?;
+            if database.recent_jobs()?.iter().any(|job| job.scope == scope) {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                anyhow::bail!("timed out waiting for job scope {scope}");
+            }
+
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
     }
 

--- a/crates/daemon/src/managed_resources/tests.rs
+++ b/crates/daemon/src/managed_resources/tests.rs
@@ -1105,8 +1105,7 @@ async fn rustfs_port_reassignment_renders_current_endpoint_for_ready_allocation(
         )
     };
     stop_recorded_rustfs_runtime(&paths).await?;
-    let _api_port_guard = TcpListener::bind(("127.0.0.1", 19_030))?;
-    let _console_port_guard = TcpListener::bind(("127.0.0.1", 19_031))?;
+    let _port_guards = bind_loopback_ports_when_available([19_030, 19_031]).await?;
 
     reconcile_project_env_with_rustfs_runtime_catalog(&paths, &project.id).await?;
     let snapshot = {
@@ -2446,6 +2445,29 @@ fn reserve_postgres_port(paths: &PvPaths, port: u16) -> Result<()> {
 
 fn local_loopback_port_available(port: u16) -> bool {
     TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+async fn bind_loopback_ports_when_available(ports: [u16; 2]) -> Result<[TcpListener; 2]> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+
+    loop {
+        match bind_loopback_ports(ports) {
+            Ok(listeners) => return Ok(listeners),
+            Err(error) if tokio::time::Instant::now() >= deadline => {
+                bail!("timed out waiting for RustFS ports to become available: {error}");
+            }
+            Err(_error) => {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+    }
+}
+
+fn bind_loopback_ports(ports: [u16; 2]) -> std::io::Result<[TcpListener; 2]> {
+    let api_listener = TcpListener::bind(("127.0.0.1", ports[0]))?;
+    let console_listener = TcpListener::bind(("127.0.0.1", ports[1]))?;
+
+    Ok([api_listener, console_listener])
 }
 
 fn rustfs_bucket_path(paths: &PvPaths, track: &str, bucket: &str) -> camino::Utf8PathBuf {

--- a/crates/daemon/src/reconciliation.rs
+++ b/crates/daemon/src/reconciliation.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
+use state::{PvPaths, StateError, UpdateLock};
 use thiserror::Error;
 use tokio::sync::Notify;
 
@@ -93,6 +94,7 @@ struct DebounceState {
 struct QueueState {
     active: Option<ReconciliationJob>,
     queued: VecDeque<ReconciliationJob>,
+    update_lock: Option<UpdateLock>,
 }
 
 #[derive(Debug, Default)]
@@ -135,6 +137,50 @@ impl ReconciliationQueue {
             scope,
             job_id: create_job_id()?,
         };
+        state.queued.push_back(job.clone());
+        self.inner.notify.notify_waiters();
+
+        Ok(EnqueueResult::Queued(QueuedReconciliation {
+            job,
+            inner: Arc::clone(&self.inner),
+            abandon_job: Some(Box::new(abandon_job)),
+            released: false,
+        }))
+    }
+
+    pub(crate) fn enqueue_mutating_with_abandon<E>(
+        &self,
+        paths: &PvPaths,
+        scope: ReconciliationScope,
+        create_job_id: impl FnOnce() -> Result<String, E>,
+        abandon_job: impl FnOnce(&str) + Send + 'static,
+    ) -> Result<EnqueueResult, E>
+    where
+        E: From<StateError>,
+    {
+        let mut state = lock_queue_state(&self.inner);
+
+        if let Some(job) = matching_queued_job(&state, &scope) {
+            return Ok(EnqueueResult::Coalesced(job));
+        }
+
+        let acquired_lock = state.update_lock.is_none();
+        if acquired_lock {
+            state.update_lock = Some(UpdateLock::acquire(paths).map_err(E::from)?);
+        }
+
+        let job_id = match create_job_id() {
+            Ok(job_id) => job_id,
+            Err(error) => {
+                if acquired_lock && state.active.is_none() && state.queued.is_empty() {
+                    state.update_lock = None;
+                }
+
+                return Err(error);
+            }
+        };
+
+        let job = ReconciliationJob { scope, job_id };
         state.queued.push_back(job.clone());
         self.inner.notify.notify_waiters();
 
@@ -421,6 +467,7 @@ fn remove_queued_job(inner: &QueueInner, job: &ReconciliationJob) -> bool {
     state.queued.retain(|queued| queued.job_id != job.job_id);
 
     if state.queued.len() != queued_len {
+        release_update_lock_if_idle(&mut state);
         inner.notify.notify_waiters();
         return true;
     }
@@ -437,11 +484,18 @@ fn release_active_job(inner: &QueueInner, job: &ReconciliationJob) -> bool {
         .is_some_and(|active| active.job_id == job.job_id)
     {
         state.active = None;
+        release_update_lock_if_idle(&mut state);
         inner.notify.notify_waiters();
         return true;
     }
 
     false
+}
+
+fn release_update_lock_if_idle(state: &mut QueueState) {
+    if state.active.is_none() && state.queued.is_empty() {
+        state.update_lock = None;
+    }
 }
 
 fn lock_queue_state(inner: &QueueInner) -> MutexGuard<'_, QueueState> {

--- a/crates/daemon/src/server.rs
+++ b/crates/daemon/src/server.rs
@@ -143,17 +143,17 @@ async fn handle_connection(
             Ok(())
         }
         DaemonCommand::RunJob { kind, scope } => {
-            match UpdateLock::check_available(&paths) {
-                Ok(()) => {}
+            let update_lock = match UpdateLock::acquire(&paths) {
+                Ok(update_lock) => update_lock,
                 Err(error @ StateError::UpdateInProgress { .. }) => {
                     write_line(&mut transport, &DaemonResponse::error(error.to_string())).await?;
 
                     return Ok(());
                 }
                 Err(error) => return Err(error.into()),
-            }
+            };
 
-            run_job(
+            let result = run_job(
                 paths,
                 queue,
                 transport,
@@ -161,7 +161,10 @@ async fn handle_connection(
                 &scope,
                 runtime_catalog.as_deref(),
             )
-            .await
+            .await;
+            drop(update_lock);
+
+            result
         }
     }
 }

--- a/crates/daemon/src/server.rs
+++ b/crates/daemon/src/server.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::StreamExt;
-use state::{PvPaths, StateError, UpdateLock};
+use state::PvPaths;
 use tokio::io::AsyncRead;
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;
@@ -143,17 +143,7 @@ async fn handle_connection(
             Ok(())
         }
         DaemonCommand::RunJob { kind, scope } => {
-            let update_lock = match UpdateLock::acquire(&paths) {
-                Ok(update_lock) => update_lock,
-                Err(error @ StateError::UpdateInProgress { .. }) => {
-                    write_line(&mut transport, &DaemonResponse::error(error.to_string())).await?;
-
-                    return Ok(());
-                }
-                Err(error) => return Err(error.into()),
-            };
-
-            let result = run_job(
+            run_job(
                 paths,
                 queue,
                 transport,
@@ -161,10 +151,7 @@ async fn handle_connection(
                 &scope,
                 runtime_catalog.as_deref(),
             )
-            .await;
-            drop(update_lock);
-
-            result
+            .await
         }
     }
 }

--- a/crates/daemon/src/server.rs
+++ b/crates/daemon/src/server.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures_util::StreamExt;
-use state::PvPaths;
+use state::{PvPaths, StateError, UpdateLock};
 use tokio::io::AsyncRead;
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;
@@ -143,6 +143,16 @@ async fn handle_connection(
             Ok(())
         }
         DaemonCommand::RunJob { kind, scope } => {
+            match UpdateLock::check_available(&paths) {
+                Ok(()) => {}
+                Err(error @ StateError::UpdateInProgress { .. }) => {
+                    write_line(&mut transport, &DaemonResponse::error(error.to_string())).await?;
+
+                    return Ok(());
+                }
+                Err(error) => return Err(error.into()),
+            }
+
             run_job(
                 paths,
                 queue,

--- a/crates/daemon/tests/daemon_foundation.rs
+++ b/crates/daemon/tests/daemon_foundation.rs
@@ -9,7 +9,7 @@ use rusqlite::params;
 use serde_json::{Value, json};
 use state::{
     DNS_PREFERRED_PORT, Database, JobRecord, JobStatus, LinkProjectInput, PortOwner, PortRequest,
-    PvPaths, RUNTIME_PORT_FALLBACK_END, RUNTIME_PORT_FALLBACK_START,
+    PvPaths, RUNTIME_PORT_FALLBACK_END, RUNTIME_PORT_FALLBACK_START, UpdateLock,
 };
 use std::io::{self, ErrorKind};
 use std::net::{Ipv4Addr, SocketAddr, TcpListener as StdTcpListener, UdpSocket as StdUdpSocket};
@@ -106,6 +106,61 @@ async fn valid_reconciliation_scopes_stream_stub_completion() -> Result<()> {
     )?;
 
     Ok(())
+}
+
+#[tokio::test]
+async fn update_lock_rejects_mutating_jobs_but_keeps_health_available() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let update_lock = UpdateLock::acquire(&paths)?;
+    let daemon = daemon::RunningDaemon::start(paths.clone()).await?;
+
+    let run_job_lines = request_lines(
+        &paths,
+        json!({
+            "protocol_version": daemon::PROTOCOL_VERSION,
+            "command": "run_job",
+            "kind": "reconcile",
+            "scope": "system",
+        }),
+    )
+    .await?;
+    let health_lines = request_lines(
+        &paths,
+        json!({
+            "protocol_version": daemon::PROTOCOL_VERSION,
+            "command": "health",
+        }),
+    )
+    .await?;
+
+    daemon.shutdown().await?;
+    drop(update_lock);
+
+    let database = Database::open(&paths)?;
+    let run_job_lines = normalize_update_lock_path(run_job_lines, paths.update_lock().as_str());
+
+    assert_with_normalized_timestamps(
+        "update_lock_rejects_mutating_jobs_but_keeps_health_available",
+        (run_job_lines, health_lines, database.recent_jobs()?),
+    )?;
+
+    Ok(())
+}
+
+fn normalize_update_lock_path(mut lines: Vec<Value>, update_lock_path: &str) -> Vec<Value> {
+    for line in &mut lines {
+        let Some(message) = line.get_mut("message") else {
+            continue;
+        };
+        let Some(message_text) = message.as_str() else {
+            continue;
+        };
+
+        *message = json!(message_text.replace(update_lock_path, "<update-lock>"));
+    }
+
+    lines
 }
 
 #[tokio::test]

--- a/crates/daemon/tests/snapshots/daemon_foundation__update_lock_rejects_mutating_jobs_but_keeps_health_available.snap
+++ b/crates/daemon/tests/snapshots/daemon_foundation__update_lock_rejects_mutating_jobs_but_keeps_health_available.snap
@@ -1,0 +1,23 @@
+---
+source: crates/daemon/tests/daemon_foundation.rs
+expression: snapshot
+---
+(
+    [
+        Object {
+            "message": String("PV update is already in progress; update lock is held at <update-lock>"),
+            "protocol_version": Number(1),
+            "status": String("error"),
+            "type": String("response"),
+        },
+    ],
+    [
+        Object {
+            "message": String("daemon healthy"),
+            "protocol_version": Number(1),
+            "status": String("ok"),
+            "type": String("response"),
+        },
+    ],
+    [],
+)

--- a/crates/self-update/Cargo.toml
+++ b/crates/self-update/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "self-update"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true, features = ["parsing"] }
+url = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+insta = { workspace = true }

--- a/crates/self-update/src/lib.rs
+++ b/crates/self-update/src/lib.rs
@@ -1,0 +1,433 @@
+use std::collections::BTreeSet;
+use std::fmt;
+
+use serde::Deserialize;
+use thiserror::Error;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+use url::Url;
+
+const SUPPORTED_SCHEMA_VERSION: u64 = 1;
+const STABLE_CHANNEL: &str = "stable";
+
+#[derive(Debug)]
+pub struct AppUpdateManifest {
+    schema_version: u64,
+    channel: String,
+    version: AppUpdateVersion,
+    minimum_pv_version: AppUpdateVersion,
+    published_at: AppUpdatePublishedAt,
+    assets: Vec<AppUpdateAsset>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct AppUpdateVersion {
+    major: u64,
+    minor: u64,
+    patch: u64,
+    raw: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Sha256Digest(String);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppUpdatePublishedAt(String);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppUpdateAsset {
+    platform: AppUpdatePlatform,
+    url: String,
+    sha256: Sha256Digest,
+    size: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum AppUpdatePlatform {
+    DarwinArm64,
+    DarwinAmd64,
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum AppUpdateManifestError {
+    #[error("invalid PV app update manifest: {reason}")]
+    InvalidManifest { reason: String },
+
+    #[error(
+        "unsupported PV app update manifest schema version {schema_version}, expected {supported_schema_version}"
+    )]
+    UnsupportedManifestSchema {
+        schema_version: u64,
+        supported_schema_version: u64,
+    },
+
+    #[error("unsupported PV app update channel `{channel}`")]
+    UnsupportedChannel { channel: String },
+
+    #[error("invalid PV app update {kind} `{value}`")]
+    InvalidIdentity { kind: &'static str, value: String },
+
+    #[error(
+        "PV app update manifest requires PV {minimum_pv_version}, current PV is {current_pv_version}"
+    )]
+    RequiresNewerPv {
+        minimum_pv_version: String,
+        current_pv_version: String,
+    },
+
+    #[error("failed to parse PV app update published_at `{value}`")]
+    InvalidPublishedAt { value: String },
+
+    #[error("unsupported PV app update platform `{platform}`")]
+    UnsupportedPlatform { platform: String },
+
+    #[error("invalid PV app update asset URL `{url}`")]
+    InvalidAssetUrl { url: String },
+
+    #[error("invalid PV app update asset size {size} for {platform}")]
+    InvalidAssetSize { platform: String, size: u64 },
+
+    #[error("duplicate PV app update asset for {platform}")]
+    DuplicatePlatform { platform: String },
+
+    #[error("PV app update manifest has no assets")]
+    NoAssets,
+
+    #[error("PV app update manifest has no asset for {platform}")]
+    MissingPlatform { platform: String },
+
+    #[error("current PV app update platform is unsupported on this host")]
+    UnsupportedCurrentPlatform,
+}
+
+pub type Result<T> = std::result::Result<T, AppUpdateManifestError>;
+
+#[derive(Debug, Deserialize)]
+struct RawManifest {
+    schema_version: u64,
+    channel: String,
+    version: String,
+    minimum_pv_version: String,
+    published_at: String,
+    assets: Vec<RawAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAsset {
+    platform: String,
+    url: String,
+    sha256: String,
+    size: u64,
+}
+
+impl AppUpdateManifest {
+    pub fn parse(json: &str) -> Result<Self> {
+        let raw: RawManifest = serde_json::from_str(json).map_err(|error| {
+            AppUpdateManifestError::InvalidManifest {
+                reason: error.to_string(),
+            }
+        })?;
+
+        Self::from_raw(raw)
+    }
+
+    pub fn select_platform(&self, platform: AppUpdatePlatform) -> Result<&AppUpdateAsset> {
+        self.assets
+            .iter()
+            .find(|asset| asset.platform == platform)
+            .ok_or_else(|| AppUpdateManifestError::MissingPlatform {
+                platform: platform.as_str().to_string(),
+            })
+    }
+
+    pub fn select_current_platform(&self) -> Result<&AppUpdateAsset> {
+        self.select_platform(AppUpdatePlatform::current()?)
+    }
+
+    pub fn schema_version(&self) -> u64 {
+        self.schema_version
+    }
+
+    pub fn channel(&self) -> &str {
+        &self.channel
+    }
+
+    pub fn version(&self) -> &AppUpdateVersion {
+        &self.version
+    }
+
+    pub fn minimum_pv_version(&self) -> &AppUpdateVersion {
+        &self.minimum_pv_version
+    }
+
+    pub fn published_at(&self) -> &AppUpdatePublishedAt {
+        &self.published_at
+    }
+
+    pub fn assets(&self) -> &[AppUpdateAsset] {
+        &self.assets
+    }
+
+    fn from_raw(raw: RawManifest) -> Result<Self> {
+        if raw.schema_version != SUPPORTED_SCHEMA_VERSION {
+            return Err(AppUpdateManifestError::UnsupportedManifestSchema {
+                schema_version: raw.schema_version,
+                supported_schema_version: SUPPORTED_SCHEMA_VERSION,
+            });
+        }
+
+        if raw.channel != STABLE_CHANNEL {
+            return Err(AppUpdateManifestError::UnsupportedChannel {
+                channel: raw.channel,
+            });
+        }
+
+        let version = AppUpdateVersion::parse(raw.version)?;
+        let minimum_pv_version = AppUpdateVersion::parse(raw.minimum_pv_version)?;
+        let current_pv_version = AppUpdateVersion::current()?;
+        if minimum_pv_version > current_pv_version {
+            return Err(AppUpdateManifestError::RequiresNewerPv {
+                minimum_pv_version: minimum_pv_version.as_str().to_string(),
+                current_pv_version: current_pv_version.as_str().to_string(),
+            });
+        }
+
+        let published_at = AppUpdatePublishedAt::parse(raw.published_at)?;
+        let assets = parse_assets(raw.assets)?;
+
+        Ok(Self {
+            schema_version: raw.schema_version,
+            channel: raw.channel,
+            version,
+            minimum_pv_version,
+            published_at,
+            assets,
+        })
+    }
+}
+
+impl AppUpdateVersion {
+    pub fn current() -> Result<Self> {
+        Self::parse(env!("CARGO_PKG_VERSION"))
+    }
+
+    pub fn parse(value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        if value.contains('/') || value.contains('\\') {
+            return invalid_identity("version", value);
+        }
+
+        let mut parts = value.split('.');
+        let Some(major) = parts.next() else {
+            return invalid_identity("version", value);
+        };
+        let Some(minor) = parts.next() else {
+            return invalid_identity("version", value);
+        };
+        let Some(patch) = parts.next() else {
+            return invalid_identity("version", value);
+        };
+        if parts.next().is_some() {
+            return invalid_identity("version", value);
+        }
+
+        let major = parse_version_component(major, &value)?;
+        let minor = parse_version_component(minor, &value)?;
+        let patch = parse_version_component(patch, &value)?;
+
+        Ok(Self {
+            major,
+            minor,
+            patch,
+            raw: value,
+        })
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+}
+
+impl fmt::Display for AppUpdateVersion {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl Sha256Digest {
+    pub fn parse(value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        if value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            Ok(Self(value.to_ascii_lowercase()))
+        } else {
+            invalid_identity("sha256", value)
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AppUpdatePublishedAt {
+    pub fn parse(value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        OffsetDateTime::parse(&value, &Rfc3339).map_err(|_| {
+            AppUpdateManifestError::InvalidPublishedAt {
+                value: value.clone(),
+            }
+        })?;
+
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AppUpdateAsset {
+    pub fn platform(&self) -> AppUpdatePlatform {
+        self.platform
+    }
+
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    pub fn sha256(&self) -> &Sha256Digest {
+        &self.sha256
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    fn from_raw(raw: RawAsset) -> Result<Self> {
+        let platform = AppUpdatePlatform::parse(&raw.platform)?;
+        if raw.size == 0 {
+            return Err(AppUpdateManifestError::InvalidAssetSize {
+                platform: platform.as_str().to_string(),
+                size: raw.size,
+            });
+        }
+
+        Ok(Self {
+            platform,
+            url: validate_asset_url(raw.url)?,
+            sha256: Sha256Digest::parse(raw.sha256)?,
+            size: raw.size,
+        })
+    }
+}
+
+impl AppUpdatePlatform {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "darwin-arm64" => Ok(Self::DarwinArm64),
+            "darwin-amd64" => Ok(Self::DarwinAmd64),
+            _ => Err(AppUpdateManifestError::UnsupportedPlatform {
+                platform: value.to_string(),
+            }),
+        }
+    }
+
+    pub fn current() -> Result<Self> {
+        current_platform()
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DarwinArm64 => "darwin-arm64",
+            Self::DarwinAmd64 => "darwin-amd64",
+        }
+    }
+}
+
+impl fmt::Display for AppUpdatePlatform {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+fn parse_assets(raw_assets: Vec<RawAsset>) -> Result<Vec<AppUpdateAsset>> {
+    if raw_assets.is_empty() {
+        return Err(AppUpdateManifestError::NoAssets);
+    }
+
+    let mut seen_platforms = BTreeSet::new();
+    raw_assets
+        .into_iter()
+        .map(|asset| {
+            let platform = AppUpdatePlatform::parse(&asset.platform)?;
+            if !seen_platforms.insert(platform) {
+                return Err(AppUpdateManifestError::DuplicatePlatform {
+                    platform: platform.as_str().to_string(),
+                });
+            }
+
+            AppUpdateAsset::from_raw(asset)
+        })
+        .collect()
+}
+
+fn validate_asset_url(url: String) -> Result<String> {
+    if url.contains('\\') {
+        return Err(AppUpdateManifestError::InvalidAssetUrl { url });
+    }
+
+    let parsed = match Url::parse(&url) {
+        Ok(parsed) => parsed,
+        Err(_error) => return Err(AppUpdateManifestError::InvalidAssetUrl { url }),
+    };
+    if parsed.scheme() != "https" || parsed.host_str().is_none() {
+        return Err(AppUpdateManifestError::InvalidAssetUrl { url });
+    }
+
+    let Some(file_name) = parsed
+        .path_segments()
+        .and_then(|mut segments| segments.next_back())
+    else {
+        return Err(AppUpdateManifestError::InvalidAssetUrl { url });
+    };
+    if file_name.is_empty() || file_name == "." || file_name == ".." || file_name.contains('\\') {
+        return Err(AppUpdateManifestError::InvalidAssetUrl { url });
+    }
+
+    Ok(url)
+}
+
+fn parse_version_component(component: &str, value: &str) -> Result<u64> {
+    if component.is_empty() || component.len() > 1 && component.starts_with('0') {
+        return invalid_identity("version", value.to_string());
+    }
+
+    component
+        .parse::<u64>()
+        .map_err(|_| AppUpdateManifestError::InvalidIdentity {
+            kind: "version",
+            value: value.to_string(),
+        })
+}
+
+fn invalid_identity<T>(kind: &'static str, value: String) -> Result<T> {
+    Err(AppUpdateManifestError::InvalidIdentity { kind, value })
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn current_platform() -> Result<AppUpdatePlatform> {
+    Ok(AppUpdatePlatform::DarwinArm64)
+}
+
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+fn current_platform() -> Result<AppUpdatePlatform> {
+    Ok(AppUpdatePlatform::DarwinAmd64)
+}
+
+#[cfg(not(any(
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "macos", target_arch = "x86_64")
+)))]
+fn current_platform() -> Result<AppUpdatePlatform> {
+    Err(AppUpdateManifestError::UnsupportedCurrentPlatform)
+}

--- a/crates/self-update/tests/app_update_manifest.rs
+++ b/crates/self-update/tests/app_update_manifest.rs
@@ -1,0 +1,275 @@
+use anyhow::Result;
+use insta::assert_debug_snapshot;
+use self_update::{AppUpdateManifest, AppUpdateManifestError, AppUpdatePlatform, AppUpdateVersion};
+
+#[derive(Debug)]
+#[expect(
+    dead_code,
+    reason = "snapshot-only structure is read through derived Debug"
+)]
+struct InvalidManifestSnapshot {
+    name: &'static str,
+    error: ManifestErrorSnapshot,
+}
+
+#[derive(Debug)]
+#[expect(
+    dead_code,
+    reason = "snapshot-only structure is read through derived Debug"
+)]
+enum ManifestErrorSnapshot {
+    UnsupportedManifestSchema {
+        schema_version: u64,
+        supported_schema_version: u64,
+    },
+    UnsupportedChannel {
+        channel: String,
+    },
+    InvalidIdentity {
+        kind: &'static str,
+        value: String,
+    },
+    RequiresNewerPv {
+        minimum_pv_version: String,
+        current_pv_version: &'static str,
+    },
+    InvalidPublishedAt {
+        value: String,
+    },
+    UnsupportedPlatform {
+        platform: String,
+    },
+    InvalidAssetUrl {
+        url: String,
+    },
+    InvalidAssetSize {
+        platform: String,
+        size: u64,
+    },
+    DuplicatePlatform {
+        platform: String,
+    },
+    Other {
+        message: String,
+    },
+}
+
+#[test]
+fn app_update_manifest_parses_stable_release_and_selects_platform() -> Result<()> {
+    let manifest = AppUpdateManifest::parse(VALID_MANIFEST)?;
+    let selected = manifest.select_platform(AppUpdatePlatform::DarwinArm64)?;
+
+    assert_eq!(manifest.schema_version(), 1);
+    assert_eq!(manifest.channel(), "stable");
+    assert_eq!(manifest.version().as_str(), "0.2.0");
+    assert_eq!(manifest.minimum_pv_version().as_str(), "0.1.0");
+    assert_eq!(selected.platform(), AppUpdatePlatform::DarwinArm64);
+    assert_eq!(
+        selected.url(),
+        "https://downloads.example.test/pv/0.2.0/pv-darwin-arm64"
+    );
+    assert_eq!(
+        selected.sha256().as_str(),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
+    assert_eq!(selected.size(), 12345678);
+
+    assert_debug_snapshot!(manifest);
+
+    Ok(())
+}
+
+#[test]
+fn app_update_manifest_rejects_schema_channel_version_and_compatibility_errors() -> Result<()> {
+    let unsupported_schema =
+        VALID_MANIFEST.replacen("\"schema_version\": 1", "\"schema_version\": 2", 1);
+    let preview_channel =
+        VALID_MANIFEST.replacen("\"channel\": \"stable\"", "\"channel\": \"preview\"", 1);
+    let invalid_version =
+        VALID_MANIFEST.replacen("\"version\": \"0.2.0\"", "\"version\": \"0.02.0\"", 1);
+    let newer_minimum = VALID_MANIFEST.replacen(
+        "\"minimum_pv_version\": \"0.1.0\"",
+        "\"minimum_pv_version\": \"999.0.0\"",
+        1,
+    );
+
+    let errors = [
+        ("unsupported_schema", unsupported_schema),
+        ("preview_channel", preview_channel),
+        ("invalid_version", invalid_version),
+        ("newer_minimum", newer_minimum),
+    ]
+    .into_iter()
+    .map(|(name, manifest)| {
+        Ok(InvalidManifestSnapshot {
+            name,
+            error: normalize_manifest_error(parse_manifest_error(&manifest)?),
+        })
+    })
+    .collect::<Result<Vec<_>>>()?;
+
+    assert_debug_snapshot!(errors);
+
+    Ok(())
+}
+
+#[test]
+fn app_update_manifest_rejects_invalid_asset_fields() -> Result<()> {
+    let invalid_url = VALID_MANIFEST.replacen(
+        "https://downloads.example.test/pv/0.2.0/pv-darwin-arm64",
+        "http://downloads.example.test/pv/0.2.0/pv-darwin-arm64",
+        1,
+    );
+    let invalid_checksum = VALID_MANIFEST.replacen(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "not-a-sha",
+        1,
+    );
+    let invalid_timestamp = VALID_MANIFEST.replacen(
+        "\"published_at\": \"2026-06-11T12:00:00Z\"",
+        "\"published_at\": \"not-a-date\"",
+        1,
+    );
+    let invalid_platform =
+        VALID_MANIFEST.replacen("\"platform\": \"darwin-arm64\"", "\"platform\": \"any\"", 1);
+    let zero_size = VALID_MANIFEST.replacen("\"size\": 12345678", "\"size\": 0", 1);
+    let duplicate_platform = VALID_MANIFEST.replacen(
+        "\"platform\": \"darwin-amd64\"",
+        "\"platform\": \"darwin-arm64\"",
+        1,
+    );
+
+    let errors = [
+        ("invalid_url", invalid_url),
+        ("invalid_checksum", invalid_checksum),
+        ("invalid_timestamp", invalid_timestamp),
+        ("invalid_platform", invalid_platform),
+        ("zero_size", zero_size),
+        ("duplicate_platform", duplicate_platform),
+    ]
+    .into_iter()
+    .map(|(name, manifest)| {
+        Ok(InvalidManifestSnapshot {
+            name,
+            error: normalize_manifest_error(parse_manifest_error(&manifest)?),
+        })
+    })
+    .collect::<Result<Vec<_>>>()?;
+
+    assert_debug_snapshot!(errors);
+
+    Ok(())
+}
+
+#[test]
+fn app_update_manifest_selection_reports_missing_platform() -> Result<()> {
+    let arm64_only = VALID_MANIFEST.replace(
+        r#",
+    {
+      "platform": "darwin-amd64",
+      "url": "https://downloads.example.test/pv/0.2.0/pv-darwin-amd64",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "size": 12345678
+    }"#,
+        "",
+    );
+    let manifest = AppUpdateManifest::parse(&arm64_only)?;
+    let error = select_platform_error(&manifest, AppUpdatePlatform::DarwinAmd64)?;
+
+    assert_debug_snapshot!(error);
+
+    Ok(())
+}
+
+#[test]
+fn app_update_versions_reject_path_unsafe_values() {
+    for value in ["", ".", "..", "../0.2.0", "0.2.0/pv", "0.2.0\\pv"] {
+        assert!(AppUpdateVersion::parse(value).is_err());
+    }
+
+    assert!(AppUpdateVersion::parse("0.2.0").is_ok());
+}
+
+fn parse_manifest_error(json: &str) -> Result<AppUpdateManifestError> {
+    match AppUpdateManifest::parse(json) {
+        Ok(manifest) => anyhow::bail!("manifest parsed successfully: {manifest:#?}"),
+        Err(error) => Ok(error),
+    }
+}
+
+fn normalize_manifest_error(error: AppUpdateManifestError) -> ManifestErrorSnapshot {
+    match error {
+        AppUpdateManifestError::UnsupportedManifestSchema {
+            schema_version,
+            supported_schema_version,
+        } => ManifestErrorSnapshot::UnsupportedManifestSchema {
+            schema_version,
+            supported_schema_version,
+        },
+        AppUpdateManifestError::UnsupportedChannel { channel } => {
+            ManifestErrorSnapshot::UnsupportedChannel { channel }
+        }
+        AppUpdateManifestError::InvalidIdentity { kind, value } => {
+            ManifestErrorSnapshot::InvalidIdentity { kind, value }
+        }
+        AppUpdateManifestError::RequiresNewerPv {
+            minimum_pv_version,
+            current_pv_version: _,
+        } => ManifestErrorSnapshot::RequiresNewerPv {
+            minimum_pv_version,
+            current_pv_version: "<current-pv-version>",
+        },
+        AppUpdateManifestError::InvalidPublishedAt { value } => {
+            ManifestErrorSnapshot::InvalidPublishedAt { value }
+        }
+        AppUpdateManifestError::UnsupportedPlatform { platform } => {
+            ManifestErrorSnapshot::UnsupportedPlatform { platform }
+        }
+        AppUpdateManifestError::InvalidAssetUrl { url } => {
+            ManifestErrorSnapshot::InvalidAssetUrl { url }
+        }
+        AppUpdateManifestError::InvalidAssetSize { platform, size } => {
+            ManifestErrorSnapshot::InvalidAssetSize { platform, size }
+        }
+        AppUpdateManifestError::DuplicatePlatform { platform } => {
+            ManifestErrorSnapshot::DuplicatePlatform { platform }
+        }
+        error => ManifestErrorSnapshot::Other {
+            message: error.to_string(),
+        },
+    }
+}
+
+fn select_platform_error(
+    manifest: &AppUpdateManifest,
+    platform: AppUpdatePlatform,
+) -> Result<AppUpdateManifestError> {
+    match manifest.select_platform(platform) {
+        Ok(asset) => anyhow::bail!("asset selected successfully: {asset:#?}"),
+        Err(error) => Ok(error),
+    }
+}
+
+const VALID_MANIFEST: &str = r#"
+{
+  "schema_version": 1,
+  "channel": "stable",
+  "version": "0.2.0",
+  "minimum_pv_version": "0.1.0",
+  "published_at": "2026-06-11T12:00:00Z",
+  "assets": [
+    {
+      "platform": "darwin-arm64",
+      "url": "https://downloads.example.test/pv/0.2.0/pv-darwin-arm64",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 12345678
+    },
+    {
+      "platform": "darwin-amd64",
+      "url": "https://downloads.example.test/pv/0.2.0/pv-darwin-amd64",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "size": 12345678
+    }
+  ]
+}
+"#;

--- a/crates/self-update/tests/snapshots/app_update_manifest__app_update_manifest_parses_stable_release_and_selects_platform.snap
+++ b/crates/self-update/tests/snapshots/app_update_manifest__app_update_manifest_parses_stable_release_and_selects_platform.snap
@@ -1,0 +1,41 @@
+---
+source: crates/self-update/tests/app_update_manifest.rs
+expression: manifest
+---
+AppUpdateManifest {
+    schema_version: 1,
+    channel: "stable",
+    version: AppUpdateVersion {
+        major: 0,
+        minor: 2,
+        patch: 0,
+        raw: "0.2.0",
+    },
+    minimum_pv_version: AppUpdateVersion {
+        major: 0,
+        minor: 1,
+        patch: 0,
+        raw: "0.1.0",
+    },
+    published_at: AppUpdatePublishedAt(
+        "2026-06-11T12:00:00Z",
+    ),
+    assets: [
+        AppUpdateAsset {
+            platform: DarwinArm64,
+            url: "https://downloads.example.test/pv/0.2.0/pv-darwin-arm64",
+            sha256: Sha256Digest(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            ),
+            size: 12345678,
+        },
+        AppUpdateAsset {
+            platform: DarwinAmd64,
+            url: "https://downloads.example.test/pv/0.2.0/pv-darwin-amd64",
+            sha256: Sha256Digest(
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ),
+            size: 12345678,
+        },
+    ],
+}

--- a/crates/self-update/tests/snapshots/app_update_manifest__app_update_manifest_rejects_invalid_asset_fields.snap
+++ b/crates/self-update/tests/snapshots/app_update_manifest__app_update_manifest_rejects_invalid_asset_fields.snap
@@ -1,0 +1,44 @@
+---
+source: crates/self-update/tests/app_update_manifest.rs
+expression: errors
+---
+[
+    InvalidManifestSnapshot {
+        name: "invalid_url",
+        error: InvalidAssetUrl {
+            url: "http://downloads.example.test/pv/0.2.0/pv-darwin-arm64",
+        },
+    },
+    InvalidManifestSnapshot {
+        name: "invalid_checksum",
+        error: InvalidIdentity {
+            kind: "sha256",
+            value: "not-a-sha",
+        },
+    },
+    InvalidManifestSnapshot {
+        name: "invalid_timestamp",
+        error: InvalidPublishedAt {
+            value: "not-a-date",
+        },
+    },
+    InvalidManifestSnapshot {
+        name: "invalid_platform",
+        error: UnsupportedPlatform {
+            platform: "any",
+        },
+    },
+    InvalidManifestSnapshot {
+        name: "zero_size",
+        error: InvalidAssetSize {
+            platform: "darwin-arm64",
+            size: 0,
+        },
+    },
+    InvalidManifestSnapshot {
+        name: "duplicate_platform",
+        error: DuplicatePlatform {
+            platform: "darwin-arm64",
+        },
+    },
+]

--- a/crates/self-update/tests/snapshots/app_update_manifest__app_update_manifest_rejects_schema_channel_version_and_compatibility_errors.snap
+++ b/crates/self-update/tests/snapshots/app_update_manifest__app_update_manifest_rejects_schema_channel_version_and_compatibility_errors.snap
@@ -1,0 +1,33 @@
+---
+source: crates/self-update/tests/app_update_manifest.rs
+expression: errors
+---
+[
+    InvalidManifestSnapshot {
+        name: "unsupported_schema",
+        error: UnsupportedManifestSchema {
+            schema_version: 2,
+            supported_schema_version: 1,
+        },
+    },
+    InvalidManifestSnapshot {
+        name: "preview_channel",
+        error: UnsupportedChannel {
+            channel: "preview",
+        },
+    },
+    InvalidManifestSnapshot {
+        name: "invalid_version",
+        error: InvalidIdentity {
+            kind: "version",
+            value: "0.02.0",
+        },
+    },
+    InvalidManifestSnapshot {
+        name: "newer_minimum",
+        error: RequiresNewerPv {
+            minimum_pv_version: "999.0.0",
+            current_pv_version: "<current-pv-version>",
+        },
+    },
+]

--- a/crates/self-update/tests/snapshots/app_update_manifest__app_update_manifest_selection_reports_missing_platform.snap
+++ b/crates/self-update/tests/snapshots/app_update_manifest__app_update_manifest_selection_reports_missing_platform.snap
@@ -1,0 +1,7 @@
+---
+source: crates/self-update/tests/app_update_manifest.rs
+expression: "select_platform_error(&manifest, AppUpdatePlatform::DarwinAmd64,)?"
+---
+MissingPlatform {
+    platform: "darwin-amd64",
+}

--- a/crates/state/src/app_release.rs
+++ b/crates/state/src/app_release.rs
@@ -31,6 +31,7 @@ impl AppReleaseLayout {
         let binary_path = self.paths.app_release_binary(version);
 
         fs::copy_file_atomically(source, &binary_path)?;
+        fs::secure_executable_file(&binary_path)?;
 
         Ok(AppReleaseInstall {
             version: version.to_string(),

--- a/crates/state/src/app_release.rs
+++ b/crates/state/src/app_release.rs
@@ -1,0 +1,157 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use crate::{PvPaths, StateError, fs};
+
+static APP_RELEASE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppReleaseLayout {
+    paths: PvPaths,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AppReleaseInstall {
+    version: String,
+    binary_path: Utf8PathBuf,
+}
+
+impl AppReleaseLayout {
+    pub fn new(paths: PvPaths) -> Self {
+        Self { paths }
+    }
+
+    pub fn install_release_binary(
+        &self,
+        version: &str,
+        source: &Utf8Path,
+    ) -> Result<AppReleaseInstall, StateError> {
+        validate_app_release_version(version)?;
+        let binary_path = self.paths.app_release_binary(version);
+
+        fs::copy_file_atomically(source, &binary_path)?;
+
+        Ok(AppReleaseInstall {
+            version: version.to_string(),
+            binary_path,
+        })
+    }
+
+    pub fn activate_release(&self, version: &str) -> Result<(), StateError> {
+        validate_app_release_version(version)?;
+        let release_binary = self.paths.app_release_binary(version);
+        if !fs::path_is_file(&release_binary)? {
+            return Err(StateError::AppReleaseMissing {
+                version: version.to_string(),
+                path: release_binary,
+            });
+        }
+
+        let active_path = self.paths.active_pv_binary();
+        let temporary_path = temporary_active_symlink(&active_path);
+        fs::remove_file_if_exists(&temporary_path)?;
+        fs::symlink_file(
+            Utf8Path::new(&format!("releases/{version}/pv")),
+            &temporary_path,
+        )?;
+        fs::rename(&temporary_path, &active_path)?;
+        fs::sync_directory(self.paths.bin())?;
+
+        Ok(())
+    }
+
+    pub fn active_release(&self) -> Result<Option<String>, StateError> {
+        let active_path = self.paths.active_pv_binary();
+        if !fs::path_entry_exists(&active_path)? {
+            return Ok(None);
+        }
+
+        let target = fs::read_link(&active_path)?;
+        let target_text = target.as_str();
+        let Some(version) = target_text
+            .strip_prefix("releases/")
+            .and_then(|value| value.strip_suffix("/pv"))
+        else {
+            return Err(invalid_pointer(&active_path, target_text));
+        };
+        validate_app_release_version(version)?;
+
+        let release_binary = self.paths.bin().join(target_text);
+        if !fs::path_is_file(&release_binary)? {
+            return Err(invalid_pointer(&active_path, target_text));
+        }
+
+        Ok(Some(version.to_string()))
+    }
+}
+
+impl AppReleaseInstall {
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    pub fn binary_path(&self) -> &Utf8Path {
+        &self.binary_path
+    }
+}
+
+fn temporary_active_symlink(active_path: &Utf8Path) -> Utf8PathBuf {
+    let file_name = active_path.file_name().unwrap_or("pv");
+    let process_id = std::process::id();
+    let counter = APP_RELEASE_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    active_path.with_file_name(format!("{file_name}.{process_id}.{counter}.tmp"))
+}
+
+fn validate_app_release_version(version: &str) -> Result<(), StateError> {
+    if version.contains('/') || version.contains('\\') {
+        return invalid_version(version);
+    }
+
+    let mut parts = version.split('.');
+    let Some(major) = parts.next() else {
+        return invalid_version(version);
+    };
+    let Some(minor) = parts.next() else {
+        return invalid_version(version);
+    };
+    let Some(patch) = parts.next() else {
+        return invalid_version(version);
+    };
+    if parts.next().is_some() {
+        return invalid_version(version);
+    }
+
+    parse_version_component(major, version)?;
+    parse_version_component(minor, version)?;
+    parse_version_component(patch, version)?;
+
+    Ok(())
+}
+
+fn parse_version_component(component: &str, version: &str) -> Result<(), StateError> {
+    if component.is_empty() || component.len() > 1 && component.starts_with('0') {
+        return invalid_version(version);
+    }
+
+    component
+        .parse::<u64>()
+        .map(|_component| ())
+        .map_err(|_error| StateError::InvalidAppReleaseVersion {
+            version: version.to_string(),
+        })
+}
+
+fn invalid_version<T>(version: &str) -> Result<T, StateError> {
+    Err(StateError::InvalidAppReleaseVersion {
+        version: version.to_string(),
+    })
+}
+
+fn invalid_pointer(path: &Utf8Path, target: &str) -> StateError {
+    StateError::InvalidAppReleasePointer {
+        path: path.to_path_buf(),
+        target: target.to_string(),
+    }
+}

--- a/crates/state/src/error.rs
+++ b/crates/state/src/error.rs
@@ -16,6 +16,18 @@ pub enum StateError {
         source: std::io::Error,
     },
 
+    #[error("invalid PV app release version `{version}`")]
+    InvalidAppReleaseVersion { version: String },
+
+    #[error("PV app release `{version}` is missing at {path}")]
+    AppReleaseMissing { version: String, path: Utf8PathBuf },
+
+    #[error("active PV binary symlink at {path} targets invalid release `{target}`")]
+    InvalidAppReleasePointer { path: Utf8PathBuf, target: String },
+
+    #[error("PV update is already in progress; update lock is held at {path}")]
+    UpdateInProgress { path: Utf8PathBuf },
+
     #[error("unsafe permissions for {path}: expected {expected:o}, found {actual:o}")]
     UnsafePermissions {
         path: Utf8PathBuf,

--- a/crates/state/src/fs.rs
+++ b/crates/state/src/fs.rs
@@ -8,6 +8,7 @@ use crate::{PvPaths, StateError, backup};
 
 const USER_ONLY_DIR_MODE: u32 = 0o700;
 const SENSITIVE_FILE_MODE: u32 = 0o600;
+const EXECUTABLE_FILE_MODE: u32 = 0o700;
 static TEMPORARY_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -160,6 +161,12 @@ pub(crate) fn secure_database_files(paths: &PvPaths) -> Result<(), StateError> {
 pub(crate) fn secure_sensitive_file(path: &Utf8Path) -> Result<(), StateError> {
     set_file_mode(path, SENSITIVE_FILE_MODE)?;
     validate_mode(path, SENSITIVE_FILE_MODE)?;
+    validate_owner(path)
+}
+
+pub(crate) fn secure_executable_file(path: &Utf8Path) -> Result<(), StateError> {
+    set_file_mode(path, EXECUTABLE_FILE_MODE)?;
+    validate_mode(path, EXECUTABLE_FILE_MODE)?;
     validate_owner(path)
 }
 

--- a/crates/state/src/fs.rs
+++ b/crates/state/src/fs.rs
@@ -70,6 +70,25 @@ pub fn write_sensitive_file(path: &Utf8Path, content: &str) -> Result<(), StateE
     secure_sensitive_file(path)
 }
 
+pub fn copy_file_atomically(source: &Utf8Path, target: &Utf8Path) -> Result<(), StateError> {
+    ensure_parent_dir(target)?;
+    let temporary_path = temporary_path_for(target);
+    let result =
+        copy_file(source, &temporary_path).and_then(|_bytes| rename(&temporary_path, target));
+
+    match result {
+        Ok(()) => {
+            sync_parent_directory(target)?;
+            Ok(())
+        }
+        Err(error) => {
+            if let Err(_cleanup_error) = remove_file_if_exists(&temporary_path) {}
+
+            Err(error)
+        }
+    }
+}
+
 #[expect(
     clippy::disallowed_types,
     reason = "PV filesystem helper owns direct file handles"
@@ -181,6 +200,14 @@ fn write_atomically(path: &Utf8Path, content: &str) -> Result<(), StateError> {
         .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
 }
 
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns atomic file copies"
+)]
+fn copy_file(source: &Utf8Path, target: &Utf8Path) -> Result<u64, StateError> {
+    std::fs::copy(source, target).map_err(|source| StateError::filesystem(target, source))
+}
+
 fn temporary_path_for(path: &Utf8Path) -> Utf8PathBuf {
     let file_name = path.file_name().unwrap_or("pv");
     let process_id = std::process::id();
@@ -236,8 +263,28 @@ fn create_dir_all(path: &Utf8Path) -> Result<(), StateError> {
     clippy::disallowed_methods,
     reason = "PV filesystem helper owns direct filesystem access"
 )]
+pub fn rename(from: &Utf8Path, to: &Utf8Path) -> Result<(), StateError> {
+    std::fs::rename(from, to).map_err(|source| StateError::filesystem(to.to_path_buf(), source))
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
 pub fn remove_file(path: &Utf8Path) -> Result<(), StateError> {
     std::fs::remove_file(path).map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}
+
+pub fn remove_file_if_exists(path: &Utf8Path) -> Result<(), StateError> {
+    match remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(StateError::Filesystem { source, .. })
+            if source.kind() == std::io::ErrorKind::NotFound =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
 }
 
 pub fn delete_file(path: &Utf8Path) -> Result<(), StateError> {
@@ -330,6 +377,87 @@ fn owner_uid(path: &Utf8Path) -> Result<u32, StateError> {
 
 pub fn path_exists(path: &Utf8Path) -> bool {
     path.exists()
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+pub fn path_entry_exists(path: &Utf8Path) -> Result<bool, StateError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_metadata) => Ok(true),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(StateError::filesystem(path.to_path_buf(), source)),
+    }
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+pub fn path_is_file(path: &Utf8Path) -> Result<bool, StateError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(source) => Err(StateError::filesystem(path.to_path_buf(), source)),
+    }
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct filesystem access"
+)]
+pub fn read_link(path: &Utf8Path) -> Result<Utf8PathBuf, StateError> {
+    let target = std::fs::read_link(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))?;
+
+    Utf8PathBuf::from_path_buf(target).map_err(|path| {
+        StateError::filesystem(
+            path.to_string_lossy().as_ref(),
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "symlink target is not valid UTF-8",
+            ),
+        )
+    })
+}
+
+#[cfg(unix)]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "PV filesystem helper owns direct symlink updates"
+)]
+pub fn symlink_file(target: &Utf8Path, link: &Utf8Path) -> Result<(), StateError> {
+    std::os::unix::fs::symlink(target, link)
+        .map_err(|source| StateError::filesystem(link.to_path_buf(), source))
+}
+
+#[cfg(not(unix))]
+pub fn symlink_file(_target: &Utf8Path, link: &Utf8Path) -> Result<(), StateError> {
+    Err(StateError::filesystem(
+        link.to_path_buf(),
+        io::Error::new(io::ErrorKind::Unsupported, "PV requires Unix symlinks"),
+    ))
+}
+
+pub fn sync_parent_directory(path: &Utf8Path) -> Result<(), StateError> {
+    if let Some(parent) = path.parent() {
+        sync_directory(parent)?;
+    }
+
+    Ok(())
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "PV filesystem helper owns direct file handles"
+)]
+pub fn sync_directory(path: &Utf8Path) -> Result<(), StateError> {
+    let directory = std::fs::File::open(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))?;
+    directory
+        .sync_all()
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
 }
 
 #[expect(

--- a/crates/state/src/lib.rs
+++ b/crates/state/src/lib.rs
@@ -1,10 +1,13 @@
+mod app_release;
 mod backup;
 mod database;
 mod error;
 pub mod fs;
 mod migrations;
 mod paths;
+mod update_lock;
 
+pub use app_release::{AppReleaseInstall, AppReleaseLayout};
 pub use database::{
     DNS_PREFERRED_PORT, Database, DatabaseInspection, EnvContextValues,
     GATEWAY_HTTP_PREFERRED_PORT, GATEWAY_HTTPS_PREFERRED_PORT, GatewayPort, GatewayPortAssignments,
@@ -20,6 +23,7 @@ pub use database::{
 };
 pub use error::StateError;
 pub use paths::{PathSummaryEntry, PvPaths};
+pub use update_lock::UpdateLock;
 
 #[doc(hidden)]
 pub mod testing {

--- a/crates/state/src/paths.rs
+++ b/crates/state/src/paths.rs
@@ -74,8 +74,24 @@ impl PvPaths {
         &self.bin
     }
 
+    pub fn app_releases_dir(&self) -> Utf8PathBuf {
+        self.bin().join("releases")
+    }
+
+    pub fn app_release_binary(&self, version: &str) -> Utf8PathBuf {
+        self.app_releases_dir().join(version).join("pv")
+    }
+
+    pub fn active_pv_binary(&self) -> Utf8PathBuf {
+        self.bin().join("pv")
+    }
+
     pub fn run(&self) -> &Utf8Path {
         &self.run
+    }
+
+    pub fn update_lock(&self) -> Utf8PathBuf {
+        self.run().join("update.lock")
     }
 
     pub fn daemon_socket(&self) -> Utf8PathBuf {

--- a/crates/state/src/update_lock.rs
+++ b/crates/state/src/update_lock.rs
@@ -29,13 +29,6 @@ impl UpdateLock {
             Err(error) => Err(StateError::filesystem(path, io::Error::from(error))),
         }
     }
-
-    pub fn check_available(paths: &PvPaths) -> Result<(), StateError> {
-        let lock = Self::acquire(paths)?;
-        drop(lock);
-
-        Ok(())
-    }
 }
 
 #[expect(

--- a/crates/state/src/update_lock.rs
+++ b/crates/state/src/update_lock.rs
@@ -1,0 +1,53 @@
+use std::io;
+
+use camino::Utf8Path;
+use rustix::fs::FlockOperation;
+
+use crate::{PvPaths, StateError, fs};
+
+#[derive(Debug)]
+#[expect(
+    clippy::disallowed_types,
+    reason = "update lock guard owns the OS-locked file handle"
+)]
+pub struct UpdateLock {
+    _file: std::fs::File,
+}
+
+impl UpdateLock {
+    pub fn acquire(paths: &PvPaths) -> Result<Self, StateError> {
+        fs::ensure_user_dir(paths.run())?;
+        let path = paths.update_lock();
+        let file = open_update_lock_file(&path)?;
+        fs::secure_sensitive_file(&path)?;
+
+        match rustix::fs::flock(&file, FlockOperation::NonBlockingLockExclusive) {
+            Ok(()) => Ok(Self { _file: file }),
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                Err(StateError::UpdateInProgress { path })
+            }
+            Err(error) => Err(StateError::filesystem(path, io::Error::from(error))),
+        }
+    }
+
+    pub fn check_available(paths: &PvPaths) -> Result<(), StateError> {
+        let lock = Self::acquire(paths)?;
+        drop(lock);
+
+        Ok(())
+    }
+}
+
+#[expect(
+    clippy::disallowed_types,
+    reason = "update lock helper owns direct file handles for OS locking"
+)]
+fn open_update_lock_file(path: &Utf8Path) -> Result<std::fs::File, StateError> {
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|source| StateError::filesystem(path.to_path_buf(), source))
+}

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -7,12 +7,12 @@ use insta::{Settings, assert_debug_snapshot};
 use rusqlite::{Connection, params};
 use state::testing::Migration;
 use state::{
-    Database, EnvContextValues, GATEWAY_HTTP_PREFERRED_PORT, GATEWAY_HTTPS_PREFERRED_PORT,
-    GatewayPort, JobStatus, ManagedResourceDesiredState, ManagedResourceTrackInstallInput,
-    ManagedResourceTrackRemovalInput, PortOwner, PortRequest, ProjectEnvObservedStatus,
-    ProjectEnvObservedWarningInput, ProjectManagedResourceInput, ProjectRecord, PvPaths,
-    RUNTIME_PORT_FALLBACK_END, RUNTIME_PORT_FALLBACK_START, ResourceAllocationInput,
-    RuntimeObservedStatus, RuntimeSubject, StateError,
+    AppReleaseLayout, Database, EnvContextValues, GATEWAY_HTTP_PREFERRED_PORT,
+    GATEWAY_HTTPS_PREFERRED_PORT, GatewayPort, JobStatus, ManagedResourceDesiredState,
+    ManagedResourceTrackInstallInput, ManagedResourceTrackRemovalInput, PortOwner, PortRequest,
+    ProjectEnvObservedStatus, ProjectEnvObservedWarningInput, ProjectManagedResourceInput,
+    ProjectRecord, PvPaths, RUNTIME_PORT_FALLBACK_END, RUNTIME_PORT_FALLBACK_START,
+    ResourceAllocationInput, RuntimeObservedStatus, RuntimeSubject, StateError, UpdateLock,
 };
 
 #[test]
@@ -123,6 +123,25 @@ fn pv_paths_include_gateway_and_worker_runtime_artifacts() {
 }
 
 #[test]
+fn pv_paths_include_self_update_artifacts() {
+    let paths = PvPaths::for_home("/Users/alice");
+
+    assert_eq!(
+        paths.app_releases_dir().as_str(),
+        "/Users/alice/.pv/bin/releases"
+    );
+    assert_eq!(
+        paths.app_release_binary("0.2.0").as_str(),
+        "/Users/alice/.pv/bin/releases/0.2.0/pv"
+    );
+    assert_eq!(paths.active_pv_binary().as_str(), "/Users/alice/.pv/bin/pv");
+    assert_eq!(
+        paths.update_lock().as_str(),
+        "/Users/alice/.pv/run/update.lock"
+    );
+}
+
+#[test]
 fn layout_creates_expected_directories_with_user_only_modes() -> Result<()> {
     let tempdir = tempdir()?;
     let paths = PvPaths::for_home(tempdir.path().join("home"));
@@ -130,6 +149,82 @@ fn layout_creates_expected_directories_with_user_only_modes() -> Result<()> {
     state::fs::ensure_layout(&paths)?;
 
     assert_debug_snapshot!(state::fs::inspect_layout(&paths)?);
+
+    Ok(())
+}
+
+#[test]
+fn app_release_layout_installs_fixture_binaries_and_updates_active_symlink() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let layout = AppReleaseLayout::new(paths.clone());
+    let first_source = tempdir.path().join("pv-0.1.0");
+    let second_source = tempdir.path().join("pv-0.2.0");
+    state::fs::write_sensitive_file(&first_source, "pv 0.1.0\n")?;
+    state::fs::write_sensitive_file(&second_source, "pv 0.2.0\n")?;
+
+    let first = layout.install_release_binary("0.1.0", &first_source)?;
+    layout.activate_release("0.1.0")?;
+    let second = layout.install_release_binary("0.2.0", &second_source)?;
+    layout.activate_release("0.2.0")?;
+
+    assert_eq!(first.version(), "0.1.0");
+    assert_eq!(second.version(), "0.2.0");
+    assert_eq!(layout.active_release()?, Some("0.2.0".to_string()));
+    assert_eq!(
+        state::fs::read_to_string(&paths.app_release_binary("0.1.0"))?,
+        "pv 0.1.0\n"
+    );
+    assert_eq!(
+        state::fs::read_to_string(&paths.app_release_binary("0.2.0"))?,
+        "pv 0.2.0\n"
+    );
+
+    let mut release_entries = state::fs::read_dir_paths(&paths.app_releases_dir())?
+        .into_iter()
+        .map(|path| path.file_name().unwrap_or("").to_string())
+        .collect::<Vec<_>>();
+    release_entries.sort();
+    assert_eq!(release_entries, vec!["0.1.0", "0.2.0"]);
+
+    Ok(())
+}
+
+#[test]
+fn app_release_layout_rejects_unsafe_versions() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let layout = AppReleaseLayout::new(paths);
+    let source = tempdir.path().join("pv");
+    state::fs::write_sensitive_file(&source, "pv\n")?;
+
+    for version in ["", ".", "..", "../0.2.0", "0.2.0/pv", "0.2.0\\pv"] {
+        assert!(matches!(
+            layout.install_release_binary(version, &source),
+            Err(StateError::InvalidAppReleaseVersion { .. })
+        ));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn update_lock_rejects_concurrent_holder_and_ignores_stale_file() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    state::fs::write_sensitive_file(&paths.update_lock(), "leftover lock file\n")?;
+
+    let first = UpdateLock::acquire(&paths)?;
+    let second = UpdateLock::acquire(&paths);
+
+    assert!(matches!(
+        second,
+        Err(StateError::UpdateInProgress { path }) if path == paths.update_lock()
+    ));
+
+    drop(first);
+    let reacquired = UpdateLock::acquire(&paths)?;
+    drop(reacquired);
 
     Ok(())
 }

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::os::unix::fs::PermissionsExt;
 
 use anyhow::{Result, anyhow};
 use camino::Utf8Path;
@@ -179,6 +180,8 @@ fn app_release_layout_installs_fixture_binaries_and_updates_active_symlink() -> 
         state::fs::read_to_string(&paths.app_release_binary("0.2.0"))?,
         "pv 0.2.0\n"
     );
+    assert_eq!(file_mode(&paths.app_release_binary("0.1.0"))?, "700");
+    assert_eq!(file_mode(&paths.app_release_binary("0.2.0"))?, "700");
 
     let mut release_entries = state::fs::read_dir_paths(&paths.app_releases_dir())?
         .into_iter()
@@ -188,6 +191,16 @@ fn app_release_layout_installs_fixture_binaries_and_updates_active_symlink() -> 
     assert_eq!(release_entries, vec!["0.1.0", "0.2.0"]);
 
     Ok(())
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "state foundation tests inspect fixture file permissions"
+)]
+fn file_mode(path: &Utf8Path) -> Result<String> {
+    let mode = std::fs::metadata(path)?.permissions().mode() & 0o777;
+
+    Ok(format!("{mode:o}"))
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Document the v1 PV app update manifest schema and the PR22B-only implementation boundary in DESIGN.md.
- Add a typed self-update manifest parser with stable-channel validation, current-platform asset selection, checksum/URL/size/timestamp validation, and compatibility checks.
- Add app release layout helpers plus an OS-level update lock that rejects foreground and background mutating daemon reconciliation while keeping health available.

## Out of scope
- No `pv update`, `pv update --check`, binary download/swap, daemon restart coordination, rollback, installer/release metadata generation, Managed Resource update orchestration, artifact recipe changes, or runtime channel selection.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo nextest run -p self-update -p state -p daemon --all-features --locked`
- `cargo insta pending-snapshots --workspace`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-update infrastructure with manifest parsing and validation for app release management.
  * Implemented update lock mechanism to prevent concurrent update operations.
  * Daemon reconciliation now respects active updates, deferring work when updates are in progress.

* **Chores**
  * Extended workspace configuration to include self-update crate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->