### PR TITLE
[codex] Generate project TLS certificates

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -971,7 +971,7 @@ Version/track fields may be YAML strings or numbers. PV normalizes them to strin
 
 Project config can request Managed Resource tracks and define environment variable mappings for a Project. The mappings may use PV-provided placeholder values such as resource username, password, database, bucket, prefix, endpoint, and assigned port.
 
-Project config can declare additional Project hostnames with `hostnames:`. These hostnames are routed to the same Project and included in that Project's certificate SANs. `hostnames:` is additive and does not include or redefine the primary Project hostname, which comes from `pv link --hostname` or the directory-derived default. Additional hostnames must be full `.test` hostnames; PV v1 rejects non-`.test` hostnames and wildcard hostnames.
+Project config can declare additional Project hostnames with `hostnames:`. These hostnames are routed to the same Project and receive Gateway TLS certificates for their own hostnames. `hostnames:` is additive and does not include or redefine the primary Project hostname, which comes from `pv link --hostname` or the directory-derived default. Additional hostnames must be full `.test` hostnames; PV v1 rejects non-`.test` hostnames and wildcard hostnames.
 
 All hostnames in PV's desired routing table are unique across primary and additional hostnames. If an additional hostname conflicts with another Project's primary or additional hostname, the Project config is invalid. If `pv link --hostname` tries to use a hostname that is already primary or additional for another Project, it fails with a clear collision error. PV keeps serving the last valid desired state and surfaces conflicts in `pv list` and `pv status`.
 
@@ -1084,6 +1084,12 @@ Project config env values support PV's simple placeholder syntax: `${name}`. PV 
 Placeholder names must use lowercase snake_case, such as `${project_url}`, `${access_key}`, `${secret_key}`, and `${smtp_port}`.
 
 `${project_url}` renders the URL for the primary Project hostname, such as `https://acme.test`. It does not vary by additional hostnames.
+
+`${tls_key}` renders the stable PV-owned path to the TLS private key for the Project's primary hostname. `${tls_cert}` renders the stable PV-owned path to the TLS certificate chain for the Project's primary hostname. `${tls_ca}` renders the path to PV's local CA certificate. PV must never expose the local CA private key through Project env placeholders.
+
+TLS placeholders are scoped to the primary Project hostname only. They do not render files for additional `hostnames:`, do not imply wildcard certificate support, and do not imply wildcard Project routing. Additional hostnames remain explicit Gateway routes with Gateway-managed TLS certificates.
+
+PV owns stable Project TLS files under Project-specific storage in `~/.pv/certificates/` and refreshes them during reconciliation when the Project's primary hostname or local CA changes. Placeholder values must not point at Caddy/FrankenPHP's internal certificate storage; that layout is an implementation detail of the managed Gateway.
 
 Unknown placeholders fail Project config validation. PV keeps serving the last valid desired state and surfaces the validation error in `pv list` and `pv status`.
 

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -1117,24 +1117,24 @@ the owner of the agent ecosystem.
 
 ## Project TLS Placeholders
 
-PV should expose stable Project TLS file paths as env placeholders instead of
-building framework-specific integrations for every frontend tool.
+Status: accepted into `DESIGN.md`. PV should expose stable Project TLS file
+paths as env placeholders instead of building framework-specific integrations
+for every frontend tool.
 
-Possible placeholders:
+The first version should expose only primary-hostname TLS material:
 
 ```yaml
 env:
-  APP_URL: "${project_url}"
   VITE_DEV_SERVER_KEY: "${tls_key}"
   VITE_DEV_SERVER_CERT: "${tls_cert}"
   PV_TLS_CA: "${tls_ca}"
 ```
 
-The concrete placeholders should be:
+The concrete placeholders are:
 
-- `${tls_key}`: path to the Project TLS private key
-- `${tls_cert}`: path to the Project TLS certificate
-- `${tls_ca}`: path to PV's local CA certificate, if exposed
+- `${tls_key}`: path to the Project primary-hostname TLS private key
+- `${tls_cert}`: path to the Project primary-hostname TLS certificate chain
+- `${tls_ca}`: path to PV's local CA certificate
 
 `${tls_ca}` should point only to the CA certificate. PV must never expose the CA
 private key through Project env placeholders.
@@ -1163,12 +1163,14 @@ Do not make Caddy/FrankenPHP's internal certificate storage part of PV's public
 contract.
 
 The current design says the Gateway uses PV's local CA and Caddy/FrankenPHP
-generates Project certificates as needed. For placeholders, PV probably needs a
-deliberate export or generation path with stable filenames under PV-owned
-storage, such as a future `~/.pv/certificates/projects/...` layout.
+generates Project certificates as needed. For placeholders, PV needs a deliberate
+export or generation path with stable filenames under PV-owned storage, such as
+a future `~/.pv/certificates/projects/...` layout.
 
-The exact storage path can wait for implementation design, but the env contract
-should be stable from the user's point of view.
+The exact storage path, whether stable files are symlinks or exported copies,
+and when reconciliation forces or refreshes certificate material can wait for
+implementation design. The env contract should be stable from the user's point
+of view.
 
 ### Boundaries
 
@@ -1178,6 +1180,8 @@ This should not turn into:
 - automatic edits to `webpack.mix.js`
 - frontend build tool detection
 - JS dev server process management
+- JS dev server path-proxying through the Gateway
+- wildcard certificate or wildcard routing support in the first version
 - a PV plugin ecosystem for frontend TLS
 
 If a Project wants custom behavior, it can use normal env mappings and its own

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -105,6 +105,7 @@ pub(crate) fn unlink(
     let paths = pv_paths(environment)?;
     let mut database = Database::open(&paths)?;
     let project = resolve_project(&database, args.hostname.as_deref(), environment)?;
+    delete_optional_project_tls_dir(&paths, &project)?;
     let project = database.unlink_project(&project.id)?;
     let mut output = Output::new(stdout, OutputMode::plain());
 
@@ -115,6 +116,19 @@ pub(crate) fn unlink(
     request_system_reconciliation(&paths, &mut output)?;
 
     Ok(ExitCode::SUCCESS)
+}
+
+fn delete_optional_project_tls_dir(
+    paths: &PvPaths,
+    project: &ProjectRecord,
+) -> Result<(), ExecuteError> {
+    match state::fs::delete_dir_all(&paths.project_tls_dir(&project.id)) {
+        Ok(()) => Ok(()),
+        Err(StateError::Filesystem { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+            Ok(())
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 pub(crate) fn open(

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -162,7 +162,7 @@ pub(crate) fn env(
     )?;
     config::validate_project_env_shape(&config_file.config)?;
 
-    let context = project_env_context(database.project_env_context(&project.id)?);
+    let context = project_env_context(&paths, database.project_env_context(&project.id)?);
     let rendered = config::render_project_env(&config_file.config, &context)?;
     let existing_env = read_project_env_file(&project.path)?;
     let transform = config::transform_managed_env_block(existing_env.as_deref(), &rendered)?;
@@ -346,9 +346,14 @@ fn daemon_is_unavailable(error: &io::Error) -> bool {
     )
 }
 
-fn project_env_context(context: ProjectEnvStateContext) -> ProjectEnvContext {
+fn project_env_context(paths: &PvPaths, context: ProjectEnvStateContext) -> ProjectEnvContext {
+    let project_id = context.project_id;
+
     ProjectEnvContext {
         primary_hostname: context.primary_hostname,
+        tls_ca_path: paths.ca_certificate().to_string(),
+        tls_cert_path: paths.project_tls_certificate(&project_id).to_string(),
+        tls_key_path: paths.project_tls_private_key(&project_id).to_string(),
         resources: context
             .resources
             .into_iter()

--- a/crates/cli/tests/project_env.rs
+++ b/crates/cli/tests/project_env.rs
@@ -9,7 +9,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::tempdir;
 use cli::{Environment, run_with_environment};
 use config::ProjectConfigFile;
-use insta::assert_debug_snapshot;
+use insta::{Settings, assert_debug_snapshot};
 use state::{
     Database, EnvContextValues, LinkProjectInput, ProjectManagedResourceInput, ProjectRecord,
     PvPaths, ResourceAllocationInput,
@@ -69,7 +69,13 @@ fn project_env_renders_current_project_values_to_stdout() -> anyhow::Result<()> 
     create_dir(&nested)?;
     write_file(
         &project.join("pv.yml"),
-        "env:\n  APP_URL: \"${project_url}\"\n  APP_ENV: local\n",
+        r#"env:
+  APP_URL: "${project_url}"
+  APP_ENV: local
+  VITE_DEV_SERVER_KEY: "${tls_key}"
+  VITE_DEV_SERVER_CERT: "${tls_cert}"
+  PV_TLS_CA: "${tls_ca}"
+"#,
     )?;
     let project_record = register_project(&home, &project, "acme.test")?;
     let environment = TestEnvironment::new(&home, &project_record.path.join("nested"));
@@ -78,7 +84,13 @@ fn project_env_renders_current_project_values_to_stdout() -> anyhow::Result<()> 
 
     assert_eq!(output.exit_code, ExitCode::SUCCESS);
     assert!(output.stderr.is_empty());
-    assert_debug_snapshot!(output);
+    let mut settings = Settings::clone_current();
+    settings.add_filter(tempdir.path().as_str(), "<tempdir>");
+    settings.add_filter("/private<tempdir>", "<tempdir>");
+    settings.add_filter(project_record.id.as_str(), "<project-id>");
+    settings.bind(|| {
+        assert_debug_snapshot!(output);
+    });
 
     Ok(())
 }

--- a/crates/cli/tests/project_unlink.rs
+++ b/crates/cli/tests/project_unlink.rs
@@ -1,0 +1,130 @@
+use std::ffi::OsString;
+use std::io;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use camino::Utf8Path;
+use camino_tempfile::tempdir;
+use cli::{Environment, run_with_environment};
+use insta::{Settings, assert_debug_snapshot};
+use state::{Database, LinkProjectInput, ProjectRecord, PvPaths};
+
+#[derive(Debug)]
+struct TestEnvironment {
+    home: PathBuf,
+    current_dir: PathBuf,
+}
+
+impl TestEnvironment {
+    fn new(home: &Utf8Path, current_dir: &Utf8Path) -> Self {
+        Self {
+            home: home.as_std_path().to_path_buf(),
+            current_dir: current_dir.as_std_path().to_path_buf(),
+        }
+    }
+}
+
+impl Environment for TestEnvironment {
+    fn var_os(&self, _key: &str) -> Option<OsString> {
+        None
+    }
+
+    fn home_dir(&self) -> Option<PathBuf> {
+        Some(self.home.clone())
+    }
+
+    fn current_dir(&self) -> io::Result<PathBuf> {
+        Ok(self.current_dir.clone())
+    }
+
+    fn current_exe(&self) -> io::Result<PathBuf> {
+        Ok(PathBuf::from("/bin/pv"))
+    }
+
+    fn stdin_is_terminal(&self) -> bool {
+        false
+    }
+
+    fn read_line(&self) -> io::Result<String> {
+        Ok(String::new())
+    }
+
+    fn open_url(&self, _url: &str) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn unlink_removes_project_tls_directory() -> anyhow::Result<()> {
+    let tempdir = tempdir()?;
+    let home = tempdir.path().join("home");
+    let project_path = tempdir.path().join("acme");
+    let paths = PvPaths::for_home(home.clone());
+    let project = seed_project(&paths, &project_path)?;
+    let project_tls_dir = paths.project_tls_dir(&project.id);
+    state::fs::write_sensitive_file(
+        &paths.project_tls_certificate(&project.id),
+        "test certificate\n",
+    )?;
+    state::fs::write_sensitive_file(&paths.project_tls_private_key(&project.id), "test key\n")?;
+    let environment = TestEnvironment::new(&home, &project_path);
+
+    let output = run_pv(&["unlink", "acme.test"], &environment)?;
+    let database = Database::open(&paths)?;
+
+    assert_eq!(output.exit_code, ExitCode::SUCCESS);
+    assert!(output.stderr.is_empty());
+    assert!(database.project_by_id(&project.id)?.is_none());
+    assert!(!path_exists(&project_tls_dir));
+    assert!(path_exists(&project.path));
+
+    let mut settings = Settings::clone_current();
+    settings.add_filter(tempdir.path().as_str(), "<tempdir>");
+    settings.add_filter("/private<tempdir>", "<tempdir>");
+    settings.bind(|| {
+        assert_debug_snapshot!((&output.exit_code, &output.stdout, &output.stderr));
+    });
+
+    Ok(())
+}
+
+fn seed_project(paths: &PvPaths, project_path: &Utf8Path) -> anyhow::Result<ProjectRecord> {
+    state::fs::write_sensitive_file(&project_path.join("pv.yml"), "php: 8.4\n")?;
+
+    let mut database = Database::open(paths)?;
+    let project = database
+        .link_project(LinkProjectInput {
+            path: project_path.to_path_buf(),
+            original_path: project_path.to_path_buf(),
+            primary_hostname: "acme.test".to_string(),
+            config_path: project_path.join("pv.yml"),
+            desired_php_track: Some("8.4".to_string()),
+            additional_hostnames: Vec::new(),
+        })?
+        .project;
+
+    Ok(project)
+}
+
+struct RunOutput {
+    exit_code: ExitCode,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_pv(args: &[&str], environment: &impl Environment) -> anyhow::Result<RunOutput> {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let args = std::iter::once("pv").chain(args.iter().copied());
+    let exit_code = run_with_environment(args, environment, &mut stdout, &mut stderr)?;
+
+    Ok(RunOutput {
+        exit_code,
+        stdout: String::from_utf8(stdout)?,
+        stderr: String::from_utf8(stderr)?,
+    })
+}
+
+fn path_exists(path: &Utf8Path) -> bool {
+    path.exists()
+}

--- a/crates/cli/tests/snapshots/project_env__project_env_renders_current_project_values_to_stdout.snap
+++ b/crates/cli/tests/snapshots/project_env__project_env_renders_current_project_values_to_stdout.snap
@@ -8,6 +8,6 @@ RunOutput {
             0,
         ),
     ),
-    stdout: "APP_ENV=local\nAPP_URL=https://acme.test\n",
+    stdout: "APP_ENV=local\nAPP_URL=https://acme.test\nPV_TLS_CA=<tempdir>/home/.pv/certificates/ca.pem\nVITE_DEV_SERVER_CERT=<tempdir>/home/.pv/certificates/projects/<project-id>/tls.crt\nVITE_DEV_SERVER_KEY=<tempdir>/home/.pv/certificates/projects/<project-id>/tls.key\n",
     stderr: "",
 }

--- a/crates/cli/tests/snapshots/project_unlink__unlink_removes_project_tls_directory.snap
+++ b/crates/cli/tests/snapshots/project_unlink__unlink_removes_project_tls_directory.snap
@@ -1,0 +1,13 @@
+---
+source: crates/cli/tests/project_unlink.rs
+expression: "(&output.exit_code, &output.stdout, &output.stderr)"
+---
+(
+    ExitCode(
+        unix_exit_status(
+            0,
+        ),
+    ),
+    "Unlinked acme.test -> <tempdir>/acme\nwarning: PV daemon is not running; reconciliation will run after `pv setup` starts it\n",
+    "",
+)

--- a/crates/config/benches/config.rs
+++ b/crates/config/benches/config.rs
@@ -121,6 +121,9 @@ fn render_inputs() -> (ProjectConfig, ProjectEnvContext) {
 
     let context = ProjectEnvContext {
         primary_hostname: "acme.test".to_string(),
+        tls_ca_path: "/Users/alice/.pv/certificates/ca.pem".to_string(),
+        tls_cert_path: "/Users/alice/.pv/certificates/projects/project123/tls.crt".to_string(),
+        tls_key_path: "/Users/alice/.pv/certificates/projects/project123/tls.key".to_string(),
         resources,
     };
 

--- a/crates/config/src/env.rs
+++ b/crates/config/src/env.rs
@@ -11,6 +11,9 @@ const CREATED_PROJECT_ENV_FILE_MODE: u32 = 0o600;
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ProjectEnvContext {
     pub primary_hostname: String,
+    pub tls_ca_path: String,
+    pub tls_cert_path: String,
+    pub tls_key_path: String,
     pub resources: BTreeMap<String, ResourceEnvContext>,
 }
 
@@ -261,6 +264,15 @@ fn project_context_values(
         "project_url".to_string(),
         format!("https://{}", context.primary_hostname),
     );
+    if !context.tls_ca_path.is_empty() {
+        values.insert("tls_ca".to_string(), context.tls_ca_path.clone());
+    }
+    if !context.tls_cert_path.is_empty() {
+        values.insert("tls_cert".to_string(), context.tls_cert_path.clone());
+    }
+    if !context.tls_key_path.is_empty() {
+        values.insert("tls_key".to_string(), context.tls_key_path.clone());
+    }
 
     Ok(values)
 }

--- a/crates/config/src/model.rs
+++ b/crates/config/src/model.rs
@@ -102,6 +102,63 @@ impl ProjectConfig {
                         .any(|allocation| !allocation.env.is_empty())
             })
     }
+
+    pub fn uses_tls_placeholders(&self) -> bool {
+        self.env
+            .values()
+            .any(|value| value_uses_tls_placeholder(value))
+            || self.resources.values().any(|resource| {
+                resource
+                    .env
+                    .values()
+                    .any(|value| value_uses_tls_placeholder(value))
+                    || resource.allocations.values().any(|allocation| {
+                        allocation
+                            .env
+                            .values()
+                            .any(|value| value_uses_tls_placeholder(value))
+                    })
+            })
+    }
+}
+
+fn value_uses_tls_placeholder(value: &str) -> bool {
+    let characters = value.chars().collect::<Vec<_>>();
+    let mut index = 0;
+
+    while index < characters.len() {
+        if characters[index] != '$' {
+            index += 1;
+            continue;
+        }
+
+        if characters.get(index + 1) == Some(&'$') {
+            index += 2;
+            continue;
+        }
+
+        if characters.get(index + 1) != Some(&'{') {
+            index += 1;
+            continue;
+        }
+
+        let Some(end_index) = characters[index + 2..]
+            .iter()
+            .position(|character| *character == '}')
+            .map(|offset| index + 2 + offset)
+        else {
+            index += 2;
+            continue;
+        };
+        let placeholder = characters[index + 2..end_index].iter().collect::<String>();
+        if matches!(placeholder.as_str(), "tls_ca" | "tls_cert" | "tls_key") {
+            return true;
+        }
+
+        index = end_index + 1;
+    }
+
+    false
 }
 
 fn serialize_optional_path<S>(path: &Option<Utf8PathBuf>, serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/config/src/parser.rs
+++ b/crates/config/src/parser.rs
@@ -10,7 +10,7 @@ use yaml_serde::{Mapping, Number, Value};
 use crate::hostname::normalize_additional_hostname;
 use crate::{AllocationConfig, ConfigError, PhpConfig, ProjectConfig, ResourceConfig};
 
-const PROJECT_ENV_PLACEHOLDERS: &[&str] = &["project_url"];
+const PROJECT_ENV_PLACEHOLDERS: &[&str] = &["project_url", "tls_ca", "tls_cert", "tls_key"];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum EnvPlaceholderScope<'a> {

--- a/crates/config/tests/project_config.rs
+++ b/crates/config/tests/project_config.rs
@@ -190,6 +190,12 @@ fn project_config_rejects_invalid_env_placeholders() -> Result<()> {
             if placeholder == "ProjectUrl"
     ));
     assert!(ProjectConfig::parse("env:\n  APP_URL: \"$${missing_value}\"\n").is_ok());
+    assert!(
+        ProjectConfig::parse(
+            "env:\n  VITE_DEV_SERVER_KEY: \"${tls_key}\"\n  VITE_DEV_SERVER_CERT: \"${tls_cert}\"\n  PV_TLS_CA: \"${tls_ca}\"\n"
+        )
+        .is_ok()
+    );
     assert!(ProjectConfig::parse("rustfs:\n  env:\n    PUBLIC_URL: \"${url}\"\n").is_ok());
 
     Ok(())
@@ -204,6 +210,17 @@ fn project_config_validates_url_placeholder_scopes() {
                 r#"
 env:
   APP_URL: "${project_url}"
+"#,
+            ),
+        ),
+        (
+            "tls-placeholders-project-env",
+            ProjectConfig::parse(
+                r#"
+env:
+  VITE_DEV_SERVER_KEY: "${tls_key}"
+  VITE_DEV_SERVER_CERT: "${tls_cert}"
+  PV_TLS_CA: "${tls_ca}"
 "#,
             ),
         ),
@@ -236,6 +253,18 @@ mysql:
             ),
         ),
         (
+            "resource-project-tls",
+            ProjectConfig::parse(
+                r#"
+mysql:
+  env:
+    VITE_DEV_SERVER_KEY: "${tls_key}"
+    VITE_DEV_SERVER_CERT: "${tls_cert}"
+    PV_TLS_CA: "${tls_ca}"
+"#,
+            ),
+        ),
+        (
             "resource-scoped-url",
             ProjectConfig::parse(
                 r#"
@@ -264,6 +293,20 @@ mysql:
     app:
       env:
         APP_URL: "${project_url}"
+"#,
+            ),
+        ),
+        (
+            "allocation-project-tls",
+            ProjectConfig::parse(
+                r#"
+mysql:
+  allocations:
+    app:
+      env:
+        VITE_DEV_SERVER_KEY: "${tls_key}"
+        VITE_DEV_SERVER_CERT: "${tls_cert}"
+        PV_TLS_CA: "${tls_ca}"
 "#,
             ),
         ),

--- a/crates/config/tests/project_config.rs
+++ b/crates/config/tests/project_config.rs
@@ -340,6 +340,25 @@ mysql:
 }
 
 #[test]
+fn project_config_reports_tls_placeholder_usage() -> Result<()> {
+    let project_tls = ProjectConfig::parse("env:\n  VITE_DEV_SERVER_KEY: \"${tls_key}\"\n")?;
+    let resource_tls = ProjectConfig::parse("mysql:\n  env:\n    TLS_CERT: \"${tls_cert}\"\n")?;
+    let allocation_tls = ProjectConfig::parse(
+        "postgres:\n  allocations:\n    app:\n      env:\n        TLS_CA: \"${tls_ca}\"\n",
+    )?;
+    let escaped_tls = ProjectConfig::parse("env:\n  LITERAL: \"$${tls_key}\"\n")?;
+    let no_tls = ProjectConfig::parse("env:\n  APP_URL: \"${project_url}\"\n")?;
+
+    assert!(project_tls.uses_tls_placeholders());
+    assert!(resource_tls.uses_tls_placeholders());
+    assert!(allocation_tls.uses_tls_placeholders());
+    assert!(!escaped_tls.uses_tls_placeholders());
+    assert!(!no_tls.uses_tls_placeholders());
+
+    Ok(())
+}
+
+#[test]
 fn project_config_rejects_env_placeholders_outside_scope() -> Result<()> {
     assert!(matches!(
         ProjectConfig::parse("env:\n  DB_DATABASE: \"${database}\"\n"),

--- a/crates/config/tests/project_env.rs
+++ b/crates/config/tests/project_env.rs
@@ -21,6 +21,9 @@ mysql:
     )?;
     let context = ProjectEnvContext {
         primary_hostname: "acme.test".to_string(),
+        tls_ca_path: "/Users/alice/.pv/certificates/ca.pem".to_string(),
+        tls_cert_path: "/Users/alice/.pv/certificates/projects/project123/tls.crt".to_string(),
+        tls_key_path: "/Users/alice/.pv/certificates/projects/project123/tls.key".to_string(),
         resources: BTreeMap::new(),
     };
 
@@ -193,6 +196,62 @@ mysql:
             .map(String::as_str),
         Some("https://primary.acme.test")
     );
+    assert_debug_snapshot!((&rendered, format_project_env(&rendered)));
+
+    Ok(())
+}
+
+#[test]
+fn project_env_renderer_resolves_tls_paths_across_scopes() -> Result<()> {
+    let config = ProjectConfig::parse(
+        r#"
+env:
+  ROOT_TLS_KEY: "${tls_key}"
+  ROOT_TLS_CERT: "${tls_cert}"
+  ROOT_TLS_CA: "${tls_ca}"
+mysql:
+  env:
+    RESOURCE_TLS_KEY: "${tls_key}"
+    RESOURCE_TLS_CERT: "${tls_cert}"
+    RESOURCE_TLS_CA: "${tls_ca}"
+  allocations:
+    app:
+      env:
+        ALLOCATION_TLS_KEY: "${tls_key}"
+        ALLOCATION_TLS_CERT: "${tls_cert}"
+        ALLOCATION_TLS_CA: "${tls_ca}"
+"#,
+    )?;
+    let context = project_context(&[(
+        "mysql",
+        ResourceEnvContext {
+            track: "8.4".to_string(),
+            values: values(&[
+                ("host", "127.0.0.1"),
+                ("password", "secret"),
+                ("port", "3306"),
+                ("tls_key", "/unexpected/resource.key"),
+                ("tls_cert", "/unexpected/resource.crt"),
+                ("tls_ca", "/unexpected/resource-ca.pem"),
+                ("username", "root"),
+            ]),
+            allocations: allocations(&[(
+                "app",
+                AllocationEnvContext {
+                    generated_name: "acme_test_app".to_string(),
+                    values: values(&[
+                        ("database", "acme_test_app"),
+                        ("tls_key", "/unexpected/allocation.key"),
+                        ("tls_cert", "/unexpected/allocation.crt"),
+                        ("tls_ca", "/unexpected/allocation-ca.pem"),
+                    ]),
+                },
+            )]),
+        },
+    )]);
+
+    let rendered = render_project_env(&config, &context)?;
+
     assert_debug_snapshot!((&rendered, format_project_env(&rendered)));
 
     Ok(())
@@ -549,6 +608,9 @@ fn project_context_with_primary(
 ) -> ProjectEnvContext {
     ProjectEnvContext {
         primary_hostname: primary_hostname.to_string(),
+        tls_ca_path: "/Users/alice/.pv/certificates/ca.pem".to_string(),
+        tls_cert_path: "/Users/alice/.pv/certificates/projects/project123/tls.crt".to_string(),
+        tls_key_path: "/Users/alice/.pv/certificates/projects/project123/tls.key".to_string(),
         resources: resources
             .iter()
             .map(|(resource, context)| ((*resource).to_string(), context.clone()))

--- a/crates/config/tests/snapshots/project_config__project_config_validates_url_placeholder_scopes.snap
+++ b/crates/config/tests/snapshots/project_config__project_config_validates_url_placeholder_scopes.snap
@@ -18,6 +18,22 @@ expression: cases
         ),
     ),
     (
+        "tls-placeholders-project-env",
+        Ok(
+            ProjectConfig {
+                php: None,
+                document_root: None,
+                hostnames: [],
+                env: {
+                    "PV_TLS_CA": "${tls_ca}",
+                    "VITE_DEV_SERVER_CERT": "${tls_cert}",
+                    "VITE_DEV_SERVER_KEY": "${tls_key}",
+                },
+                resources: {},
+            },
+        ),
+    ),
+    (
         "legacy-url-project-env",
         Err(
             UnknownEnvPlaceholder {
@@ -48,6 +64,28 @@ expression: cases
                         track: None,
                         env: {
                             "APP_URL": "${project_url}",
+                        },
+                        allocations: {},
+                    },
+                },
+            },
+        ),
+    ),
+    (
+        "resource-project-tls",
+        Ok(
+            ProjectConfig {
+                php: None,
+                document_root: None,
+                hostnames: [],
+                env: {},
+                resources: {
+                    "mysql": ResourceConfig {
+                        track: None,
+                        env: {
+                            "PV_TLS_CA": "${tls_ca}",
+                            "VITE_DEV_SERVER_CERT": "${tls_cert}",
+                            "VITE_DEV_SERVER_KEY": "${tls_key}",
                         },
                         allocations: {},
                     },
@@ -100,6 +138,32 @@ expression: cases
                             "app": AllocationConfig {
                                 env: {
                                     "APP_URL": "${project_url}",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        ),
+    ),
+    (
+        "allocation-project-tls",
+        Ok(
+            ProjectConfig {
+                php: None,
+                document_root: None,
+                hostnames: [],
+                env: {},
+                resources: {
+                    "mysql": ResourceConfig {
+                        track: None,
+                        env: {},
+                        allocations: {
+                            "app": AllocationConfig {
+                                env: {
+                                    "PV_TLS_CA": "${tls_ca}",
+                                    "VITE_DEV_SERVER_CERT": "${tls_cert}",
+                                    "VITE_DEV_SERVER_KEY": "${tls_key}",
                                 },
                             },
                         },

--- a/crates/config/tests/snapshots/project_env__project_env_renderer_resolves_tls_paths_across_scopes.snap
+++ b/crates/config/tests/snapshots/project_env__project_env_renderer_resolves_tls_paths_across_scopes.snap
@@ -1,0 +1,20 @@
+---
+source: crates/config/tests/project_env.rs
+expression: "(&rendered, format_project_env(&rendered))"
+---
+(
+    RenderedProjectEnv {
+        values: {
+            "ALLOCATION_TLS_CA": "/Users/alice/.pv/certificates/ca.pem",
+            "ALLOCATION_TLS_CERT": "/Users/alice/.pv/certificates/projects/project123/tls.crt",
+            "ALLOCATION_TLS_KEY": "/Users/alice/.pv/certificates/projects/project123/tls.key",
+            "RESOURCE_TLS_CA": "/Users/alice/.pv/certificates/ca.pem",
+            "RESOURCE_TLS_CERT": "/Users/alice/.pv/certificates/projects/project123/tls.crt",
+            "RESOURCE_TLS_KEY": "/Users/alice/.pv/certificates/projects/project123/tls.key",
+            "ROOT_TLS_CA": "/Users/alice/.pv/certificates/ca.pem",
+            "ROOT_TLS_CERT": "/Users/alice/.pv/certificates/projects/project123/tls.crt",
+            "ROOT_TLS_KEY": "/Users/alice/.pv/certificates/projects/project123/tls.key",
+        },
+    },
+    "ALLOCATION_TLS_CA=/Users/alice/.pv/certificates/ca.pem\nALLOCATION_TLS_CERT=/Users/alice/.pv/certificates/projects/project123/tls.crt\nALLOCATION_TLS_KEY=/Users/alice/.pv/certificates/projects/project123/tls.key\nRESOURCE_TLS_CA=/Users/alice/.pv/certificates/ca.pem\nRESOURCE_TLS_CERT=/Users/alice/.pv/certificates/projects/project123/tls.crt\nRESOURCE_TLS_KEY=/Users/alice/.pv/certificates/projects/project123/tls.key\nROOT_TLS_CA=/Users/alice/.pv/certificates/ca.pem\nROOT_TLS_CERT=/Users/alice/.pv/certificates/projects/project123/tls.crt\nROOT_TLS_KEY=/Users/alice/.pv/certificates/projects/project123/tls.key\n",
+)

--- a/crates/daemon/src/error.rs
+++ b/crates/daemon/src/error.rs
@@ -75,6 +75,9 @@ pub enum DaemonError {
     #[error("Managed Resource command failed: {0}")]
     ManagedResourceCommand(#[from] ManagedResourceCommandError),
 
+    #[error("platform error: {0}")]
+    Platform(#[from] platform::PlatformError),
+
     #[error("Managed Resource default installs failed: {}", default_install_failures(.failures))]
     ManagedResourceDefaultInstallFailures { failures: Vec<String> },
 

--- a/crates/daemon/src/project_env.rs
+++ b/crates/daemon/src/project_env.rs
@@ -210,7 +210,7 @@ async fn reconcile_loaded_project(
         return Ok(summary);
     }
 
-    let context = project_env_context_for_plan(database, project, &plan)?;
+    let context = project_env_context_for_plan(paths, database, project, &plan)?;
     let rendered = config::render_project_env(&config_file.config, &context)?;
     let transform = config::write_project_env_file(&project.path.join(".env"), &rendered)?;
     let mut warnings = observed_warnings(&transform.warnings);
@@ -542,6 +542,7 @@ fn apply_project_resource_plan(
 }
 
 fn project_env_context_for_plan(
+    paths: &PvPaths,
     database: &Database,
     project: &ProjectRecord,
     plan: &ProjectResourcePlan,
@@ -576,6 +577,9 @@ fn project_env_context_for_plan(
 
     Ok(ProjectEnvContext {
         primary_hostname: project.primary_hostname.clone(),
+        tls_ca_path: paths.ca_certificate().to_string(),
+        tls_cert_path: paths.project_tls_certificate(&project.id).to_string(),
+        tls_key_path: paths.project_tls_private_key(&project.id).to_string(),
         resources,
     })
 }

--- a/crates/daemon/src/project_env.rs
+++ b/crates/daemon/src/project_env.rs
@@ -210,6 +210,10 @@ async fn reconcile_loaded_project(
         return Ok(summary);
     }
 
+    if config_file.config.uses_tls_placeholders() {
+        ensure_project_tls_files(paths, project)?;
+    }
+
     let context = project_env_context_for_plan(paths, database, project, &plan)?;
     let rendered = config::render_project_env(&config_file.config, &context)?;
     let transform = config::write_project_env_file(&project.path.join(".env"), &rendered)?;
@@ -241,6 +245,49 @@ async fn reconcile_loaded_project(
     };
 
     Ok(summary)
+}
+
+fn ensure_project_tls_files(paths: &PvPaths, project: &ProjectRecord) -> Result<(), DaemonError> {
+    let ca_certificate_pem = state::fs::read_to_string(&paths.ca_certificate())?;
+    let ca_private_key_pem = state::fs::read_to_string(&paths.ca_private_key())?;
+    let certificate_path = paths.project_tls_certificate(&project.id);
+    let private_key_path = paths.project_tls_private_key(&project.id);
+    let existing_certificate_pem = read_optional_file(&certificate_path)?;
+    let existing_private_key_pem = read_optional_file(&private_key_path)?;
+
+    if let (Some(certificate_pem), Some(private_key_pem)) =
+        (&existing_certificate_pem, &existing_private_key_pem)
+        && platform::project_certificate_matches(
+            certificate_pem,
+            private_key_pem,
+            &project.primary_hostname,
+            &ca_certificate_pem,
+        )
+    {
+        return Ok(());
+    }
+
+    let generated = platform::generate_project_certificate(
+        &project.primary_hostname,
+        &ca_certificate_pem,
+        &ca_private_key_pem,
+    )?;
+    let certificate_chain_pem = format!("{}{}", generated.certificate_pem, ca_certificate_pem);
+
+    state::fs::write_sensitive_file(&certificate_path, &certificate_chain_pem)?;
+    state::fs::write_sensitive_file(&private_key_path, &generated.private_key_pem)?;
+
+    Ok(())
+}
+
+fn read_optional_file(path: &Utf8PathBuf) -> Result<Option<String>, DaemonError> {
+    match state::fs::read_to_string(path) {
+        Ok(content) => Ok(Some(content)),
+        Err(StateError::Filesystem { source, .. }) if source.kind() == io::ErrorKind::NotFound => {
+            Ok(None)
+        }
+        Err(error) => Err(error.into()),
+    }
 }
 
 fn maybe_resolve_project_php_runtime(

--- a/crates/daemon/tests/project_env_reconciliation.rs
+++ b/crates/daemon/tests/project_env_reconciliation.rs
@@ -7,6 +7,7 @@ use anyhow::{Result, anyhow};
 use camino::Utf8Path;
 use camino_tempfile::tempdir;
 use insta::{Settings, assert_debug_snapshot};
+use platform::GeneratedLocalCa;
 use serde_json::{Value, json};
 use state::fs::write_sensitive_file;
 use state::{
@@ -33,9 +34,13 @@ async fn root_only_env_rendering_writes_dotenv_and_records_rendered_state() -> R
   PV_TLS_CA: "${tls_ca}"
 "#,
     )?;
+    let local_ca = seed_local_ca(&paths)?;
 
     let lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
+    let (certificate_pem, private_key_pem) = read_project_tls_files(&paths, &project)?;
+
+    assert_project_certificate_matches(&certificate_pem, &private_key_pem, "acme.test", &local_ca);
 
     assert_with_normalized_timestamps_and_tempdir(
         "root_only_env_rendering_writes_dotenv_and_records_rendered_state",
@@ -47,6 +52,72 @@ async fn root_only_env_rendering_writes_dotenv_and_records_rendered_state() -> R
         ),
         tempdir.path(),
     )?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn tls_placeholders_generate_and_refresh_primary_hostname_certificate() -> Result<()> {
+    let tempdir = tempdir()?;
+    let paths = PvPaths::for_home(tempdir.path().join("home"));
+    let project = link_project(
+        &paths,
+        &tempdir.path().join("project"),
+        "acme.test",
+        r#"env:
+  VITE_DEV_SERVER_KEY: "${tls_key}"
+  VITE_DEV_SERVER_CERT: "${tls_cert}"
+"#,
+    )?;
+    let local_ca = seed_local_ca(&paths)?;
+
+    run_project_reconciliation(&paths, &project).await?;
+    let (initial_certificate_pem, initial_private_key_pem) =
+        read_project_tls_files(&paths, &project)?;
+
+    assert_eq!(certificate_pem_block_count(&initial_certificate_pem), 2);
+    assert_project_certificate_matches(
+        &initial_certificate_pem,
+        &initial_private_key_pem,
+        "acme.test",
+        &local_ca,
+    );
+
+    run_project_reconciliation(&paths, &project).await?;
+    let (rerun_certificate_pem, rerun_private_key_pem) = read_project_tls_files(&paths, &project)?;
+    assert_eq!(
+        (
+            initial_certificate_pem.as_str(),
+            initial_private_key_pem.as_str()
+        ),
+        (
+            rerun_certificate_pem.as_str(),
+            rerun_private_key_pem.as_str()
+        ),
+        "unchanged TLS placeholders should not rewrite Project cert files"
+    );
+
+    let renamed_project = update_project_primary_hostname(&paths, &project, "renamed.test")?;
+    run_project_reconciliation(&paths, &renamed_project).await?;
+    let (renamed_certificate_pem, renamed_private_key_pem) =
+        read_project_tls_files(&paths, &renamed_project)?;
+
+    assert_ne!(
+        renamed_certificate_pem, initial_certificate_pem,
+        "primary hostname changes should refresh the Project certificate"
+    );
+    assert_project_certificate_matches(
+        &renamed_certificate_pem,
+        &renamed_private_key_pem,
+        "renamed.test",
+        &local_ca,
+    );
+    assert!(!platform::project_certificate_matches(
+        &renamed_certificate_pem,
+        &renamed_private_key_pem,
+        "acme.test",
+        &local_ca.certificate_pem
+    ));
 
     Ok(())
 }
@@ -1389,6 +1460,15 @@ fn seed_manifest(paths: &PvPaths, default_track: &str) -> Result<()> {
     Ok(())
 }
 
+fn seed_local_ca(paths: &PvPaths) -> Result<GeneratedLocalCa> {
+    let local_ca = platform::generate_local_ca()?;
+
+    write_sensitive_file(&paths.ca_certificate(), &local_ca.certificate_pem)?;
+    write_sensitive_file(&paths.ca_private_key(), &local_ca.private_key_pem)?;
+
+    Ok(local_ca)
+}
+
 fn test_manifest(default_track: &str) -> String {
     json!({
         "schema_version": 1,
@@ -1484,6 +1564,34 @@ fn read_project_config(project: &ProjectRecord) -> Result<String> {
 
 fn read_dotenv(project: &ProjectRecord) -> Result<String> {
     state::fs::read_to_string(&project.path.join(".env")).map_err(Into::into)
+}
+
+fn read_project_tls_files(paths: &PvPaths, project: &ProjectRecord) -> Result<(String, String)> {
+    let certificate_pem = state::fs::read_to_string(&paths.project_tls_certificate(&project.id))?;
+    let private_key_pem = state::fs::read_to_string(&paths.project_tls_private_key(&project.id))?;
+
+    Ok((certificate_pem, private_key_pem))
+}
+
+fn assert_project_certificate_matches(
+    certificate_pem: &str,
+    private_key_pem: &str,
+    primary_hostname: &str,
+    local_ca: &GeneratedLocalCa,
+) {
+    assert!(
+        platform::project_certificate_matches(
+            certificate_pem,
+            private_key_pem,
+            primary_hostname,
+            &local_ca.certificate_pem,
+        ),
+        "Project certificate should match the primary hostname and current local CA"
+    );
+}
+
+fn certificate_pem_block_count(content: &str) -> usize {
+    content.matches("-----BEGIN CERTIFICATE-----").count()
 }
 
 fn read_optional_dotenv(project: &ProjectRecord) -> Result<Option<String>> {

--- a/crates/daemon/tests/project_env_reconciliation.rs
+++ b/crates/daemon/tests/project_env_reconciliation.rs
@@ -25,13 +25,19 @@ async fn root_only_env_rendering_writes_dotenv_and_records_rendered_state() -> R
         &paths,
         &tempdir.path().join("project"),
         "acme.test",
-        "env:\n  APP_URL: \"${project_url}\"\n  APP_NAME: acme\n",
+        r#"env:
+  APP_URL: "${project_url}"
+  APP_NAME: acme
+  VITE_DEV_SERVER_KEY: "${tls_key}"
+  VITE_DEV_SERVER_CERT: "${tls_cert}"
+  PV_TLS_CA: "${tls_ca}"
+"#,
     )?;
 
     let lines = run_project_reconciliation(&paths, &project).await?;
     let database = Database::open(&paths)?;
 
-    assert_with_normalized_timestamps(
+    assert_with_normalized_timestamps_and_tempdir(
         "root_only_env_rendering_writes_dotenv_and_records_rendered_state",
         (
             lines,
@@ -39,6 +45,7 @@ async fn root_only_env_rendering_writes_dotenv_and_records_rendered_state() -> R
             database.project_env_observed_state(&project.id)?,
             database.recent_jobs()?,
         ),
+        tempdir.path(),
     )?;
 
     Ok(())
@@ -1524,6 +1531,29 @@ fn assert_with_normalized_timestamps(
     let mut settings = Settings::clone_current();
     settings.add_filter(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", "<timestamp>");
     settings.add_filter(r"project:[a-z0-9]{10}", "project:<project_id>");
+    settings.add_filter(r"projects/[a-z0-9]{10}/", "projects/<project_id>/");
+    settings.add_filter(
+        r#"project_id: "[a-z0-9]{10}""#,
+        r#"project_id: "<project_id>""#,
+    );
+    settings.add_filter(r"Project `[a-z0-9]{10}`", "Project `<project_id>`");
+    settings.bind(|| {
+        assert_debug_snapshot!(name, snapshot);
+        Ok::<(), anyhow::Error>(())
+    })
+}
+
+fn assert_with_normalized_timestamps_and_tempdir(
+    name: &'static str,
+    snapshot: impl std::fmt::Debug,
+    tempdir: &Utf8Path,
+) -> Result<()> {
+    let mut settings = Settings::clone_current();
+    settings.add_filter(tempdir.as_str(), "<tempdir>");
+    settings.add_filter("/private<tempdir>", "<tempdir>");
+    settings.add_filter(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", "<timestamp>");
+    settings.add_filter(r"project:[a-z0-9]{10}", "project:<project_id>");
+    settings.add_filter(r"projects/[a-z0-9]{10}/", "projects/<project_id>/");
     settings.add_filter(
         r#"project_id: "[a-z0-9]{10}""#,
         r#"project_id: "<project_id>""#,

--- a/crates/daemon/tests/snapshots/project_env_reconciliation__root_only_env_rendering_writes_dotenv_and_records_rendered_state.snap
+++ b/crates/daemon/tests/snapshots/project_env_reconciliation__root_only_env_rendering_writes_dotenv_and_records_rendered_state.snap
@@ -33,7 +33,7 @@ expression: snapshot
             "type": String("job_completed"),
         },
     ],
-    "# >>> PV MANAGED\nAPP_NAME=acme\nAPP_URL=https://acme.test\n# <<< PV MANAGED\n",
+    "# >>> PV MANAGED\nAPP_NAME=acme\nAPP_URL=https://acme.test\nPV_TLS_CA=<tempdir>/home/.pv/certificates/ca.pem\nVITE_DEV_SERVER_CERT=<tempdir>/home/.pv/certificates/projects/<project_id>/tls.crt\nVITE_DEV_SERVER_KEY=<tempdir>/home/.pv/certificates/projects/<project_id>/tls.key\n# <<< PV MANAGED\n",
     Some(
         ProjectEnvObservedStateRecord {
             project_id: "<project_id>",

--- a/crates/daemon/tests/supervisor_foundation.rs
+++ b/crates/daemon/tests/supervisor_foundation.rs
@@ -479,8 +479,8 @@ async fn supervisor_rejects_owned_runtime_when_private_environment_changes() -> 
     let mut spec = process_spec(
         &paths,
         "private-env-runtime",
-        "/bin/sh",
-        vec!["-c".to_string(), "while true; do sleep 1; done".to_string()],
+        "/bin/sleep",
+        vec!["30".to_string()],
     );
     spec.private_environment = BTreeMap::from([(
         "RUSTFS_SECRET_KEY".to_string(),

--- a/crates/platform/src/ca.rs
+++ b/crates/platform/src/ca.rs
@@ -3,10 +3,11 @@ use std::io::Cursor;
 
 use camino::{Utf8Path, Utf8PathBuf};
 use rcgen::{
-    BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair, KeyUsagePurpose,
-    PKCS_ECDSA_P256_SHA256, PublicKeyData, date_time_ymd,
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
+    Issuer, KeyPair, KeyUsagePurpose, PKCS_ECDSA_P256_SHA256, PublicKeyData, date_time_ymd,
 };
 use sha2::{Digest, Sha256};
+use x509_parser::extensions::GeneralName;
 use x509_parser::prelude::FromDer;
 use x509_parser::prelude::X509Certificate;
 
@@ -20,6 +21,12 @@ pub struct GeneratedLocalCa {
     pub certificate_pem: String,
     pub private_key_pem: String,
     pub metadata: LocalCaMetadata,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GeneratedProjectCertificate {
+    pub certificate_pem: String,
+    pub private_key_pem: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -87,6 +94,73 @@ pub fn generate_local_ca() -> Result<GeneratedLocalCa, PlatformError> {
         private_key_pem,
         metadata,
     })
+}
+
+pub fn generate_project_certificate(
+    primary_hostname: &str,
+    ca_certificate_pem: &str,
+    ca_private_key_pem: &str,
+) -> Result<GeneratedProjectCertificate, PlatformError> {
+    let ca_key_pair = KeyPair::from_pem(ca_private_key_pem)
+        .map_err(PlatformError::ProjectCertificateGeneration)?;
+    let issuer = Issuer::from_ca_cert_pem(ca_certificate_pem, ca_key_pair)
+        .map_err(PlatformError::ProjectCertificateGeneration)?;
+    let mut params = CertificateParams::new(vec![primary_hostname.to_string()])
+        .map_err(PlatformError::ProjectCertificateGeneration)?;
+    params.not_before = date_time_ymd(2026, 1, 1);
+    params.not_after = date_time_ymd(2036, 1, 1);
+    params
+        .distinguished_name
+        .push(DnType::CommonName, primary_hostname);
+    params.use_authority_key_identifier_extension = true;
+    params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+
+    let key_pair = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+        .map_err(PlatformError::ProjectCertificateGeneration)?;
+    let certificate = params
+        .signed_by(&key_pair, &issuer)
+        .map_err(PlatformError::ProjectCertificateGeneration)?;
+
+    Ok(GeneratedProjectCertificate {
+        certificate_pem: certificate.pem(),
+        private_key_pem: key_pair.serialize_pem(),
+    })
+}
+
+pub fn project_certificate_matches(
+    certificate_chain_pem: &str,
+    private_key_pem: &str,
+    primary_hostname: &str,
+    ca_certificate_pem: &str,
+) -> bool {
+    let Ok(certificate_der) = first_certificate_der_from_pem(certificate_chain_pem) else {
+        return false;
+    };
+    let Ok(ca_certificate_der) = certificate_der_from_pem(ca_certificate_pem) else {
+        return false;
+    };
+    let Ok(key_pair) = KeyPair::from_pem(private_key_pem) else {
+        return false;
+    };
+    let Ok((_remaining, certificate)) = X509Certificate::from_der(&certificate_der) else {
+        return false;
+    };
+    let Ok((_remaining, ca_certificate)) = X509Certificate::from_der(&ca_certificate_der) else {
+        return false;
+    };
+
+    if certificate.public_key().raw != key_pair.subject_public_key_info().as_slice() {
+        return false;
+    }
+    if certificate
+        .verify_signature(Some(&ca_certificate.tbs_certificate.subject_pki))
+        .is_err()
+    {
+        return false;
+    }
+
+    certificate_has_dns_name(&certificate, primary_hostname)
 }
 
 impl LocalCaMetadata {
@@ -273,6 +347,31 @@ pub(crate) fn certificate_der_from_pem(certificate_pem: &str) -> Result<Vec<u8>,
     }
 }
 
+fn first_certificate_der_from_pem(certificate_pem: &str) -> Result<Vec<u8>, io::Error> {
+    let mut reader = Cursor::new(certificate_pem.as_bytes());
+    let mut certificates = rustls_pemfile::certs(&mut reader);
+
+    match certificates.next().transpose()? {
+        Some(certificate) => Ok(certificate.as_ref().to_vec()),
+        None => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "expected at least one certificate PEM block",
+        )),
+    }
+}
+
+fn certificate_has_dns_name(certificate: &X509Certificate<'_>, primary_hostname: &str) -> bool {
+    let Ok(Some(subject_alternative_name)) = certificate.subject_alternative_name() else {
+        return false;
+    };
+
+    subject_alternative_name
+        .value
+        .general_names
+        .iter()
+        .any(|name| matches!(name, GeneralName::DNSName(hostname) if *hostname == primary_hostname))
+}
+
 fn certificate_fingerprint(certificate_der: &[u8]) -> String {
     let digest = Sha256::digest(certificate_der);
     digest
@@ -288,6 +387,7 @@ fn repair_reason_from_ca_error(error: PlatformError) -> CaRepairReason {
         PlatformError::InvalidCaShape => CaRepairReason::InvalidCaShape,
         PlatformError::KeyMismatch => CaRepairReason::KeyMismatch,
         PlatformError::CaGeneration(_)
+        | PlatformError::ProjectCertificateGeneration(_)
         | PlatformError::Pem(_)
         | PlatformError::LocalCaPostWriteMissing
         | PlatformError::LocalCaPostWriteRepairRequired { .. }

--- a/crates/platform/src/error.rs
+++ b/crates/platform/src/error.rs
@@ -10,6 +10,9 @@ pub enum PlatformError {
     #[error("could not generate PV local CA: {0}")]
     CaGeneration(#[from] rcgen::Error),
 
+    #[error("could not generate Project TLS certificate: {0}")]
+    ProjectCertificateGeneration(#[source] rcgen::Error),
+
     #[error("could not parse PEM file: {0}")]
     Pem(#[from] io::Error),
 

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -11,8 +11,9 @@ mod trust;
 
 pub use browser::open_url;
 pub use ca::{
-    CaFileState, CaRepairReason, GeneratedLocalCa, LocalCaMetadata, generate_local_ca,
-    inspect_local_ca_files,
+    CaFileState, CaRepairReason, GeneratedLocalCa, GeneratedProjectCertificate, LocalCaMetadata,
+    generate_local_ca, generate_project_certificate, inspect_local_ca_files,
+    project_certificate_matches,
 };
 pub use error::PlatformError;
 pub use launch_agent::{

--- a/crates/platform/tests/resolver_config.rs
+++ b/crates/platform/tests/resolver_config.rs
@@ -7,9 +7,10 @@ use insta::{Settings, assert_debug_snapshot};
 use platform::{
     CaFileState, CaRepairReason, GeneratedLocalCa, KeychainCertificate, KeychainTrustResult,
     LocalCaMetadata, PfConfReference, PfRedirectConfig, ResolverConfig, SystemTrustInspector,
-    TrustDomainState, generate_local_ca, inspect_local_ca_files, inspect_pf_anchor_file,
-    inspect_pf_conf_reference, inspect_resolver_file, inspect_system_ca_trust,
-    loopback_tcp_listener_ports, trusted_pv_ca_fingerprints,
+    TrustDomainState, generate_local_ca, generate_project_certificate, inspect_local_ca_files,
+    inspect_pf_anchor_file, inspect_pf_conf_reference, inspect_resolver_file,
+    inspect_system_ca_trust, loopback_tcp_listener_ports, project_certificate_matches,
+    trusted_pv_ca_fingerprints,
 };
 use state::fs;
 
@@ -299,6 +300,38 @@ fn local_ca_generation_produces_matching_pv_root_certificate_and_key() -> Result
     assert!(!metadata.fingerprint.is_empty());
     assert!(generated.certificate_pem.contains("BEGIN CERTIFICATE"));
     assert!(generated.private_key_pem.contains("BEGIN PRIVATE KEY"));
+
+    Ok(())
+}
+
+#[test]
+fn project_certificate_generation_signs_primary_hostname_with_local_ca() -> Result<()> {
+    let local = generate_local_ca()?;
+    let stale = generate_local_ca()?;
+    let generated =
+        generate_project_certificate("acme.test", &local.certificate_pem, &local.private_key_pem)?;
+    let certificate_chain = format!("{}{}", generated.certificate_pem, local.certificate_pem);
+
+    assert!(generated.certificate_pem.contains("BEGIN CERTIFICATE"));
+    assert!(generated.private_key_pem.contains("BEGIN PRIVATE KEY"));
+    assert!(project_certificate_matches(
+        &certificate_chain,
+        &generated.private_key_pem,
+        "acme.test",
+        &local.certificate_pem
+    ));
+    assert!(!project_certificate_matches(
+        &certificate_chain,
+        &generated.private_key_pem,
+        "api.acme.test",
+        &local.certificate_pem
+    ));
+    assert!(!project_certificate_matches(
+        &certificate_chain,
+        &generated.private_key_pem,
+        "acme.test",
+        &stale.certificate_pem
+    ));
 
     Ok(())
 }

--- a/crates/state/src/paths.rs
+++ b/crates/state/src/paths.rs
@@ -173,6 +173,18 @@ impl PvPaths {
         self.certificates().join("ca-key.pem")
     }
 
+    pub fn project_tls_dir(&self, project_id: &str) -> Utf8PathBuf {
+        self.certificates().join("projects").join(project_id)
+    }
+
+    pub fn project_tls_certificate(&self, project_id: &str) -> Utf8PathBuf {
+        self.project_tls_dir(project_id).join("tls.crt")
+    }
+
+    pub fn project_tls_private_key(&self, project_id: &str) -> Utf8PathBuf {
+        self.project_tls_dir(project_id).join("tls.key")
+    }
+
     pub fn gateway_log(&self) -> Utf8PathBuf {
         self.logs().join("gateway/gateway.log")
     }

--- a/crates/state/tests/state_foundation.rs
+++ b/crates/state/tests/state_foundation.rs
@@ -37,6 +37,18 @@ fn ca_paths_are_derived_from_an_injected_home() {
         paths.ca_private_key().as_str(),
         "/tmp/pv-test-home/.pv/certificates/ca-key.pem"
     );
+    assert_eq!(
+        paths.project_tls_dir("project123").as_str(),
+        "/tmp/pv-test-home/.pv/certificates/projects/project123"
+    );
+    assert_eq!(
+        paths.project_tls_certificate("project123").as_str(),
+        "/tmp/pv-test-home/.pv/certificates/projects/project123/tls.crt"
+    );
+    assert_eq!(
+        paths.project_tls_private_key("project123").as_str(),
+        "/tmp/pv-test-home/.pv/certificates/projects/project123/tls.key"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Render stable Project TLS env placeholders for the primary hostname.
- Generate PV-owned Project TLS certificate/key files during daemon env reconciliation when TLS placeholders are used.
- Reuse valid certs and refresh them when the primary hostname or local CA changes.

## Validation

- `cargo fmt --all`
- `cargo clippy --package config --package platform --package daemon --all-targets --all-features --locked -- -D warnings`
- `cargo nextest run --package config --test project_config --package platform --test resolver_config --package daemon --test project_env_reconciliation`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project-scoped TLS placeholders for the primary hostname, plus stable PV-owned TLS asset placeholders.
  * Project environment rendering now includes TLS certificate/key/CA values (including dev server TLS inputs).
  * Projects that reference TLS placeholders automatically generate and manage per-project certificates signed by the local CA.
* **Bug Fixes**
  * Improved placeholder validation across project, resource, and allocation scopes (including escaped placeholders).
  * TLS reconciliation now verifies existing certs and regenerates when CA/hostname pairing changes.
  * `pv unlink` now removes per-project TLS assets while leaving the project directory intact.
* **Documentation**
  * Clarified `.test` hostname routing and TLS certificate behavior, and updated the TLS placeholder contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->